### PR TITLE
Add abyss middleware

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV DB_CERT_DIR /etc/ssl/private/db-certs/
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y \
-    curl build-essential \
+    curl build-essential git \
  && rm -rf /var/lib/apt/lists/*
 
 COPY ./django/pyproject.toml ./django/poetry.lock /app/

--- a/django/poetry.lock
+++ b/django/poetry.lock
@@ -1,4 +1,19 @@
 [[package]]
+name = "abyss"
+version = "0.0.dev0"
+description = ""
+category = "main"
+optional = false
+python-versions = "*"
+develop = false
+
+[package.source]
+type = "git"
+url = "https://github.com/akx/abyss.git"
+reference = "4352e557f25a303f718ec1bf82ea0ca545ebc077"
+resolved_reference = "4352e557f25a303f718ec1bf82ea0ca545ebc077"
+
+[[package]]
 name = "amqp"
 version = "5.0.5"
 description = "Low-level AMQP client for Python (fork of amqplib)."
@@ -467,7 +482,7 @@ redis = ">=3.0.0"
 
 [[package]]
 name = "django-storages"
-version = "1.11.1"
+version = "1.12.3"
 description = "Support for many storage backends in Django"
 category = "main"
 optional = false
@@ -476,13 +491,13 @@ python-versions = ">=3.5"
 [package.dependencies]
 boto3 = {version = ">=1.4.4", optional = true, markers = "extra == \"boto3\""}
 Django = ">=2.2"
-google-cloud-storage = {version = ">=1.15.0", optional = true, markers = "extra == \"google\""}
+google-cloud-storage = {version = ">=1.27.0", optional = true, markers = "extra == \"google\""}
 
 [package.extras]
-azure = ["azure-storage-blob (>=1.3.1,<12.0.0)"]
+azure = ["azure-storage-blob (>=12.0.0)"]
 boto3 = ["boto3 (>=1.4.4)"]
 dropbox = ["dropbox (>=7.2.1)"]
-google = ["google-cloud-storage (>=1.15.0)"]
+google = ["google-cloud-storage (>=1.27.0)"]
 libcloud = ["apache-libcloud"]
 sftp = ["paramiko"]
 
@@ -1765,9 +1780,10 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "a0846d71e19f88dbe4179e9385f9d4fbf135bce1d38707ed9974925a1ccfa032"
+content-hash = "276e9cccea2ecc53379a093d6ca6df39a03145da3169c54dbc16ad0d682affbf"
 
 [metadata.files]
+abyss = []
 amqp = [
     {file = "amqp-5.0.5-py3-none-any.whl", hash = "sha256:1e759a7f202d910939de6eca45c23a107f6b71111f41d1282c648e9ac3d21901"},
     {file = "amqp-5.0.5.tar.gz", hash = "sha256:affdd263d8b8eb3c98170b78bf83867cdb6a14901d586e00ddb65bfe2f0c4e60"},
@@ -2025,8 +2041,8 @@ django-redis = [
     {file = "django_redis-4.12.1-py3-none-any.whl", hash = "sha256:1133b26b75baa3664164c3f44b9d5d133d1b8de45d94d79f38d1adc5b1d502e5"},
 ]
 django-storages = [
-    {file = "django-storages-1.11.1.tar.gz", hash = "sha256:c823dbf56c9e35b0999a13d7e05062b837bae36c518a40255d522fbe3750fbb4"},
-    {file = "django_storages-1.11.1-py3-none-any.whl", hash = "sha256:f28765826d507a0309cfaa849bd084894bc71d81bf0d09479168d44785396f80"},
+    {file = "django-storages-1.12.3.tar.gz", hash = "sha256:a475edb2f0f04c4f7e548919a751ecd50117270833956ed5bd585c0575d2a5e7"},
+    {file = "django_storages-1.12.3-py3-none-any.whl", hash = "sha256:204a99f218b747c46edbfeeb1310d357f83f90fa6a6024d8d0a3f422570cee84"},
 ]
 django-stubs = [
     {file = "django-stubs-1.7.0.tar.gz", hash = "sha256:ddd190aca5b9adb4d30760d5c64f67cb3658703f5f42c3bb0c2c71ff4d752c39"},

--- a/django/pyproject.toml
+++ b/django/pyproject.toml
@@ -32,6 +32,7 @@ django-cors-headers = "^3.7.0"
 boto3 = "^1.17.47"
 bleach = "^3.3.0"
 markdown-it-py = {extras = ["linkify"], version = "^1.1.0"}
+abyss = {git = "https://github.com/akx/abyss.git", rev = "4352e557f25a303f718ec1bf82ea0ca545ebc077"}
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2"

--- a/django/thunderstore/abyss/middleware.py
+++ b/django/thunderstore/abyss/middleware.py
@@ -1,0 +1,22 @@
+from abyss.django import AbyssMiddleware
+from django.http import HttpRequest
+from django.utils import timezone
+
+
+class TracingMiddleware(AbyssMiddleware):
+    STORAGE_CLASS = "thunderstore.abyss.storage.get_abyss_storage"
+    FILENAME_PREFIX = "traces/"
+
+    def build_filename_for_request(self, request: HttpRequest) -> str:
+        timestamp = timezone.now().isoformat().replace(":", "-")
+        path_stamp = request.path.strip("/").replace("/", "-")
+        prefix = self.FILENAME_PREFIX or ""
+        return f"{prefix}{timestamp}_{path_stamp}.tracing"
+
+    def should_profile_request(self, request: HttpRequest):
+        base = super().should_profile_request(request)
+        return (
+            base
+            and hasattr(request, "user")
+            and (request.user.is_staff or request.user.is_superuser)
+        )

--- a/django/thunderstore/abyss/storage.py
+++ b/django/thunderstore/abyss/storage.py
@@ -1,0 +1,20 @@
+from django.conf import settings
+from storages.backends.s3boto3 import S3Boto3Storage
+
+
+def get_abyss_storage():
+    return S3Boto3Storage(
+        **{
+            "access_key": settings.ABYSS_S3_ACCESS_KEY_ID,
+            "secret_key": settings.ABYSS_S3_SECRET_ACCESS_KEY,
+            "file_overwrite": settings.ABYSS_S3_FILE_OVERWRITE,
+            "object_parameters": settings.ABYSS_S3_OBJECT_PARAMETERS,
+            "bucket_name": settings.ABYSS_S3_STORAGE_BUCKET_NAME,
+            "location": settings.ABYSS_S3_LOCATION,
+            "custom_domain": settings.ABYSS_S3_CUSTOM_DOMAIN,
+            "secure_urls": settings.ABYSS_S3_SECURE_URLS,
+            "endpoint_url": settings.ABYSS_S3_ENDPOINT_URL,
+            "region_name": settings.ABYSS_S3_REGION_NAME,
+            "default_acl": settings.ABYSS_S3_DEFAULT_ACL,
+        }
+    )

--- a/django/thunderstore/core/settings.py
+++ b/django/thunderstore/core/settings.py
@@ -65,6 +65,7 @@ env = environ.Env(
     AWS_LOCATION=(str, ""),
     AWS_QUERYSTRING_AUTH=(bool, False),
     AWS_S3_SECURE_URLS=(bool, True),
+    AWS_S3_FILE_OVERWRITE=(bool, False),
     USERMEDIA_S3_ENDPOINT_URL=(str, ""),
     USERMEDIA_S3_ACCESS_KEY_ID=(str, ""),
     USERMEDIA_S3_SECRET_ACCESS_KEY=(str, ""),
@@ -72,6 +73,16 @@ env = environ.Env(
     USERMEDIA_S3_REGION_NAME=(str, ""),
     USERMEDIA_S3_STORAGE_BUCKET_NAME=(str, ""),
     USERMEDIA_S3_LOCATION=(str, ""),
+    ABYSS_S3_ENDPOINT_URL=(str, ""),
+    ABYSS_S3_ACCESS_KEY_ID=(str, ""),
+    ABYSS_S3_SECRET_ACCESS_KEY=(str, ""),
+    ABYSS_S3_REGION_NAME=(str, ""),
+    ABYSS_S3_STORAGE_BUCKET_NAME=(str, ""),
+    ABYSS_S3_LOCATION=(str, ""),
+    ABYSS_S3_FILE_OVERWRITE=(bool, False),
+    ABYSS_S3_CUSTOM_DOMAIN=(str, ""),
+    ABYSS_S3_SECURE_URLS=(bool, True),
+    ABYSS_S3_DEFAULT_ACL=(str, "private"),
     REDIS_URL=(str, ""),
     DB_CERT_DIR=(str, ""),
     DB_CLIENT_CERT=(str, ""),
@@ -211,6 +222,7 @@ MIDDLEWARE = [
     "thunderstore.community.middleware.CommunitySiteMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "thunderstore.abyss.middleware.TracingMiddleware",
 ]
 
 ROOT_URLCONF = "thunderstore.core.urls"
@@ -519,6 +531,7 @@ AWS_S3_REGION_NAME = env.str("AWS_S3_REGION_NAME")
 AWS_S3_ENDPOINT_URL = env.str("AWS_S3_ENDPOINT_URL")
 AWS_S3_HOST = env.str("AWS_S3_HOST")
 AWS_S3_CUSTOM_DOMAIN = env.str("AWS_S3_CUSTOM_DOMAIN")
+AWS_S3_FILE_OVERWRITE = env.bool("AWS_S3_FILE_OVERWRITE")
 AWS_STORAGE_BUCKET_NAME = env.str("AWS_STORAGE_BUCKET_NAME")
 AWS_DEFAULT_ACL = env.str("AWS_DEFAULT_ACL")
 AWS_BUCKET_ACL = env.str("AWS_BUCKET_ACL")
@@ -540,6 +553,22 @@ USERMEDIA_S3_REGION_NAME = env.str("USERMEDIA_S3_REGION_NAME")
 USERMEDIA_S3_STORAGE_BUCKET_NAME = env.str("USERMEDIA_S3_STORAGE_BUCKET_NAME")
 USERMEDIA_S3_LOCATION = validate_filepath_prefix(env.str("USERMEDIA_S3_LOCATION"))
 USERMEDIA_S3_OBJECT_PARAMETERS = {
+    "CacheControl": "max-age=2592000",  # 30 days
+}
+
+# Abyss S3 settings
+
+ABYSS_S3_ENDPOINT_URL = env.str("ABYSS_S3_ENDPOINT_URL")
+ABYSS_S3_ACCESS_KEY_ID = env.str("ABYSS_S3_ACCESS_KEY_ID")
+ABYSS_S3_SECRET_ACCESS_KEY = env.str("ABYSS_S3_SECRET_ACCESS_KEY")
+ABYSS_S3_REGION_NAME = env.str("ABYSS_S3_REGION_NAME")
+ABYSS_S3_STORAGE_BUCKET_NAME = env.str("ABYSS_S3_STORAGE_BUCKET_NAME")
+ABYSS_S3_LOCATION = validate_filepath_prefix(env.str("ABYSS_S3_LOCATION"))
+ABYSS_S3_FILE_OVERWRITE = env.bool("ABYSS_S3_FILE_OVERWRITE")
+ABYSS_S3_CUSTOM_DOMAIN = env.str("ABYSS_S3_CUSTOM_DOMAIN")
+ABYSS_S3_SECURE_URLS = env.bool("ABYSS_S3_SECURE_URLS")
+ABYSS_S3_DEFAULT_ACL = env.str("ABYSS_S3_DEFAULT_ACL")
+ABYSS_S3_OBJECT_PARAMETERS = {
     "CacheControl": "max-age=2592000",  # 30 days
 }
 


### PR DESCRIPTION
Add a middleware that uses abyss to generate and store traces to the
configured storage.

Only generate traces for requests by superusers with a specific
parameter set.