### PR TITLE
Multiple small fixes to Thunderstore

### DIFF
--- a/django/thunderstore/core/management/commands/create_test_data.py
+++ b/django/thunderstore/core/management/commands/create_test_data.py
@@ -36,7 +36,7 @@ class Command(BaseCommand):
             last = last_identity.pk
 
         uploaders = [
-            UploaderIdentity.objects.create(name=f"Test_Identity-{last + i}")
+            UploaderIdentity.objects.create(name=f"Test_Identity_{last + i}")
             for i in range(count)
         ]
         print("Creating packages...")

--- a/django/thunderstore/repository/admin.py
+++ b/django/thunderstore/repository/admin.py
@@ -148,6 +148,7 @@ class PackageAdmin(admin.ModelAdmin):
         "is_active",
         "is_deprecated",
         "is_pinned",
+        "file_size",
     )
     list_filter = (
         "is_active",
@@ -158,6 +159,9 @@ class PackageAdmin(admin.ModelAdmin):
         "name",
         "owner__name",
     )
+
+    def file_size(self, obj):
+        return obj.latest.file_size
 
     def has_add_permission(self, request: HttpRequest) -> bool:
         return False

--- a/django/thunderstore/repository/api/v1/serializers.py
+++ b/django/thunderstore/repository/api/v1/serializers.py
@@ -42,6 +42,7 @@ class PackageVersionSerializer(ModelSerializer):
             "website_url",
             "is_active",
             "uuid4",
+            "file_size",
         )
 
 

--- a/django/thunderstore/repository/views/repository.py
+++ b/django/thunderstore/repository/views/repository.py
@@ -193,7 +193,7 @@ class PackageListSearchView(ListView):
         )
 
         icontains_query = Q()
-        parts = search_query.split(" ")
+        parts = [x for x in search_query.split(" ") if x]
         for part in parts:
             for field in search_fields:
                 icontains_query &= ~Q(**{f"{field}__icontains": part})


### PR DESCRIPTION
- Add file size display to django admins package object listing
- Add file size keyvalue to api/v1/package response json
- Fix create_test_data management command
- Fix package searches ending with a space, to not return all packages