### PR TITLE
Add team donation link settings page

### DIFF
--- a/django/thunderstore/repository/forms/team.py
+++ b/django/thunderstore/repository/forms/team.py
@@ -158,3 +158,26 @@ class DisbandTeamForm(forms.ModelForm):
     def save(self, **kwargs):
         self.instance.ensure_user_can_disband(self.user)
         self.instance.delete()
+
+
+class DonationLinkTeamForm(forms.ModelForm):
+    instance: Team
+
+    class Meta:
+        model = Team
+        fields = ["donation_link"]
+
+    def __init__(self, user: UserType, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.user = user
+
+    def clean(self):
+        if not self.instance.pk:
+            raise ValidationError("Missing team instance")
+        self.instance.ensure_user_can_edit_info(self.user)
+        return super().clean()
+
+    @transaction.atomic
+    def save(self, **kwargs):
+        self.instance.ensure_user_can_edit_info(self.user)
+        return super().save(**kwargs)

--- a/django/thunderstore/repository/templates/settings/team_base.html
+++ b/django/thunderstore/repository/templates/settings/team_base.html
@@ -11,6 +11,7 @@
         <ul class="pl-3 mb-0">
             <li><a href="{% url 'settings.teams.detail' team.name %}">Members</a></li>
             <li><a href="{% url 'settings.teams.detail.service_accounts' team.name %}">Service Accounts</a></li>
+            <li><a href="{% url 'settings.teams.detail.donation_link' team.name %}">Donation Link</a></li>
             <li><a href="{% url 'settings.teams.detail.leave' team.name %}" class="text-danger">Leave</a></li>
             <li><a href="{% url 'settings.teams.detail.disband' team.name %}" class="text-danger">Disband</a></li>
         </ul>

--- a/django/thunderstore/repository/templates/settings/team_donation_link.html
+++ b/django/thunderstore/repository/templates/settings/team_donation_link.html
@@ -1,0 +1,52 @@
+{% extends 'settings/team_base.html' %}
+
+{% block title %}Configure Donation Link{% endblock %}
+
+{% block settings_content %}
+<div class="alert alert-primary" role="alert">
+    <p class="mb-0">
+        This is a <b>placeholder feature</b> and <b>might be removed in the future</b>
+        when a more comprehensive solution is implemented.
+    </p>
+</div>
+<p>
+    You can configure a donation link for the team here. The donation link is
+    exposed via our API and might be shown on some UIs when viewing packages
+    owned by the team, although implementations vary.
+</p>
+<p>
+    Only HTTPS links are allowed for security reasons.
+</p>
+
+
+<form class="form-inline" method="post" action="{{ request.path }}">
+    {% csrf_token %}
+    <div class="col-12 p-0 mb-2">
+        <div class="d-flex">
+            <div>
+                <input
+                    type="text"
+                    class="form-control"
+                    name="donation_link"
+                    placeholder="https://"
+                    {% if not can_edit %}readonly{% endif %}
+                    {% if form.donation_link.initial %}value="{{ form.donation_link.initial }}"{% endif %}>
+                <div class="text-danger mt-2">{{ form.donation_link.errors }}</div>
+            </div>
+        </div>
+    </div>
+    <div class="text-danger mb-2">
+        {{ form.non_field_errors }}
+    </div>
+    <div class="col-12 p-0">
+        <input
+            type="submit"
+            class="btn btn-primary{% if not can_edit %} disabled{% endif %}"
+            {% if not can_edit %}disabled{% endif %}
+            value="Save">
+        {% if not can_edit %}
+            <p class="text-danger mt-3 mb-0">Only the team owner can edit this field</p>
+        {% endif %}
+    </div>
+</form>
+{% endblock %}

--- a/django/thunderstore/repository/tests/test_team.py
+++ b/django/thunderstore/repository/tests/test_team.py
@@ -687,7 +687,7 @@ def test_team_get_namespace(team):
     ),
 )
 def test_team_donation_link_validation(
-    team: Team, value: str, should_fail: bool
+    team: Team, value: Optional[str], should_fail: bool
 ) -> None:
     team.donation_link = value
     if should_fail:
