### PR TITLE
Fix an issue with admin page crashing

### DIFF
--- a/django/thunderstore/repository/admin.py
+++ b/django/thunderstore/repository/admin.py
@@ -161,7 +161,7 @@ class PackageAdmin(admin.ModelAdmin):
     )
 
     def file_size(self, obj):
-        return obj.latest.file_size
+        return obj.latest.file_size if obj.latest else 0
 
     def has_add_permission(self, request: HttpRequest) -> bool:
         return False


### PR DESCRIPTION
Fix an issue where the package admin page would crash if the latest was
set to None for whatever reason on any package.