### PR TITLE
added pymdownx.superfences for nested code blocks

### DIFF
--- a/django/thunderstore/repository/templatetags/markdownify.py
+++ b/django/thunderstore/repository/templatetags/markdownify.py
@@ -28,6 +28,7 @@ def markdownify(value):
                     "markdown.extensions.abbr",
                     "markdown.extensions.def_list",
                     "markdown.extensions.fenced_code",
+                    "pymdownx.superfences",
                     "markdown.extensions.footnotes",
                     "markdown.extensions.tables",
                     "markdown.extensions.admonition",

--- a/django/thunderstore/repository/templatetags/markdownify.py
+++ b/django/thunderstore/repository/templatetags/markdownify.py
@@ -27,7 +27,6 @@ def markdownify(value):
                 extensions=[
                     "markdown.extensions.abbr",
                     "markdown.extensions.def_list",
-                    "markdown.extensions.fenced_code",
                     "pymdownx.superfences",
                     "markdown.extensions.footnotes",
                     "markdown.extensions.tables",


### PR DESCRIPTION
This adds the markdown plugin [superfences](https://facelessuser.github.io/pymdown-extensions/extensions/superfences/) as an extentions. This allows for nested code blocks inside lists, etc. There seem to be no side effects but you may now more edge cases. 

It makes the markdown behave more expected as it is the same for example on Github.

Here is an example before and after:

![ThunderstoreBefore](https://user-images.githubusercontent.com/39767545/120927114-042d8c80-c6e0-11eb-97cd-b6066cb0f1a1.png)
![ThunderstoreAfter](https://user-images.githubusercontent.com/39767545/120927146-1dced400-c6e0-11eb-9120-b3c364b4a51f.png)

