### PR TITLE
Fix API cache cleanup for siteless communities

### DIFF
--- a/django/thunderstore/repository/models/cache.py
+++ b/django/thunderstore/repository/models/cache.py
@@ -64,6 +64,8 @@ class APIV1PackageCache(S3FileMixin):
             latest = cls.get_latest_for_community(
                 community_identifier=community.identifier
             )
+            if latest is None:
+                continue
             cutoff = latest.last_modified - timedelta(hours=1)
             stale = cls.objects.filter(last_modified__lte=cutoff, community=community)
             for entry in stale.iterator():

--- a/django/thunderstore/repository/tests/test_cache_models.py
+++ b/django/thunderstore/repository/tests/test_cache_models.py
@@ -130,6 +130,13 @@ def test_api_v1_package_cache_drop_stale_cache(
 
 
 @pytest.mark.django_db
+def test_api_v1_package_cache_drop_stale_cache_none(settings: Any) -> None:
+    settings.DISABLE_TRANSACTION_CHECKS = True
+    CommunityFactory()  # Create a community without a community site
+    assert APIV1PackageCache.drop_stale_cache() is None  # Ensure no crash
+
+
+@pytest.mark.django_db
 def test_api_v1_package_cache_delete_file_transactions_disabled(community: Community):
     cache = APIV1PackageCache.update_for_community(community, b"")
     with pytest.raises(RuntimeError, match="Must not be called during a transaction"):


### PR DESCRIPTION
Fix API cache cleanup for cases where there is no API cache to clean up
(due to there being no CommunitySite object assigned and thus no cache
being generated).

Refs TS-379