### PR TITLE
Fix OAuth account linking

### DIFF
--- a/django/thunderstore/community/middleware.py
+++ b/django/thunderstore/community/middleware.py
@@ -3,11 +3,12 @@ from typing import TYPE_CHECKING, Optional
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.exceptions import ObjectDoesNotExist
-from django.http import Http404, HttpRequest, HttpResponse
+from django.http import Http404, HttpRequest, HttpResponse, HttpResponseRedirect
 from django.urls import reverse
 
 from thunderstore.community.utils import get_community_site_for_request
 from thunderstore.core.urls import AUTH_ROOT
+from thunderstore.core.utils import make_full_url
 
 if TYPE_CHECKING:
     from thunderstore.community.models import Community, CommunitySite
@@ -41,6 +42,12 @@ class CommunitySiteMiddleware:
         self.auth_path = f"/{AUTH_ROOT}"
 
     def get_404(self) -> HttpResponse:
+        # TODO: Replace with absolute link to main page instead of guessing
+        main_site_domain = settings.SESSION_COOKIE_DOMAIN
+        if main_site_domain is not None:
+            # TODO: Replace with unified URL building utility
+            main_site_url = f"{settings.PROTOCOL}{main_site_domain}"
+            return HttpResponseRedirect(redirect_to=main_site_url)
         return HttpResponse(content=b"Community not found", status=404)
 
     def __call__(self, request: CommunityHttpRequest) -> HttpResponse:

--- a/django/thunderstore/community/tests/test_middleware.py
+++ b/django/thunderstore/community/tests/test_middleware.py
@@ -1,0 +1,32 @@
+from typing import Any
+
+import pytest
+from django.utils.encoding import iri_to_uri
+
+from thunderstore.community.middleware import CommunitySiteMiddleware
+
+
+@pytest.mark.parametrize("protocol", ("http://", "https://"))
+@pytest.mark.parametrize(
+    "cookie_domain, status, content",
+    (
+        (None, 404, b"Community not found"),
+        ("localhost", 302, None),
+        ("thunderstore.localhost", 302, None),
+    ),
+)
+def test_community_site_middleware_get_404(
+    protocol: str,
+    cookie_domain: str,
+    status: int,
+    content: bytes,
+    settings: Any,
+) -> None:
+    settings.SESSION_COOKIE_DOMAIN = cookie_domain
+    settings.PROTOCOL = protocol
+    response = CommunitySiteMiddleware(None).get_404()
+    assert response.status_code == status
+    if content:
+        assert content in response.content
+    if status == 302:
+        assert response["Location"] == iri_to_uri(f"{protocol}{cookie_domain}")

--- a/django/thunderstore/social/templates/settings/linked_accounts.html
+++ b/django/thunderstore/social/templates/settings/linked_accounts.html
@@ -1,5 +1,5 @@
 {% extends 'settings/base.html' %}
-{% load social %}
+{% load social auth_login %}
 
 {% block title %}Linked Accounts{% endblock %}
 
@@ -31,7 +31,7 @@
             <span class="fab fa-{{entry}} mr-3"></span><span class="text-capitalize">{{ entry }}</span>
         </div>
         <div class="col-3">
-            <a href="{% url "social:begin" entry %}" class="btn btn-outline-success">Connect</a>
+            <a href="{% add_auth_login_link entry %}" class="btn btn-outline-success">Connect</a>
         </div>
     </div>
 {% endfor %}


### PR DESCRIPTION
This pull requests introduces a fix to a bug that is preventing OAuth accounts from being linked to the logged in user in some subdomains due to invalid redirect URLs.

Additionally some improved default behavior for the auth domain is included, which should lead to less dead ends if the OAuth process fails for some reason.