### PR TITLE
Allow enabling debug toolbar for superusers only

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,4 +4,4 @@ exclude =
   .git,
   __pycache__,
   migrations
-ignore = E203,W503,PT003,PIE783
+ignore = E203,W503,PT003,PIE783,E501


### PR DESCRIPTION
Make it possible to enable debug toolbar for superusers only, allowing
it to be safely run in production to debug performance.