### PR TITLE
Swap to s3 backed v1 API package list cache

### DIFF
--- a/django/thunderstore/cache/cache.py
+++ b/django/thunderstore/cache/cache.py
@@ -6,10 +6,8 @@ from urllib.parse import quote
 
 from django.conf import settings
 from django.core.cache import cache
-from django.http import HttpResponse
 from redis.exceptions import LockError
 
-from thunderstore.cache.models import DatabaseCache
 from thunderstore.core.utils import ChoiceEnum
 
 DEFAULT_CACHE_EXPIRY = 60 * 5
@@ -166,65 +164,6 @@ class ManualCacheMixin(object):
             default_args=args,
             default_kwargs=kwargs,
             expiry=self.cache_expiry,
-        )
-
-
-class BackgroundUpdatedCacheMixin(object):
-    cache_database_fallback = True
-
-    @classmethod
-    def get_no_cache_response(cls):
-        return HttpResponse("Cache missing")
-
-    @classmethod
-    def get_cache_key(cls, request, *args, **kwargs):
-        return get_cache_key(
-            cache_bust_condition=CacheBustCondition.background_update_only,
-            cache_type="view",
-            key=get_view_cache_name(cls),
-            vary_on=args + tuple(kwargs.values()) + (request.community_site,),
-        )
-
-    @classmethod
-    def get_cache(cls, key, default):
-        result = cache.get(key, None)
-        if result:
-            return result
-        elif cls.cache_database_fallback:
-            db_result = DatabaseCache.get(key, None)
-            if db_result:
-                cache.set(key, db_result, None)
-                return db_result
-        return default
-
-    @classmethod
-    def set_cache(cls, key, value, timeout):
-        result = cache.set(key, value, timeout)
-        if cls.cache_database_fallback:
-            DatabaseCache.set(key, value, timeout)
-        return result
-
-    def dispatch(self, *args, **kwargs):
-        if self.request.method != "GET" or kwargs.get("skip_cache", False) is True:
-            return (
-                super(BackgroundUpdatedCacheMixin, self)
-                .dispatch(*args, **kwargs)
-                .render()
-            )
-        return self.get_cache(
-            self.get_cache_key(*args, **kwargs),
-            self.get_no_cache_response(),
-        )
-
-    @classmethod
-    def update_cache(cls, view, *args, **kwargs):
-        kwargs.update({"skip_cache": True})
-        result = view(*args, **kwargs)
-        del kwargs["skip_cache"]
-        cls.set_cache(
-            key=cls.get_cache_key(*args, **kwargs),
-            value=result,
-            timeout=None,
         )
 
 

--- a/django/thunderstore/core/settings.py
+++ b/django/thunderstore/core/settings.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import os
+import sys
 
 import environ
 from django.http import HttpRequest
@@ -614,6 +615,11 @@ CACHE_S3_DEFAULT_ACL = env.str("CACHE_S3_DEFAULT_ACL")
 CACHE_S3_OBJECT_PARAMETERS = {
     "CacheControl": "max-age=2592000",  # 30 days
 }
+
+if not all((CACHE_S3_ENDPOINT_URL, CACHE_S3_ACCESS_KEY_ID, CACHE_S3_SECRET_ACCESS_KEY)):
+    if sys.argv[0] != "manage.py":
+        raise RuntimeError("Invalid cache configuration")
+
 
 if all((AWS_S3_ENDPOINT_URL, AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID)):
     DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"

--- a/django/thunderstore/repository/api/v1/serializers.py
+++ b/django/thunderstore/repository/api/v1/serializers.py
@@ -12,12 +12,7 @@ class PackageVersionSerializer(ModelSerializer):
     dependencies = SerializerMethodField()
 
     def get_download_url(self, instance):
-        url = instance.download_url
-        if "request" in self.context:
-            url = self.context["request"].build_absolute_uri(instance.download_url)
-        if settings.PROTOCOL == "https://" and url.startswith("http://"):
-            url = f"https://{url[7:]}"
-        return url
+        return f"{settings.PROTOCOL}{self.context['community_site'].site.domain}{instance.download_url}"
 
     def get_full_name(self, instance):
         return instance.full_version_name

--- a/django/thunderstore/repository/api/v1/tests/test_api_v1.py
+++ b/django/thunderstore/repository/api/v1/tests/test_api_v1.py
@@ -1,32 +1,128 @@
+import gzip
 import json
+import time
+from io import BytesIO
 
 import pytest
+from django.conf import settings
+from django.utils.http import http_date
+from rest_framework.renderers import JSONRenderer
+from rest_framework.test import APIClient
 
+from thunderstore.community.models import CommunitySite, PackageListing
 from thunderstore.core.factories import UserFactory
 from thunderstore.repository.api.v1.tasks import update_api_v1_caches
+from thunderstore.repository.api.v1.viewsets import PACKAGE_SERIALIZER
+from thunderstore.repository.models.cache import APIV1PackageCache
 
 
 @pytest.mark.django_db
-def test_api_v1(api_client, active_package_listing):
+def test_api_v1_package_list(
+    api_client: APIClient,
+    community_site: CommunitySite,
+    active_package_listing: PackageListing,
+) -> None:
+    response = api_client.get("/api/v1/package/")
+    assert response.status_code == 503
+
+    assert (
+        APIV1PackageCache.get_latest_for_community(active_package_listing.community)
+        is None
+    )
     update_api_v1_caches()
