### PR TITLE
Reduce cache code complexity slightly

### DIFF
--- a/django/thunderstore/cache/cache.py
+++ b/django/thunderstore/cache/cache.py
@@ -81,7 +81,7 @@ def cache_get_or_set_by_key(
     get_default,
     default_args=(),
     default_kwargs=None,
-    expiry=None,
+    expiry=DEFAULT_CACHE_EXPIRY,
 ):
     if default_kwargs is None:
         default_kwargs = {}

--- a/django/thunderstore/cache/pagination.py
+++ b/django/thunderstore/cache/pagination.py
@@ -2,7 +2,7 @@ from django.core.paginator import Page, Paginator
 from django.db.models import QuerySet
 from django.utils.functional import cached_property
 
-from thunderstore.cache.cache import DEFAULT_CACHE_EXPIRY, cache_get_or_set_by_key
+from thunderstore.cache.cache import cache_get_or_set_by_key
 
 
 class CachedPaginator(Paginator):
@@ -47,7 +47,6 @@ class CachedPaginator(Paginator):
             cache_key=f"{self.cache_key}.count",
             cache_vary=self.cache_vary,
             get_default=lambda: super(CachedPaginator, self).count,
-            expiry=DEFAULT_CACHE_EXPIRY,
         )
 
     def _check_object_list_is_ordered(self):
@@ -79,5 +78,4 @@ class CachedPage(Page):
             cache_key=f"{self.cache_key}.page.{self.number}",
             cache_vary=self.cache_vary,
             get_default=lambda: list(self._object_list),
-            expiry=DEFAULT_CACHE_EXPIRY,
         )


### PR DESCRIPTION
Implement the change made in commit
5a87fb33022e1f08dac9c07a12e74f75069333bb in a less complex way by
moving the cache timeout to the caching function as a default, instead
of explicitly setting it on all of the call sites as that is not the
intention.