### PR TITLE
Use primary host fallback for URL building

### DIFF
--- a/django/thunderstore/repository/models/package.py
+++ b/django/thunderstore/repository/models/package.py
@@ -1,6 +1,7 @@
 import re
 import uuid
 from distutils.version import StrictVersion
+from typing import Optional
 
 from django.conf import settings
 from django.contrib.sites.models import Site
@@ -260,10 +261,11 @@ class Package(models.Model):
             },
         )
 
-    def get_full_url(self, site: Site):
+    def get_full_url(self, site: Optional[Site] = None):
+        hostname = settings.PRIMARY_HOST if site is None else site.domain
         return "%(protocol)s%(hostname)s%(path)s" % {
             "protocol": settings.PROTOCOL,
-            "hostname": site.domain,
+            "hostname": hostname,
             "path": self.get_absolute_url(),
         }
 

--- a/django/thunderstore/repository/tests/test_package.py
+++ b/django/thunderstore/repository/tests/test_package.py
@@ -1,6 +1,14 @@
+from typing import Any
+
 import pytest
 
+from thunderstore.community.factories import (
+    CommunityFactory,
+    CommunitySiteFactory,
+    SiteFactory,
+)
 from thunderstore.community.models.package_listing import PackageListing
+from thunderstore.repository.models import Package
 
 
 @pytest.mark.django_db
@@ -30,3 +38,24 @@ def test_package_get_page_url(
         active_package_listing.community.identifier
     )
     assert owner_url == f"/c/test/p/Test_Team/{active_package_listing.package.name}/"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "site_host", ("thunderstore.dev", "test.thunderstore.dev", None)
+)
+@pytest.mark.parametrize(
+    "primary_host", ("thunderstore.io", "stonderthure.io.example.org")
+)
+def test_package_get_full_url(
+    settings: Any,
+    site_host: str,
+    primary_host: str,
+    active_package: Package,
+) -> None:
+    site = SiteFactory(domain=site_host) if site_host is not None else None
+    settings.PRIMARY_HOST = primary_host
+
+    expected_host = site_host if site else primary_host
+    expected_url = f"{settings.PROTOCOL}{expected_host}/package/{active_package.namespace.name}/{active_package.name}/"
+    assert active_package.get_full_url(site=site) == expected_url


### PR DESCRIPTION
Use the `PRIMARY_HOST` setting as a fallback when building a package's
full URL if a Site isn't provided.

This is a required change as in the new URL scheme we no longer have a community site context available. However, this can't be relied on before #405 is finalized.

This PR also does not mean we should default to the `PRIMARY_HOST` in every scenario. If possible, we should direct to the community-specific URLs defined in the new URL schema, and this can be done at least for the v1 API just fine.

Refs TS-383