@@ -695,3 +695,31 @@ def test_team_donation_link_validation(
             team.save()
     else:
         team.save()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("user_type", TestUserTypes.options())
+@pytest.mark.parametrize("role", TeamMemberRole.options() + [None])
+def test_team_ensure_user_can_edit_info(team: Team, user_type: str, role: str) -> None:
+    user = TestUserTypes.get_user_by_type(user_type)
+    if role is not None and user_type not in TestUserTypes.fake_users():
+        TeamMember.objects.create(user=user, team=team, role=role)
+
+    if user_type in TestUserTypes.fake_users():
+        expected_error = "Must be authenticated"
+    elif user_type == TestUserTypes.deactivated_user:
+        expected_error = "User has been deactivated"
+    elif user_type == TestUserTypes.service_account:
+        expected_error = "Service accounts are unable to edit team info"
+    elif role == TeamMemberRole.owner:
+        expected_error = None
+    else:
+        expected_error = "Must be an owner to edit team info"
+
+    if expected_error is not None:
+        assert team.can_user_edit_info(user) is False
+        with pytest.raises(ValidationError, match=expected_error):
+            team.ensure_user_can_edit_info(user)
+    else:
+        assert team.can_user_edit_info(user) is True
+        assert team.ensure_user_can_edit_info(user) is None

--- a/django/thunderstore/repository/urls.py
+++ b/django/thunderstore/repository/urls.py
@@ -17,6 +17,7 @@ from thunderstore.repository.views.team_settings import (
     SettingsTeamCreateView,
     SettingsTeamDetailView,
     SettingsTeamDisbandView,
+    SettingsTeamDonationLinkView,
     SettingsTeamLeaveView,
     SettingsTeamListView,
     SettingsTeamServiceAccountView,
@@ -94,5 +95,10 @@ settings_urls = [
         "teams/<str:name>/disband/",
         SettingsTeamDisbandView.as_view(),
         name="settings.teams.detail.disband",
+    ),
+    path(
+        "teams/<str:name>/donation-link/",
+        SettingsTeamDonationLinkView.as_view(),
+        name="settings.teams.detail.donation_link",
     ),
 ]

--- a/django/thunderstore/repository/views/team_settings.py
+++ b/django/thunderstore/repository/views/team_settings.py
@@ -4,7 +4,13 @@ from django.contrib import messages
 from django.core.exceptions import SuspiciousOperation, ValidationError
 from django.db import transaction
 from django.shortcuts import redirect, render
-from django.views.generic import CreateView, DetailView, FormView, TemplateView
+from django.views.generic import (
+    CreateView,
+    DetailView,
+    FormView,
+    TemplateView,
+    UpdateView,
+)
 
 from thunderstore.account.forms import (
     CreateServiceAccountForm,
@@ -16,6 +22,7 @@ from thunderstore.repository.forms import (
     AddTeamMemberForm,
     CreateTeamForm,
     DisbandTeamForm,
+    DonationLinkTeamForm,
     EditTeamMemberForm,
     RemoveTeamMemberForm,
     TeamMemberRole,
@@ -250,3 +257,21 @@ class SettingsTeamAddServiceAccountView(TeamDetailView, UserFormKwargs, FormView
         context["api_token"] = form.api_token
         context["nickname"] = form.cleaned_data["nickname"]
         return render(self.request, self.template_name, context)
+
+
+class SettingsTeamDonationLinkView(TeamDetailView, UserFormKwargs, UpdateView):
+    template_name = "settings/team_donation_link.html"
+    form_class = DonationLinkTeamForm
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["page_title"] = f"Team {self.object.name} Donation Link"
+        context["can_edit"] = self.object.can_user_edit_info(self.request.user)
+        return context
+
+    def get_success_url(self):
+        return self.object.donation_link_url
+
+    def form_valid(self, form: DonationLinkTeamForm):
+        messages.success(self.request, "Donation link saved")
+        return super().form_valid(form)


### PR DESCRIPTION
Add a new settings page which allows for the donation link field on a
team to be filled by the team's owner.

Visual preview (screenshot text is outdated, but otherwise matches):
![image](https://user-images.githubusercontent.com/8225825/161369975-9b0fc772-96fa-40f0-be7e-6208e128fcf9.png)

**BLOCKED BY #539**