### PR TITLE
Preserve thumbnail png extension

### DIFF
--- a/django/thunderstore/core/settings.py
+++ b/django/thunderstore/core/settings.py
@@ -429,6 +429,10 @@ REST_FRAMEWORK = {
     ],
 }
 
+# Thumbnails
+
+THUMBNAIL_PRESERVE_EXTENSIONS = ('png',)
+
 #######################################
 #               STORAGE               #
 #######################################

--- a/django/thunderstore/core/settings.py
+++ b/django/thunderstore/core/settings.py
@@ -431,9 +431,7 @@ REST_FRAMEWORK = {
 
 # Thumbnails
 
-THUMBNAIL_PRESERVE_EXTENSIONS = None
 THUMBNAIL_QUALITY = 95
-THUMBNAIL_TRANSPARENCY_EXTENSION = 'jpg'
 
 #######################################
 #               STORAGE               #

--- a/django/thunderstore/core/settings.py
+++ b/django/thunderstore/core/settings.py
@@ -431,7 +431,9 @@ REST_FRAMEWORK = {
 
 # Thumbnails
 
-THUMBNAIL_PRESERVE_EXTENSIONS = ('png',)
+THUMBNAIL_PRESERVE_EXTENSIONS = None
+THUMBNAIL_QUALITY = 95
+THUMBNAIL_TRANSPARENCY_EXTENSION = 'jpg'
 
 #######################################
 #               STORAGE               #


### PR DESCRIPTION
Adds a setting for easy-thumbnails to preserve png extension. Since icons are required to be uploaded as pngs, this guarantees in practice that all thumbnails will be pngs. Currently thumbnails are shown as 85% quality JPEGs, which can [make some thumbnails ugly](https://cdn.thunderstore.io/live/repository/icons/olavim-RoundsWithFriends-1.2.4.png.256x256_q85_crop.jpg).

Tested by
1. Run the project once without any changes, setup stuff in djangoadmin, and upload a test package with a known bad quality thumbnail.
2. Add the setting change.
3. Restart the project. The setting did not apply immediately, and the thumbnail was still porrige when I refresh thunderstore in browser.
4. Run `docker-compose exec django python manage.py clear_cache` in a terminal (having this command documented would be great).
5. Refresh thunderstore in browser. Thumbnail is now correctly generated in the png format.