### PR TITLE
Build API v1 cache for subdomainless communities

### DIFF
--- a/django/thunderstore/core/utils.py
+++ b/django/thunderstore/core/utils.py
@@ -54,7 +54,8 @@ def ensure_fields_editable_on_creation(readonly_fields, obj, editable_fields):
 class CommunitySiteSerializerContext:
     def get_serializer_context(self):
         context = super().get_serializer_context()
-        context["community_site"] = self.request.community_site
+        context.setdefault("community_site", self.request.community_site)
+        context.setdefault("community", self.request.community)
         return context
 
 

--- a/django/thunderstore/repository/api/v1/tasks.py
+++ b/django/thunderstore/repository/api/v1/tasks.py
@@ -1,4 +1,4 @@
-from thunderstore.community.models import CommunitySite
+from thunderstore.community.models import Community, CommunitySite
 from thunderstore.repository.api.v1.viewsets import serialize_package_list_for_community
 from thunderstore.repository.models.cache import APIV1PackageCache
 
@@ -8,9 +8,20 @@ def update_api_v1_caches() -> None:
 
 
 def update_api_v1_indexes() -> None:
-    for site in CommunitySite.objects.all():
+    for site in CommunitySite.objects.iterator():
         APIV1PackageCache.update_for_community(
             community=site.community,
-            content=serialize_package_list_for_community(community_site=site),
+            content=serialize_package_list_for_community(
+                community=site.community,
+                community_site=site,
+            ),
+        )
+    for community in Community.objects.filter(sites=None).iterator():
+        APIV1PackageCache.update_for_community(
+            community=community,
+            content=serialize_package_list_for_community(
+                community=community,
+                community_site=None,
+            ),
         )
     APIV1PackageCache.drop_stale_cache()

--- a/django/thunderstore/repository/api/v1/tests/test_api_v1.py
+++ b/django/thunderstore/repository/api/v1/tests/test_api_v1.py
@@ -5,7 +5,6 @@ from io import BytesIO
 from typing import Any, Optional
 
 import pytest
-from django.conf import settings
 from django.utils.http import http_date
 from rest_framework.renderers import JSONRenderer
 from rest_framework.test import APIClient

