### PR TITLE
Fix edge case in markdown rendering

### DIFF
--- a/django/thunderstore/markdown/templatetags/markdownify.py
+++ b/django/thunderstore/markdown/templatetags/markdownify.py
@@ -17,7 +17,7 @@ md = MarkdownIt("gfm-like")
 def render_markdown(value: str):
     return mark_safe(
         bleach.clean(
-            text=md.render(value),
+            text=md.render(value.strip()),
             tags=ALLOWED_TAGS,
             protocols=ALLOWED_PROTOCOLS,
             attributes=ALLOWED_ATTRIBUTES,


### PR DESCRIPTION
Markdown-it-py throws an IndexError with the following content:

> QUOTE\n
+ UNORDERED LIST ITEM\n
  > INDENTED QUOTE\n
\n\n

Removing any of the three content rows or reducing the number of
newlines at the end seems to solve the issue. While stripping the
markdown before rendering might not be the most robust solution, it'll
be enough to fix an issue currently encountered in production.

Refs TS-228