+    cache = APIV1PackageCache.get_latest_for_community(active_package_listing.community)
+    assert cache is not None
+
+    # Should get a full response
     response = api_client.get("/api/v1/package/")
     assert response.status_code == 200
-    result = response.json()
+
+    # The response is gzipped
+    content = BytesIO(response.content)
+    with gzip.GzipFile(fileobj=content, mode="r") as f:
+        result = json.loads(f.read())
+
     assert len(result) == 1
     assert result[0]["name"] == active_package_listing.package.name
     assert result[0]["full_name"] == active_package_listing.package.full_package_name
+    last_modified = response["Last-Modified"]
+    assert last_modified == http_date(int(cache.last_modified.timestamp()))
+    assert response["Content-Type"] == cache.content_type
+    assert response["Content-Encoding"] == cache.content_encoding
 
-    # TODO: Enable once detail views have been re-enabled
-    # uuid = result[0]["uuid4"]
-    # response = api_client.get(
-    #     f"/api/v1/package/{uuid}/",
-    # )
-    # assert response.status_code == 200
-    # assert response.json() == result[0]
+    # Should get a 304 since Last-Modified matches
+    response = api_client.get(
+        path="/api/v1/package/",
+        HTTP_IF_MODIFIED_SINCE=last_modified,
+    )
+    assert response.status_code == 304
+
+    # We need to sleep at least 0.5 seconds to ensure differing timestamp
+    # TODO: Use freezegun or similar instead of sleeping
+    # TODO: Use ETag instead of just timestmap
+    time.sleep(1)
+    update_api_v1_caches()
+    new_cache = APIV1PackageCache.get_latest_for_community(
+        active_package_listing.community
+    )
+    assert new_cache != cache
+    assert new_cache.last_modified > cache.last_modified
+
+    # Should get a 200 since cache was regenerated
+    response = api_client.get(
+        path="/api/v1/package/", HTTP_IF_MODIFIED_SINCE=last_modified
+    )
+    assert response.status_code == 200
+    assert response["Last-Modified"] != last_modified
+    assert response["Last-Modified"] == http_date(
+        int(new_cache.last_modified.timestamp())
+    )
+    assert len(result) == 1
+    assert result[0]["name"] == active_package_listing.package.name
+    assert result[0]["full_name"] == active_package_listing.package.full_package_name
+    assert result[0]["package_url"].startswith(
+        f"{settings.PROTOCOL}{community_site.site.domain}"
+    )
+    assert result[0]["versions"][0]["download_url"].startswith(
+        f"{settings.PROTOCOL}{community_site.site.domain}"
+    )
 
 
 @pytest.mark.django_db
-def test_api_v1_rate_package(api_client, active_package_listing):
+def test_api_v1_package_detail(
+    api_client: APIClient,
+    community_site: CommunitySite,
+    active_package_listing: PackageListing,
+) -> None:
+    response = api_client.get(
+        f"/api/v1/package/{active_package_listing.package.uuid4}/",
+    )
+    assert community_site.community == active_package_listing.community
+    assert response.status_code == 200
+    result = response.json()
+    assert result == json.loads(
+        JSONRenderer().render(
+            PACKAGE_SERIALIZER(
+                instance=active_package_listing,
+                context={
+                    "community_site": community_site,
+                },
+            ).data
+        )
+    )
+    assert result["package_url"].startswith(
+        f"{settings.PROTOCOL}{community_site.site.domain}"
+    )
+    assert result["versions"][0]["download_url"].startswith(
+        f"{settings.PROTOCOL}{community_site.site.domain}"
+    )
+
+
+@pytest.mark.django_db
+def test_api_v1_rate_package(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+) -> None:
     uuid = active_package_listing.package.uuid4
     user = UserFactory.create()
     api_client.force_authenticate(user)
@@ -53,9 +149,9 @@ def test_api_v1_rate_package(api_client, active_package_listing):
 
 @pytest.mark.django_db
 def test_api_v1_rate_package_permission_denied(
-    api_client,
-    active_package_listing,
-):
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+) -> None:
     uuid = active_package_listing.package.uuid4
     response = api_client.post(
         f"/api/v1/package/{uuid}/rate/",

--- a/django/thunderstore/repository/cache.py
+++ b/django/thunderstore/repository/cache.py
@@ -1,15 +1,15 @@
 from thunderstore.community.models import (
-    CommunitySite,
+    Community,
     PackageListing,
     PackageListingReviewStatus,
     Q,
 )
 
 
-def get_package_listing_queryset(community_site: CommunitySite):
+def get_package_listing_queryset(community: Community):
     return (
         PackageListing.objects.active()
-        .exclude(~Q(community=community_site.community))
+        .exclude(~Q(community=community))
         .exclude(review_status=PackageListingReviewStatus.rejected)
         .exclude(
             Q(community__require_package_listing_approval=True)

--- a/django/thunderstore/repository/tests/test_query_performance.py
+++ b/django/thunderstore/repository/tests/test_query_performance.py
@@ -46,7 +46,7 @@ def test_package_query_count(
             )
         creation_queries = len(context)
 
-    packages = get_package_listing_queryset(community_site)
+    packages = get_package_listing_queryset(community_site.community)
     with django_assert_max_num_queries(package_count + creation_queries + 1):
         serializer = PackageListingSerializer(
             packages, many=True, context={"community_site": community_site}


### PR DESCRIPTION
Swap from redis to s3 for the v1 API package list. This is a good idea
as the cache was getting large enough for some communities to cause load
issues.