--- a/django/thunderstore/repository/api/v1/tests/test_caches.py
+++ b/django/thunderstore/repository/api/v1/tests/test_caches.py
@@ -1,0 +1,135 @@
+import gzip
+import json
+from typing import Any
+
+import pytest
+
+from thunderstore.community.factories import (
+    CommunityFactory,
+    CommunitySiteFactory,
+    PackageListingFactory,
+    SiteFactory,
+)
+from thunderstore.community.models import Community, CommunitySite, PackageListing
+from thunderstore.repository.api.v1.tasks import update_api_v1_caches
+from thunderstore.repository.models import APIV1PackageCache
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("create_site", (False, True))
+def test_api_v1_cache_building_package_url(
+    community: Community,
+    active_package_listing: PackageListing,
+    create_site: bool,
+    settings: Any,
+):
+    primary_domain = "primary.example.org"
+    settings.PRIMARY_HOST = primary_domain
+    site_domain = "community.example.org"
+
+    if create_site:
+        CommunitySiteFactory(site=SiteFactory(domain=site_domain), community=community)
+
+    assert CommunitySite.objects.filter(community=community).count() == int(create_site)
+    assert APIV1PackageCache.get_latest_for_community(community.identifier) is None
+    update_api_v1_caches()
+    cache = APIV1PackageCache.get_latest_for_community(community.identifier)
+    assert cache is not None
+
+    with gzip.GzipFile(fileobj=cache.data, mode="r") as f:
+        result = json.loads(f.read())
+
+    domain = site_domain if create_site else primary_domain
+    prefix = "/package" if create_site else f"/c/{community.identifier}/p"
+    path = f"/{active_package_listing.package.namespace.name}/{active_package_listing.package.name}/"
+    assert result[0]["package_url"] == f"{settings.PROTOCOL}{domain}{prefix}{path}"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "protocol, primary_domain, site_domain, community_identifier, expected_prefix",
+    (
+        (
+            "http://",
+            "thunderstore.dev",
+            "thunderstore.dev",
+            "riskofrain2",
+            "http://thunderstore.dev/package/",
+        ),
+        (
+            "http://",
+            "thunderstore.dev",
+            "ror2.thunderstore.dev",
+            "riskofrain2",
+            "http://ror2.thunderstore.dev/package/",
+        ),
+        (
+            "https://",
+            "thunderstore.dev",
+            "ror2.thunderstore.dev",
+            "riskofrain2",
+            "https://ror2.thunderstore.dev/package/",
+        ),
+        (
+            "https://",
+            "thunderstore.dev",
+            None,
+            "riskofrain2",
+            "https://thunderstore.dev/c/riskofrain2/p/",
+        ),
+        (
+            "https://",
+            "example.org",
+            None,
+            "riskofrain2",
+            "https://example.org/c/riskofrain2/p/",
+        ),
+        (
+            "https://",
+            "example.org",
+            "thunderstore.dev",
+            "riskofrain2",
+            "https://thunderstore.dev/package/",
+        ),
+        (
+            "https://",
+            "example.org",
+            "thunderstore.dev",
+            "valheim",
+            "https://thunderstore.dev/package/",
+        ),
+        (
+            "https://",
+            "example.org",
+            None,
+            "valheim",
+            "https://example.org/c/valheim/p/",
+        ),
+    ),
+)
+def test_api_v1_cache_building_package_url_simple(
+    protocol: str,
+    primary_domain: str,
+    site_domain: str,
+    community_identifier: str,
+    expected_prefix: str,
+    settings: Any,
+) -> None:
+    settings.PRIMARY_HOST = primary_domain
+    settings.PROTOCOL = protocol
+    community = CommunityFactory(identifier=community_identifier)
+    PackageListingFactory(community_=community)
+    if site_domain:
+        CommunitySiteFactory(site=SiteFactory(domain=site_domain), community=community)
+
+    assert CommunitySite.objects.filter(community=community).count() == int(
+        bool(site_domain)
+    )
+    assert APIV1PackageCache.get_latest_for_community(community.identifier) is None
+    update_api_v1_caches()
+    cache = APIV1PackageCache.get_latest_for_community(community.identifier)
+    assert cache is not None
+
+    with gzip.GzipFile(fileobj=cache.data, mode="r") as f:
+        result = json.loads(f.read())
+    assert result[0]["package_url"].startswith(expected_prefix)

--- a/django/thunderstore/repository/api/v1/viewsets.py
+++ b/django/thunderstore/repository/api/v1/viewsets.py
@@ -12,7 +12,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 
-from thunderstore.community.models import CommunitySite
+from thunderstore.community.models import Community, CommunitySite
 from thunderstore.core.types import HttpRequestType
 from thunderstore.core.utils import CommunitySiteSerializerContext
 from thunderstore.repository.api.v1.serializers import PackageListingSerializer
@@ -25,15 +25,16 @@ from thunderstore.repository.permissions import ensure_can_rate_package
 PACKAGE_SERIALIZER = PackageListingSerializer
 
 
-def serialize_package_list_for_community(community_site: CommunitySite) -> bytes:
-    queryset = get_package_listing_queryset(
-        community_identifier=community_site.community.identifier
-    )
+def serialize_package_list_for_community(
+    community: Community, community_site: Optional[CommunitySite] = None
+) -> bytes:
+    queryset = get_package_listing_queryset(community_identifier=community.identifier)
     serializer = PACKAGE_SERIALIZER(
         queryset,
         many=True,
         context={
             "community_site": community_site,
+            "community": community,
         },
     )
     return JSONRenderer().render(serializer.data)

--- a/django/thunderstore/repository/mixins.py
+++ b/django/thunderstore/repository/mixins.py
@@ -29,3 +29,8 @@ class CommunityMixin:
         context["community_identifier"] = self.community_identifier
         context["community"] = self.community
         return context
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context.setdefault("community", self.community)
+        return context


### PR DESCRIPTION
Enable generation of API v1 cache for communities without a
CommunitySite at all, but make sure to provide at least the community in
the serializer context.

Refs TS-381