### PR TITLE
Add markdown preview & manifest validator tools

### DIFF
--- a/builder/package.json
+++ b/builder/package.json
@@ -10,6 +10,7 @@
         "crypto-js": "^4.0.0",
         "github-markdown-css": "^4.0.0",
         "jquery": "^3.5.1",
+        "js-base64": "^3.6.1",
         "mobx": "^6.3.2",
         "mobx-react": "^7.2.0",
         "node-sass": "^4.12.0",

--- a/builder/src/api.ts
+++ b/builder/src/api.ts
@@ -112,6 +112,8 @@ class ApiUrls {
     static listCategories = (communityIdentifier: string) =>
         apiUrl("community", communityIdentifier, "category");
     static renderMarkdown = () => apiUrl("frontend", "render-markdown");
+    static validateManifestV1 = () =>
+        apiUrl("submission", "validate", "manifest-v1");
 }
 
 export interface UserMedia {
@@ -273,6 +275,16 @@ class ExperimentalApiImpl extends ThunderstoreApi {
     renderMarkdown = async (props: { data: { markdown: string } }) => {
         const response = await this.post(ApiUrls.renderMarkdown(), props.data);
         return (await response.json()) as RenderMarkdownResult;
+    };
+
+    validateManifestV1 = async (props: {
+        data: { namespace: string; manifest_data: string };
+    }) => {
+        const response = await this.post(
+            ApiUrls.validateManifestV1(),
+            props.data
+        );
+        return (await response.json()) as { success: boolean };
     };
 }
 

--- a/builder/src/components/CodeInputPanel.tsx
+++ b/builder/src/components/CodeInputPanel.tsx
@@ -1,0 +1,30 @@
+import React, { CSSProperties } from "react";
+
+interface CodeInputPanelProps {
+    title: string;
+    initial: string;
+    onChange: (value: string) => void;
+    textareaStyle?: CSSProperties;
+}
+export const CodeInputPanel: React.FC<CodeInputPanelProps> = ({
+    title,
+    initial,
+    onChange,
+    children,
+    textareaStyle,
+}) => {
+    return (
+        <div className={"card bg-light mb-2"}>
+            <div className={"card-header"}>{title}</div>
+            <div className={"card-body"}>
+                {children}
+                <textarea
+                    className={"code-input"}
+                    style={textareaStyle}
+                    value={initial}
+                    onChange={(evt) => onChange(evt.target.value)}
+                />
+            </div>
+        </div>
+    );
+};

--- a/builder/src/components/FormSelectField.tsx
+++ b/builder/src/components/FormSelectField.tsx
@@ -1,0 +1,41 @@
+import { Control } from "react-hook-form/dist/types";
+import React from "react";
+import { Controller } from "react-hook-form";
+import Select from "react-select";
+
+interface FormSelectFieldProps<T> {
+    control: Control;
+    name: string;
+    data: T[];
+    getOption: (t: T) => { value: string; label: string };
+    default?: T;
+    isMulti?: boolean;
+}
+export const FormSelectField: React.FC<FormSelectFieldProps<any>> = (props) => {
+    const defaultValue = props.default
+        ? props.isMulti
+            ? [props.getOption(props.default)]
+            : props.getOption(props.default)
+        : undefined;
+
+    return (
+        <div className="w-100">
+            <div style={{ color: "#666" }}>
+                <Controller
+                    name={props.name}
+                    control={props.control}
+                    defaultValue={defaultValue}
+                    render={({ field }) => (
+                        <Select
+                            {...field}
+                            isMulti={props.isMulti || false}
+                            defaultValue={defaultValue}
+                            options={props.data.map(props.getOption)}
+                        />
+                    )}
+                />
+            </div>
+            {props.children}
+        </div>
+    );
+};

--- a/builder/src/components/ProgressBar.tsx
+++ b/builder/src/components/ProgressBar.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { observer } from "mobx-react";
+
+interface ProgressBarProps {
+    className: string;
+    progress: number;
+}
+export const ProgressBar: React.FC<ProgressBarProps> = observer(
+    ({ className, progress }) => {
+        return (
+            <div className="progress my-2">
+                <div
+                    className={`progress-bar progress-bar-striped progress-bar-animated ${className}`}
+                    role="progressbar"
+                    aria-valuenow={progress}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    style={{
+                        width: `${progress}%`,
+                    }}
+                />
+            </div>
+        );
+    }
+);

--- a/builder/src/debounce.ts
+++ b/builder/src/debounce.ts
@@ -1,0 +1,14 @@
+import { DependencyList, EffectCallback, useEffect } from "react";
+
+export const useDebounce = (
+    time: number,
+    effect: EffectCallback,
+    deps?: DependencyList,
+    onChange?: () => void
+) => {
+    useEffect(() => {
+        if (onChange) onChange();
+        const timeoutId = setTimeout(() => effect(), time);
+        return () => clearTimeout(timeoutId);
+    }, deps);
+};

--- a/builder/src/main.ts
+++ b/builder/src/main.ts
@@ -5,6 +5,7 @@ import { UploadPage } from "./upload";
 import React, { ComponentClass, FunctionComponent } from "react";
 import * as Sentry from "@sentry/react";
 import { MarkdownPreviewPage } from "./markdown";
+import { ManifestValidationPage } from "./manifest";
 
 Sentry.init({
     // TODO: Add as a build variable instead
@@ -24,4 +25,5 @@ const CreateComponent = (component: FunctionComponent | ComponentClass) => {
 (window as any).ts = {
     UploadPage: CreateComponent(UploadPage),
     MarkdownPreviewPage: CreateComponent(MarkdownPreviewPage),
+    ManifestValidationPage: CreateComponent(ManifestValidationPage),
 };

--- a/builder/src/main.ts
+++ b/builder/src/main.ts
@@ -4,6 +4,7 @@ import "./js/custom";
 import { UploadPage } from "./upload";
 import React, { ComponentClass, FunctionComponent } from "react";
 import * as Sentry from "@sentry/react";
+import { MarkdownPreviewPage } from "./markdown";
 
 Sentry.init({
     // TODO: Add as a build variable instead
@@ -22,4 +23,5 @@ const CreateComponent = (component: FunctionComponent | ComponentClass) => {
 
 (window as any).ts = {
     UploadPage: CreateComponent(UploadPage),
+    MarkdownPreviewPage: CreateComponent(MarkdownPreviewPage),
 };

--- a/builder/src/manifest.tsx
+++ b/builder/src/manifest.tsx
@@ -1,0 +1,163 @@
+import React, { useEffect, useState } from "react";
+import { ExperimentalApi, ThunderstoreApiError } from "./api";
+import { ProgressBar } from "./components/ProgressBar";
+import { useDebounce } from "./debounce";
+import * as Sentry from "@sentry/react";
+import { CodeInputPanel } from "./components/CodeInputPanel";
+import Select from "react-select";
+import { Base64 } from "js-base64";
+
+const LOCAL_STORAGE_KEY = "legacy.manifestValidator.manifest";
+const EXAMPLE_MANIFEST = `
+{
+    "name": "TestMod",
+    "version_number": "1.1.0",
+    "website_url": "https://github.com/thunderstore-io",
+    "description": "This is a description for a mod. 250 characters max",
+    "dependencies": [
+        "Mythic-TestMod-1.1.0"
+    ]
+}
+`.trim();
+
+interface ManifestV1ValidationErrors {
+    non_field_errors?: string[];
+}
+
+interface ManifestValidatorProps {
+    manifest: string;
+    namespace: string | null;
+}
+const ManifestValidator: React.FC<ManifestValidatorProps> = ({
+    manifest,
+    namespace,
+}) => {
+    const [progressClass, setProgressClass] = useState<string | null>(null);
+    const [validationErrors, setValidationErrors] = useState<string[]>([]);
+
+    const validateManifest = () => {
+        try {
+            localStorage.setItem(LOCAL_STORAGE_KEY, manifest);
+        } catch (e) {
+            Sentry.captureException(e);
+        }
+        const errors: string[] = [];
+        if (manifest.length <= 0) {
+            errors.push("Enter manifest contents");
+        }
+        if (namespace == null) {
+            errors.push(
+                "Select a team. You must be logged in to see your teams."
+            );
+        }
+        if (manifest.length > 0 && namespace != null) {
+            ExperimentalApi.validateManifestV1({
+                data: {
+                    namespace: namespace,
+                    manifest_data: Base64.encode(manifest),
+                },
+            })
+                .then((result) => {
+                    if (result.success) {
+                        setProgressClass("bg-success");
+                        setValidationErrors([]);
+                    } else {
+                        setValidationErrors(["Unknown validation error"]);
+                        setProgressClass("bg-danger");
+                    }
+                })
+                .catch((e) => {
+                    if (e instanceof ThunderstoreApiError) {
+                        const result = e.errorObject as ManifestV1ValidationErrors;
+                        if (result.non_field_errors) {
+                            errors.push(...result.non_field_errors);
+                        }
+                    } else {
+                        errors.push(
+                            "Unknown error occurred when calling the validation API"
+                        );
+                        Sentry.captureException(e);
+                    }
+                    setProgressClass("bg-danger");
+                    setValidationErrors(errors);
+                });
+        } else {
+            setProgressClass("bg-danger");
+            setValidationErrors(errors);
+        }
+    };
+
+    useDebounce(
+        600,
+        () => {
+            validateManifest();
+        },
+        [manifest, namespace],
+        () => setProgressClass("bg-warning")
+    );
+
+    return (
+        <div className={"card bg-light mb-2"}>
+            <div className={"card-header"}>
+                {progressClass !== null ? (
+                    <ProgressBar className={progressClass} progress={100} />
+                ) : null}
+            </div>
+            <div className={"card-body markdown-body"}>
+                {validationErrors.length > 0 ? (
+                    <ul className={"text-danger"}>
+                        {validationErrors.map((message) => (
+                            <li key={message}>{message}</li>
+                        ))}
+                    </ul>
+                ) : (
+                    <p>No errors found!</p>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export const ManifestValidationPage: React.FC = () => {
+    const [manifest, setManifest] = useState<string>(
+        localStorage.getItem(LOCAL_STORAGE_KEY) || EXAMPLE_MANIFEST
+    );
+    const [namespace, setNamespace] = useState<string | null>(null);
+    const [namespaces, setNamespaces] = useState<string[]>([]);
+
+    useEffect(() => {
+        ExperimentalApi.currentUser().then((res) => setNamespaces(res.teams));
+    }, []);
+
+    const namespaceChoices = namespaces.map((x) => ({ value: x, label: x }));
+
+    const handleNamespaceChange = (
+        value: { value: string; label: string },
+        action: { action: string }
+    ) => {
+        if (action.action == "set-value" || action.action == "select-option") {
+            setNamespace(value.value);
+        }
+    };
+
+    return (
+        <div style={{ marginBottom: "96px" }}>
+            <CodeInputPanel
+                title={"Manifest Validator"}
+                initial={manifest}
+                onChange={setManifest}
+                textareaStyle={{ minHeight: "300px" }}
+            >
+                <div className="w-100 mb-2">
+                    <div style={{ color: "#666" }}>
+                        <Select
+                            options={namespaceChoices}
+                            onChange={handleNamespaceChange as any}
+                        />
+                    </div>
+                </div>
+            </CodeInputPanel>
+            <ManifestValidator manifest={manifest} namespace={namespace} />
+        </div>
+    );
+};

--- a/builder/src/markdown.tsx
+++ b/builder/src/markdown.tsx
@@ -1,40 +1,94 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { ExperimentalApi } from "./api";
+import { ProgressBar } from "./components/ProgressBar";
+import { useDebounce } from "./debounce";
+import * as Sentry from "@sentry/react";
 
-export const MarkdownPreview: React.FC = () => {
-    const [markdown, setMarkdown] = useState<string>(
-        "# This is a markdown preview placeholder"
-    );
-    const [html, setHtml] = useState<string>("");
+const LOCAL_STORAGE_KEY = "legacy.markdownPreview.markdown";
 
-    useEffect(() => {
-        ExperimentalApi.renderMarkdown({ data: { markdown: markdown } }).then(
-            (result) => {
-                setHtml(result.html);
-            }
-        );
-    }, [markdown]);
-
+interface MarkdownInputProps {
+    initial: string;
+    onChange: (value: string) => void;
+}
+const MarkdownInput: React.FC<MarkdownInputProps> = ({ initial, onChange }) => {
     return (
-        <div>
-            <textarea
-                value={markdown}
-                onChange={(evt) => setMarkdown(evt.target.value)}
-            />
-            <div dangerouslySetInnerHTML={{ __html: html }} />
+        <div className={"card bg-light mb-2"}>
+            <div className={"card-header"}>Markdown Input</div>
+            <div className={"card-body"}>
+                <textarea
+                    className={"code-input"}
+                    style={{ minHeight: "400px" }}
+                    value={initial}
+                    onChange={(evt) => onChange(evt.target.value)}
+                />
+            </div>
         </div>
     );
 };
 
-interface ReadmePreviewProps {}
-export const ReadmePreview: React.FC<ReadmePreviewProps> = () => {
+interface MarkdownPreviewProps {
+    markdown: string;
+}
+const MarkdownPreview: React.FC<MarkdownPreviewProps> = ({ markdown }) => {
+    const [html, setHtml] = useState<string>("");
+    const [progressClass, setProgressClass] = useState<string | null>(null);
+
+    const renderMarkdown = () => {
+        try {
+            localStorage.setItem(LOCAL_STORAGE_KEY, markdown);
+        } catch (e) {
+            Sentry.captureException(e);
+        }
+        if (markdown.length > 0) {
+            ExperimentalApi.renderMarkdown({ data: { markdown: markdown } })
+                .then((result) => {
+                    setProgressClass("bg-success");
+                    setHtml(result.html);
+                })
+                .catch((e) => {
+                    Sentry.captureException(e);
+                    setProgressClass("bg-danger");
+                });
+        } else {
+            setHtml("");
+            setProgressClass("bg-success");
+        }
+    };
+
+    useDebounce(
+        600,
+        () => {
+            console.log("doing api call");
+            renderMarkdown();
+        },
+        [markdown],
+        () => setProgressClass("bg-warning")
+    );
+
     return (
         <div className={"card bg-light mb-2"}>
-            <div className={"card-header"}>README Preview</div>
+            <div className={"card-header"}>
+                {progressClass !== null ? (
+                    <ProgressBar className={progressClass} progress={100} />
+                ) : null}
+            </div>
             <div
                 className={"card-body markdown-body"}
-                dangerouslySetInnerHTML={{ __html: "" }}
+                dangerouslySetInnerHTML={{ __html: html }}
             />
+        </div>
+    );
+};
+
+export const MarkdownPreviewPage: React.FC = () => {
+    const [markdown, setMarkdown] = useState<string>(
+        localStorage.getItem(LOCAL_STORAGE_KEY) ||
+            "# This is a markdown preview placeholder"
+    );
+    return (
+        <div style={{ marginBottom: "96px" }}>
+            <MarkdownInput initial={markdown} onChange={setMarkdown} />
+            <MarkdownPreview markdown={markdown} />
         </div>
     );
 };

--- a/builder/src/markdown.tsx
+++ b/builder/src/markdown.tsx
@@ -3,28 +3,9 @@ import { ExperimentalApi } from "./api";
 import { ProgressBar } from "./components/ProgressBar";
 import { useDebounce } from "./debounce";
 import * as Sentry from "@sentry/react";
+import { CodeInputPanel } from "./components/CodeInputPanel";
 
 const LOCAL_STORAGE_KEY = "legacy.markdownPreview.markdown";
-
-interface MarkdownInputProps {
-    initial: string;
-    onChange: (value: string) => void;
-}
-const MarkdownInput: React.FC<MarkdownInputProps> = ({ initial, onChange }) => {
-    return (
-        <div className={"card bg-light mb-2"}>
-            <div className={"card-header"}>Markdown Input</div>
-            <div className={"card-body"}>
-                <textarea
-                    className={"code-input"}
-                    style={{ minHeight: "400px" }}
-                    value={initial}
-                    onChange={(evt) => onChange(evt.target.value)}
-                />
-            </div>
-        </div>
-    );
-};
 
 interface MarkdownPreviewProps {
     markdown: string;
@@ -58,7 +39,6 @@ const MarkdownPreview: React.FC<MarkdownPreviewProps> = ({ markdown }) => {
     useDebounce(
         600,
         () => {
-            console.log("doing api call");
             renderMarkdown();
         },
         [markdown],
@@ -87,7 +67,12 @@ export const MarkdownPreviewPage: React.FC = () => {
     );
     return (
         <div style={{ marginBottom: "96px" }}>
-            <MarkdownInput initial={markdown} onChange={setMarkdown} />
+            <CodeInputPanel
+                title={"Markdown Preview"}
+                initial={markdown}
+                onChange={setMarkdown}
+                textareaStyle={{ minHeight: "400px" }}
+            />
             <MarkdownPreview markdown={markdown} />
         </div>
     );

--- a/builder/src/scss/all.scss
+++ b/builder/src/scss/all.scss
@@ -19,3 +19,6 @@
 @import "./package-list";
 @import "./forms";
 @import "./slimselect";
+
+// Code Input
+@import "./code-input";

--- a/builder/src/scss/code-input.scss
+++ b/builder/src/scss/code-input.scss
@@ -1,0 +1,22 @@
+.code-input {
+    width: 100%;
+    //minGeight: "400px"
+    overflow: scroll;
+    border-radius: 4px;
+    border-style: none;
+    font-family: "Courier New", monospace;
+    background-color: #191919;
+    color: #ffffff;
+    padding: 6px;
+
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* Internet Explorer 10+ */
+}
+.code-input:focus-visible {
+    outline: none;
+}
+.code-input::-webkit-scrollbar {
+    /* WebKit */
+    width: 0;
+    height: 0;
+}

--- a/builder/src/scss/markdown.scss
+++ b/builder/src/scss/markdown.scss
@@ -17,6 +17,11 @@
     background-color: #191919;
 }
 
+.markdown-body code {
+    background-color: #191919;
+    color: #ffffff;
+}
+
 .markdown-body table td,
 .markdown-body table th {
     border-color: #1f1c1c;

--- a/builder/src/upload.tsx
+++ b/builder/src/upload.tsx
@@ -16,6 +16,7 @@ import { observer } from "mobx-react";
 import { useOnBeforeUnload } from "./state/OnBeforeUnload";
 import { PackageVersionHeader } from "./components/PackageVersionSummary";
 import { Control } from "react-hook-form/dist/types";
+import { ProgressBar } from "./components/ProgressBar";
 
 function getUploadProgressBarcolor(uploadStatus: FileUploadStatus | undefined) {
     if (uploadStatus == FileUploadStatus.CANCELED) {
@@ -88,29 +89,6 @@ const FormRow: React.FC<FormRowProps> = (props) => {
         </div>
     );
 };
-
-interface ProgressBarProps {
-    className: string;
-    progress: number;
-}
-const ProgressBar: React.FC<ProgressBarProps> = observer(
-    ({ className, progress }) => {
-        return (
-            <div className="progress my-2">
-                <div
-                    className={`progress-bar progress-bar-striped progress-bar-animated ${className}`}
-                    role="progressbar"
-                    aria-valuenow={progress}
-                    aria-valuemin={0}
-                    aria-valuemax={100}
-                    style={{
-                        width: `${progress}%`,
-                    }}
-                />
-            </div>
-        );
-    }
-);
 
 interface FormSelectFieldProps<T> {
     control: Control;

--- a/builder/src/upload.tsx
+++ b/builder/src/upload.tsx
@@ -117,7 +117,7 @@ const SubmissionForm: React.FC<SubmissionFormProps> = observer((props) => {
     ] = useState<SubmissionStatus | null>(null);
 
     const { register, handleSubmit, control } = useForm();
-    useOnBeforeUnload(!!file);
+    useOnBeforeUnload(!!file && submissionStatus != SubmissionStatus.COMPLETE);
 
     const cancel = async () => {
         setFile(null);
@@ -455,7 +455,9 @@ export const SubmissionResultRow: React.FC<PackageAvailableCommunityProps> = ({
         <tr>
             <td>{info.community.name}</td>
             <td>
-                <a href={info.url}>View listing</a>
+                <a href={info.url} target={"_blank"}>
+                    View listing
+                </a>
             </td>
             <td>
                 <div className="category-badge-container bg-light px-2 pt-2 flex-grow-1 d-flex flex-row flex-wrap align-items-end align-content-end ">

--- a/builder/src/upload.tsx
+++ b/builder/src/upload.tsx
@@ -8,15 +8,14 @@ import {
     PackageAvailableCommunity,
     ThunderstoreApiError,
 } from "./api";
-import { useForm, Controller } from "react-hook-form";
-import Select from "react-select";
+import { useForm } from "react-hook-form";
 import { DragDropFileInput } from "./components/DragDropFileInput";
 import { FileUpload, FileUploadStatus } from "./state/FileUpload";
 import { observer } from "mobx-react";
 import { useOnBeforeUnload } from "./state/OnBeforeUnload";
 import { PackageVersionHeader } from "./components/PackageVersionSummary";
-import { Control } from "react-hook-form/dist/types";
 import { ProgressBar } from "./components/ProgressBar";
+import { FormSelectField } from "./components/FormSelectField";
 
 function getUploadProgressBarcolor(uploadStatus: FileUploadStatus | undefined) {
     if (uploadStatus == FileUploadStatus.CANCELED) {
@@ -86,43 +85,6 @@ const FormRow: React.FC<FormRowProps> = (props) => {
             {props.error && (
                 <div className="text-danger field-errors">{props.error}</div>
             )}
-        </div>
-    );
-};
-
-interface FormSelectFieldProps<T> {
-    control: Control;
-    name: string;
-    data: T[];
-    getOption: (t: T) => { value: string; label: string };
-    default?: T;
-    isMulti?: boolean;
-}
-const FormSelectField: React.FC<FormSelectFieldProps<any>> = (props) => {
-    const defaultValue = props.default
-        ? props.isMulti
-            ? [props.getOption(props.default)]
-            : props.getOption(props.default)
-        : undefined;
-
-    return (
-        <div className="w-100">
-            <div style={{ color: "#666" }}>
-                <Controller
-                    name={props.name}
-                    control={props.control}
-                    defaultValue={defaultValue}
-                    render={({ field }) => (
-                        <Select
-                            {...field}
-                            isMulti={props.isMulti || false}
-                            defaultValue={defaultValue}
-                            options={props.data.map(props.getOption)}
-                        />
-                    )}
-                />
-            </div>
-            {props.children}
         </div>
     );
 };

--- a/builder/yarn.lock
+++ b/builder/yarn.lock
@@ -3000,6 +3000,11 @@ js-base64@^2.1.8:
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"
   integrity sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==
 
+js-base64@^3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.6.1.tgz#555aae398b74694b4037af1f8a5a6209d170efbe"
+  integrity sha512-Frdq2+tRRGLQUIQOgsIGSCd1VePCS2fsddTG5dTCqR0JHgltXWfsxnY0gIXPoMeRmdom6Oyq+UMOFg5suduOjQ==
+
 js-tokens@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"

--- a/django/thunderstore/core/urls.py
+++ b/django/thunderstore/core/urls.py
@@ -7,7 +7,11 @@ from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
 from rest_framework import permissions
 
-from thunderstore.frontend.views import ads_txt_view, robots_txt_view
+from thunderstore.frontend.views import (
+    MarkdownPreviewView,
+    ads_txt_view,
+    robots_txt_view,
+)
 from thunderstore.repository.urls import urlpatterns as repository_urls
 from thunderstore.repository.views import PackageListView
 
@@ -31,6 +35,11 @@ urlpatterns = [
     path("djangoadmin/", admin.site.urls),
     path("healthcheck/", healthcheck_view, name="healthcheck"),
     path("api/", include((api_urls, "api"), namespace="api")),
+    path(
+        "tools/markdown-preview/",
+        MarkdownPreviewView.as_view(),
+        name="tools.markdown-preview",
+    ),
 ]
 
 schema_view = get_schema_view(

--- a/django/thunderstore/core/urls.py
+++ b/django/thunderstore/core/urls.py
@@ -8,6 +8,7 @@ from drf_yasg.views import get_schema_view
 from rest_framework import permissions
 
 from thunderstore.frontend.views import (
+    ManifestV1ValidatorView,
     MarkdownPreviewView,
     ads_txt_view,
     robots_txt_view,
@@ -39,6 +40,11 @@ urlpatterns = [
         "tools/markdown-preview/",
         MarkdownPreviewView.as_view(),
         name="tools.markdown-preview",
+    ),
+    path(
+        "tools/manifest-v1-validator/",
+        ManifestV1ValidatorView.as_view(),
+        name="tools.manifest-v1-validator",
     ),
 ]
 

--- a/django/thunderstore/frontend/templates/base.html
+++ b/django/thunderstore/frontend/templates/base.html
@@ -76,6 +76,7 @@
                             <a class="dropdown-item" href="https://github.com/thunderstore-io/Thunderstore">GitHub Repo</a>
                             <a class="dropdown-item" href="{% url 'packages.create.docs' %}">Package Format Docs</a>
                             <a class="dropdown-item" href="{% url 'tools.markdown-preview' %}">Markdown Preview</a>
+                            <a class="dropdown-item" href="{% url 'tools.manifest-v1-validator' %}">Manifest Validator</a>
                         </div>
                     </div>
                 </li>

--- a/django/thunderstore/frontend/templates/base.html
+++ b/django/thunderstore/frontend/templates/base.html
@@ -75,6 +75,7 @@
                             <a class="dropdown-item" href="{% url 'swagger' %}">API Docs</a>
                             <a class="dropdown-item" href="https://github.com/thunderstore-io/Thunderstore">GitHub Repo</a>
                             <a class="dropdown-item" href="{% url 'packages.create.docs' %}">Package Format Docs</a>
+                            <a class="dropdown-item" href="{% url 'tools.markdown-preview' %}">Markdown Preview</a>
                         </div>
                     </div>
                 </li>

--- a/django/thunderstore/frontend/templates/frontend/manifest_v1_validator.html
+++ b/django/thunderstore/frontend/templates/frontend/manifest_v1_validator.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+
+{% block title %}Markdown Preview{% endblock %}
+
+{% block content_beginning %}{% endblock %}
+
+{% block content %}
+<h1 class="mt-4">Manifest Validator</h1>
+
+<div id="manifest-validator-page"></div>
+<script type="text/javascript">
+window.ts.ManifestValidationPage(document.getElementById("manifest-validator-page"));
+</script>
+
+{% endblock %}

--- a/django/thunderstore/frontend/templates/frontend/markdown_preview.html
+++ b/django/thunderstore/frontend/templates/frontend/markdown_preview.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+
+{% block title %}Markdown Preview{% endblock %}
+
+{% block content_beginning %}{% endblock %}
+
+{% block content %}
+<h1 class="mt-4">Markdown Preview</h1>
+
+<div id="markdown-preview-page"></div>
+<script type="text/javascript">
+window.ts.MarkdownPreviewPage(document.getElementById("markdown-preview-page"));
+</script>
+
+{% endblock %}

--- a/django/thunderstore/frontend/tests/test_views.py
+++ b/django/thunderstore/frontend/tests/test_views.py
@@ -9,3 +9,12 @@ def test_views_markdown_preview(client, community_site):
         HTTP_HOST=community_site.site.domain,
     )
     assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_views_manifest_v1_validator(client, community_site):
+    response = client.get(
+        reverse("tools.manifest-v1-validator"),
+        HTTP_HOST=community_site.site.domain,
+    )
+    assert response.status_code == 200

--- a/django/thunderstore/frontend/tests/test_views.py
+++ b/django/thunderstore/frontend/tests/test_views.py
@@ -1,0 +1,11 @@
+import pytest
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_views_markdown_preview(client, community_site):
+    response = client.get(
+        reverse("tools.markdown-preview"),
+        HTTP_HOST=community_site.site.domain,
+    )
+    assert response.status_code == 200

--- a/django/thunderstore/frontend/views.py
+++ b/django/thunderstore/frontend/views.py
@@ -1,4 +1,5 @@
 from django.shortcuts import render
+from django.views.generic import TemplateView
 
 
 def handle404(request, exception):
@@ -15,3 +16,7 @@ def ads_txt_view(request):
 
 def robots_txt_view(request):
     return render(request, "robots.txt", locals())
+
+
+class MarkdownPreviewView(TemplateView):
+    template_name = "frontend/markdown_preview.html"

--- a/django/thunderstore/frontend/views.py
+++ b/django/thunderstore/frontend/views.py
@@ -20,3 +20,7 @@ def robots_txt_view(request):
 
 class MarkdownPreviewView(TemplateView):
     template_name = "frontend/markdown_preview.html"
+
+
+class ManifestV1ValidatorView(TemplateView):
+    template_name = "frontend/manifest_v1_validator.html"

--- a/django/thunderstore/repository/package_manifest.py
+++ b/django/thunderstore/repository/package_manifest.py
@@ -7,6 +7,7 @@ from thunderstore.repository.serializer_fields import (
     DependencyField,
     PackageNameField,
     PackageVersionField,
+    StrictCharField,
 )
 from thunderstore.repository.utils import does_contain_package, has_duplicate_packages
 
@@ -23,11 +24,11 @@ class ManifestV1Serializer(serializers.Serializer):
 
     name = PackageNameField()
     version_number = PackageVersionField()
-    website_url = serializers.CharField(
+    website_url = StrictCharField(
         max_length=PackageVersion._meta.get_field("website_url").max_length,
         allow_blank=True,
     )
-    description = serializers.CharField(
+    description = StrictCharField(
         max_length=PackageVersion._meta.get_field("description").max_length,
         allow_blank=True,
     )

--- a/django/thunderstore/repository/serializer_fields.py
+++ b/django/thunderstore/repository/serializer_fields.py
@@ -59,34 +59,6 @@ class DependencyField(serializers.Field):
         return str(value)
 
 
-class PackageNameField(serializers.CharField):
-    def __init__(self, **kwargs):
-        kwargs["max_length"] = PackageVersion._meta.get_field("name").max_length
-        kwargs["allow_blank"] = False
-        super().__init__(**kwargs)
-        validator = RegexValidator(
-            PACKAGE_NAME_REGEX,
-            message=f"Package names can only contain a-Z A-Z 0-9 _ characers",
-        )
-        self.validators.append(validator)
-
-
-class PackageVersionField(serializers.CharField):
-    def __init__(self, **kwargs):
-        kwargs["max_length"] = PackageVersion._meta.get_field(
-            "version_number"
-        ).max_length
-        kwargs["allow_blank"] = False
-        super().__init__(**kwargs)
-        regex_validator = RegexValidator(
-            PACKAGE_VERSION_REGEX,
-            message=f"Version numbers must follow the Major.Minor.Patch format (e.g. 1.45.320)",
-        )
-        version_number_validator = VersionNumberValidator()
-        self.validators.append(regex_validator)
-        self.validators.append(version_number_validator)
-
-
 class Base64Field(serializers.CharField):
     def __init__(self, **kwargs):
         kwargs.update(
@@ -127,3 +99,41 @@ class Base64Field(serializers.CharField):
         if not value:
             return None
         return base64.b64encode(value).decode("utf-8")
+
+
+class StrictCharField(serializers.CharField):
+    """A char field that allows ONLY strings"""
+
+    def to_internal_value(self, data):
+        if not isinstance(data, str):
+            self.fail("invalid")
+        value = str(data)
+        return value.strip() if self.trim_whitespace else value
+
+
+class PackageNameField(StrictCharField):
+    def __init__(self, **kwargs):
+        kwargs["max_length"] = PackageVersion._meta.get_field("name").max_length
+        kwargs["allow_blank"] = False
+        super().__init__(**kwargs)
+        validator = RegexValidator(
+            PACKAGE_NAME_REGEX,
+            message=f"Package names can only contain a-Z A-Z 0-9 _ characers",
+        )
+        self.validators.append(validator)
+
+
+class PackageVersionField(StrictCharField):
+    def __init__(self, **kwargs):
+        kwargs["max_length"] = PackageVersion._meta.get_field(
+            "version_number"
+        ).max_length
+        kwargs["allow_blank"] = False
+        super().__init__(**kwargs)
+        regex_validator = RegexValidator(
+            PACKAGE_VERSION_REGEX,
+            message=f"Version numbers must follow the Major.Minor.Patch format (e.g. 1.45.320)",
+        )
+        version_number_validator = VersionNumberValidator()
+        self.validators.append(regex_validator)
+        self.validators.append(version_number_validator)

--- a/django/thunderstore/repository/templates/repository/package_create.html
+++ b/django/thunderstore/repository/templates/repository/package_create.html
@@ -14,10 +14,20 @@
     </p>
 </div>
 <div class="mb-3 mt-3 alert alert-info" role="alert">
-    <p class="mb-0">
-        New upload handler not working?
-        <a href="{% url 'packages.create.old' %}">Try the old one here</a>
-    </p>
+    <ul class="mb-0 pl-3">
+        <li>
+            New upload handler not working?
+            <a href="{% url 'packages.create.old' %}">Try the old one here</a>
+        </li>
+        <li>
+            Preview your readme before upload using the
+            <a href="{% url 'tools.markdown-preview' %}">markdown preview tool</a>
+        </li>
+        <li>
+            Uploading a large file? Check your package manifest first with the
+            <a href="{% url 'tools.manifest-v1-validator' %}">package manifest validator</a>
+        </li>
+    </ul>
 </div>
 
 <div id="upload-page"></div>

--- a/django/thunderstore/repository/tests/test_package_manifest.py
+++ b/django/thunderstore/repository/tests/test_package_manifest.py
@@ -408,6 +408,21 @@ def test_manifest_v1_null_fields(user, manifest_v1_data, field):
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize("fieldname", ("description", "website_url"))
+@pytest.mark.parametrize("testdata", (42, 42.432, False, True))
+def test_manifest_v1_strict_char_fields(user, manifest_v1_data, fieldname, testdata):
+    identity = UploaderIdentity.get_or_create_for_user(user)
+    manifest_v1_data[fieldname] = testdata
+    serializer = ManifestV1Serializer(
+        user=user,
+        uploader=identity,
+        data=manifest_v1_data,
+    )
+    assert serializer.is_valid() is False
+    assert "Not a valid string." in str(serializer.errors[fieldname][0])
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     "field, empty_val, should_fail",
     [

--- a/django/thunderstore/repository/tests/test_serializer_fields.py
+++ b/django/thunderstore/repository/tests/test_serializer_fields.py
@@ -17,6 +17,7 @@ from thunderstore.repository.serializer_fields import (
     ModelChoiceField,
     PackageNameField,
     PackageVersionField,
+    StrictCharField,
 )
 
 
@@ -233,3 +234,18 @@ def test_fields_base64_field_too_small_value() -> None:
         match="Ensure this field has encoded at least 10 bytes.",
     ):
         field.to_internal_value(testvalue)
+
+
+@pytest.mark.parametrize("testvalue", (42, 42.432, False, True))
+def test_fields_strict_char_field_fail(testvalue) -> None:
+    field = StrictCharField()
+    with pytest.raises(
+        serializers.ValidationError,
+        match="Not a valid string.",
+    ):
+        field.to_internal_value(testvalue)
+
+
+def test_fields_strict_char_field_success() -> None:
+    field = StrictCharField()
+    assert field.to_internal_value("test") == "test"

--- a/django/thunderstore/repository/validation/tests/test_manifest.py
+++ b/django/thunderstore/repository/validation/tests/test_manifest.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 import pytest
 from django.core.exceptions import ValidationError
@@ -50,6 +50,28 @@ def test_validate_manifest_serializer_errors(
     with pytest.raises(
         ValidationError,
         match="name: This field is required.",
+    ):
+        validate_manifest(
+            user=uploader_identity_member.user,
+            uploader=uploader_identity_member.identity,
+            manifest_data=manifest,
+        )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("fieldname", ("description", "website_url"))
+@pytest.mark.parametrize("testdata", (42, 42.432, False, True))
+def test_validate_manifest_number_in_charfield_fails(
+    uploader_identity_member: UploaderIdentityMember,
+    manifest_v1_data: Dict[str, Any],
+    fieldname: str,
+    testdata: Union[int, float, bool],
+) -> None:
+    manifest_v1_data[fieldname] = testdata
+    manifest = json.dumps(manifest_v1_data).encode("utf-8")
+    with pytest.raises(
+        ValidationError,
+        match=f"{fieldname}: Not a valid string.",
     ):
         validate_manifest(
             user=uploader_identity_member.user,


### PR DESCRIPTION
Add some useful tools for authors to make submission of large packages less painful, specifically:

- Add a tool which can be used to preview markdown
- Add a tool which can be used to validate a manifest before upload

Also make minor improvements to the package submission page overall.