### PR TITLE
Use primary host for API v1 download URLs

### DIFF
--- a/django/thunderstore/repository/api/v1/serializers.py
+++ b/django/thunderstore/repository/api/v1/serializers.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from rest_framework.fields import Field
 from rest_framework.serializers import ModelSerializer, SerializerMethodField
 
@@ -12,7 +11,7 @@ class PackageVersionSerializer(ModelSerializer):
     dependencies = SerializerMethodField()
 
     def get_download_url(self, instance):
-        return f"{settings.PROTOCOL}{self.context['community_site'].site.domain}{instance.download_url}"
+        return instance.full_download_url
 
     def get_full_name(self, instance):
         return instance.full_version_name

--- a/django/thunderstore/repository/api/v1/tests/test_api_v1.py
+++ b/django/thunderstore/repository/api/v1/tests/test_api_v1.py
@@ -2,7 +2,7 @@ import gzip
 import json
 import time
 from io import BytesIO
-from typing import Optional
+from typing import Any, Optional
 
 import pytest
 from django.conf import settings
@@ -24,7 +24,9 @@ def test_api_v1_package_list(
     community_site: CommunitySite,
     active_package_listing: PackageListing,
     old_urls: bool,
+    settings: Any,
 ) -> None:
+    settings.PRIMARY_HOST = "example.org"
     active_package_listing.package.owner.donation_link = "https://example.org/"
     active_package_listing.package.owner.save()
     if old_urls:
@@ -105,8 +107,9 @@ def test_api_v1_package_list(
     assert result[0]["package_url"].startswith(
         f"{settings.PROTOCOL}{community_site.site.domain}"
     )
+    assert settings.PRIMARY_HOST != community_site.site.domain
     assert result[0]["versions"][0]["download_url"].startswith(
-        f"{settings.PROTOCOL}{community_site.site.domain}"
+        f"{settings.PROTOCOL}{settings.PRIMARY_HOST}"
     )
 
 
@@ -117,7 +120,9 @@ def test_api_v1_package_detail(
     community_site: CommunitySite,
     active_package_listing: PackageListing,
     old_urls: bool,
+    settings: Any,
 ) -> None:
+    settings.PRIMARY_HOST = "example.org"
     if old_urls:
         url = f"/api/v1/package/{active_package_listing.package.uuid4}/"
     else:
@@ -139,8 +144,9 @@ def test_api_v1_package_detail(
     assert result["package_url"].startswith(
         f"{settings.PROTOCOL}{community_site.site.domain}"
     )
+    assert settings.PRIMARY_HOST != community_site.site.domain
     assert result["versions"][0]["download_url"].startswith(
-        f"{settings.PROTOCOL}{community_site.site.domain}"
+        f"{settings.PROTOCOL}{settings.PRIMARY_HOST}"
     )
 
 

--- a/django/thunderstore/repository/models/package_version.py
+++ b/django/thunderstore/repository/models/package_version.py
@@ -162,6 +162,14 @@ class PackageVersion(models.Model):
             },
         )
 
+    @cached_property
+    def full_download_url(self) -> str:
+        return "%(protocol)s%(hostname)s%(path)s" % {
+            "protocol": settings.PROTOCOL,
+            "hostname": settings.PRIMARY_HOST,
+            "path": self.download_url,
+        }
+
     def get_install_url(self, request):
         return "ror2mm://v1/install/%(hostname)s/%(owner)s/%(name)s/%(version)s/" % {
             "hostname": request.site.domain,

--- a/django/thunderstore/repository/tests/test_package_version.py
+++ b/django/thunderstore/repository/tests/test_package_version.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from thunderstore.community.models.package_listing import PackageListing
@@ -43,3 +45,23 @@ def test_package_version_get_owner_url(active_package_listing: PackageListing) -
         active_package_listing.community.identifier
     )
     assert owner_url == "/c/test/p/Test_Team/"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("protocol", ("http://", "https://"))
+@pytest.mark.parametrize(
+    "primary_host", ("primary.example.org", "secondary.example.org")
+)
+def test_package_version_full_download_url(
+    active_package_listing: PackageListing,
+    protocol: str,
+    primary_host: str,
+    settings: Any,
+) -> None:
+    settings.PRIMARY_HOST = primary_host
+    settings.PROTOCOL = protocol
+    package = active_package_listing.package
+    namespace = package.namespace.name
+    version = package.latest
+    expected = f"{protocol}{primary_host}/package/download/{namespace}/{package.name}/{version.version_number}/"
+    assert version.full_download_url == expected


### PR DESCRIPTION
Always use the PRIMARY_HOST when building package download URLs for the
API v1, effectively removing the need for a community_site being
available.

Refs TS-385