### PR TITLE
Experimental API: create user account based on OAuth login

### DIFF
--- a/django/thunderstore/social/api/experimental/views/complete_login.py
+++ b/django/thunderstore/social/api/experimental/views/complete_login.py
@@ -1,6 +1,10 @@
 from typing import Sequence, Type
+from uuid import uuid4
 
+from django.contrib.auth import get_user_model
+from django.db import transaction
 from django.http import HttpResponse
+from django.utils.text import slugify
 from drf_yasg.utils import swagger_auto_schema  # type: ignore
 from rest_framework import serializers
 from rest_framework.permissions import BasePermission
@@ -8,9 +12,13 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.status import HTTP_400_BAD_REQUEST
 from rest_framework.views import APIView
+from social_django.models import UserSocialAuth  # type: ignore
 
+from thunderstore.core.types import UserType
 from thunderstore.social.permissions import OauthSharedSecretPermission
-from thunderstore.social.providers import get_helper
+from thunderstore.social.providers import UserInfoSchema, get_helper
+
+User = get_user_model()
 
 
 class RequestBody(serializers.Serializer):
@@ -48,10 +56,75 @@ class CompleteLoginApiView(APIView):
         if not helper_class:
             return Response("Unsupported OAuth provider", HTTP_400_BAD_REQUEST)
 
-        # TODO: get or create a user account based on user_info, create
-        # a new session for the user and return session id.
+        # TODO: create a new session for the user and return session id.
         helper = helper_class(code, redirect_uri)
         helper.complete_login()
         user_info = helper.get_user_info()
+        user = get_or_create_auth_user(provider, user_info)
 
         return Response({"session_id": "TODO"})
+
+
+@transaction.atomic
+def get_or_create_auth_user(provider: str, user_info: UserInfoSchema) -> UserType:
+    """
+    Return local user object based on OAuth user data.
+
+    The "local" user object is the one defined in Django config.
+    social_django library manages additional OAuth related data via
+    UserSocialAuth model.
+    """
+    try:
+        sa_user: UserSocialAuth = UserSocialAuth.objects.get(
+            provider=provider,
+            uid=user_info.uid,
+        )
+    except UserSocialAuth.DoesNotExist:
+        username = get_unique_username(user_info.username)
+        full = user_info.name
+        first, last = full.split(" ", 1) if " " in full else (full, "")
+
+        user = User(
+            email=user_info.email,
+            first_name=first,
+            last_name=last,
+            username=username,
+        )
+        user.set_unusable_password()  # type: ignore
+        user.save()
+
+        sa_user = UserSocialAuth.objects.create(
+            extra_data=user_info.extra_data,
+            provider=provider,
+            uid=user_info.uid,
+            user=user,
+        )
+    else:
+        sa_user.extra_data = user_info.extra_data
+        sa_user.save()
+
+    return sa_user.user
+
+
+def get_unique_username(original_username: str) -> str:
+    """
+    Add random suffix to username when needed to make it unique.
+
+    This imitates how Social Auth library implements a similar method,
+    minus all the configurability.
+    """
+    if original_username == "":
+        raise ValueError("Username may not be empty")
+
+    max_length = User._meta.get_field("username").max_length or 150
+    suffix_length = 16
+    slugified = slugify(original_username)[:max_length]
+    username = slugified
+    attempts_remaining = 10  # Prevent infinite loops in case of bugs.
+
+    while attempts_remaining and User.objects.filter(username=username).exists():
+        suffix = uuid4().hex[:suffix_length]
+        username = slugified[: (max_length - suffix_length)] + suffix
+        attempts_remaining -= 1
+
+    return username

--- a/django/thunderstore/social/api/experimental/views/complete_login.py
+++ b/django/thunderstore/social/api/experimental/views/complete_login.py
@@ -60,13 +60,13 @@ class CompleteLoginApiView(APIView):
         helper = helper_class(code, redirect_uri)
         helper.complete_login()
         user_info = helper.get_user_info()
-        user = get_or_create_auth_user(provider, user_info)
+        user = get_or_create_auth_user(user_info)
 
         return Response({"session_id": "TODO"})
 
 
 @transaction.atomic
-def get_or_create_auth_user(provider: str, user_info: UserInfoSchema) -> UserType:
+def get_or_create_auth_user(user_info: UserInfoSchema) -> UserType:
     """
     Return local user object based on OAuth user data.
 
@@ -76,7 +76,7 @@ def get_or_create_auth_user(provider: str, user_info: UserInfoSchema) -> UserTyp
     """
     try:
         sa_user: UserSocialAuth = UserSocialAuth.objects.get(
-            provider=provider,
+            provider=user_info.provider,
             uid=user_info.uid,
         )
     except UserSocialAuth.DoesNotExist:
@@ -95,7 +95,7 @@ def get_or_create_auth_user(provider: str, user_info: UserInfoSchema) -> UserTyp
 
         sa_user = UserSocialAuth.objects.create(
             extra_data=user_info.extra_data,
-            provider=provider,
+            provider=user_info.provider,
             uid=user_info.uid,
             user=user,
         )

--- a/django/thunderstore/social/providers.py
+++ b/django/thunderstore/social/providers.py
@@ -18,6 +18,7 @@ class UserInfoSchema(BaseModel):
     email: str
     extra_data: Dict[str, Any]
     name: str
+    provider: str
     uid: str
     username: str
 
@@ -54,6 +55,13 @@ class BaseOauthHelper(ABC):
     def OAUTH_URL(self) -> str:
         """
         URL for exchanging an authorization code for an access token.
+        """
+
+    @property
+    @abstractmethod
+    def PROVIDER_NAME(self) -> str:
+        """
+        Human-readable name for the OAuth provider service.
         """
 
     def __init__(self, code: str, redirect_uri: str) -> None:
@@ -110,6 +118,7 @@ class DiscordOauthHelper(BaseOauthHelper):
     CLIENT_ID = settings.SOCIAL_AUTH_DISCORD_KEY
     CLIENT_SECRET = settings.SOCIAL_AUTH_DISCORD_SECRET
     OAUTH_URL = "https://discord.com/api/v8/oauth2/token"
+    PROVIDER_NAME = "discord"
 
     def get_user_info(self) -> UserInfoSchema:
         """
@@ -137,6 +146,7 @@ class DiscordOauthHelper(BaseOauthHelper):
                 "email": data.email,
                 "extra_data": response_json,
                 "name": "",
+                "provider": self.PROVIDER_NAME,
                 "uid": data.id,
                 "username": data.username,
             }
@@ -152,6 +162,7 @@ class GitHubOauthHelper(BaseOauthHelper):
     CLIENT_ID = settings.SOCIAL_AUTH_GITHUB_KEY
     CLIENT_SECRET = settings.SOCIAL_AUTH_GITHUB_SECRET
     OAUTH_URL = "https://github.com/login/oauth/access_token"
+    PROVIDER_NAME = "github"
 
     def get_user_email(self) -> str:
         """
@@ -213,6 +224,7 @@ class GitHubOauthHelper(BaseOauthHelper):
                 "email": data.email or self.get_user_email(),
                 "extra_data": response_json,
                 "name": data.name,
+                "provider": self.PROVIDER_NAME,
                 "uid": data.id,
                 "username": data.login,
             }

--- a/django/thunderstore/social/tests/test_complete_login.py
+++ b/django/thunderstore/social/tests/test_complete_login.py
@@ -3,16 +3,25 @@ from typing import Any, Optional
 from unittest.mock import Mock, patch
 
 import pytest
+from django.contrib.auth import get_user_model
 from django.urls import reverse
 from rest_framework.response import Response
 from rest_framework.test import APIClient
+from social_django.models import UserSocialAuth  # type: ignore
 
+from thunderstore.social.api.experimental.views.complete_login import (
+    get_or_create_auth_user,
+    get_unique_username,
+)
 from thunderstore.social.permissions import OauthSharedSecretPermission
 from thunderstore.social.providers import (
     DiscordOauthHelper,
     GitHubOauthHelper,
     UserInfoSchema,
 )
+
+User = get_user_model()
+
 
 SECRET = "ABC123"
 PAYLOAD = json.dumps(
@@ -24,11 +33,19 @@ PAYLOAD = json.dumps(
 RETURN_VALUE = UserInfoSchema.parse_obj(
     {
         "email": "foo@bar.com",
+        "extra_data": {"foo": "bar"},
         "name": "Foo Bar",
         "uid": "1234",
         "username": "Foo",
     }
 )
+USER_INFO = {
+    "email": "x@example.org",
+    "extra_data": {"x": "y"},
+    "name": "X Y",
+    "uid": "uid",
+    "username": "x",
+}
 
 
 @patch.object(OauthSharedSecretPermission, "SHARED_SECRET", "")
@@ -200,6 +217,88 @@ def test_valid_request(api_client: APIClient, provider: str) -> None:
 
     assert (response.status_code) == 200
     assert (response.json()["session_id"]) == "TODO"
+
+
+def test_get_unique_username_rejects_empty_usernames() -> None:
+    with pytest.raises(ValueError, match="Username may not be empty"):
+        get_unique_username("")
+
+
+@pytest.mark.django_db
+def test_get_unique_username_clips_usernames_only_when_needed() -> None:
+    max_length = User._meta.get_field("username").max_length
+    max_str = "x" * max_length
+
+    assert get_unique_username(max_str) == max_str
+    assert get_unique_username(f"{max_str}!") == max_str
+
+
+@pytest.mark.django_db
+def test_get_unique_username_adds_random_suffixes_only_when_needed() -> None:
+    username1 = get_unique_username("Fabio")
+    User.objects.create(username=username1)
+    username2 = get_unique_username("Fabio")
+    User.objects.create(username=username2)
+    username3 = get_unique_username(username2)
+
+    assert username2 != username1
+    assert username3 != username1
+    assert username3 != username2
+
+
+@pytest.mark.django_db
+def test_get_or_create_auth_user_creates_user_without_password() -> None:
+    ui = UserInfoSchema.parse_obj(USER_INFO)
+
+    user = get_or_create_auth_user("github", ui)
+
+    assert not user.has_usable_password()
+
+
+@pytest.mark.django_db
+def test_get_or_create_auth_user_creates_user_only_when_needed() -> None:
+    assert User.objects.count() == 0
+    assert UserSocialAuth.objects.count() == 0
+
+    # Create original user.
+    ui = UserInfoSchema.parse_obj(USER_INFO)
+    user1 = get_or_create_auth_user("github", ui)
+    assert User.objects.count() == 1
+    assert UserSocialAuth.objects.count() == 1
+    assert UserSocialAuth.objects.latest("modified").user_id == user1.pk
+
+    # Using the same information should return the original user.
+    user2 = get_or_create_auth_user("github", ui)
+    assert User.objects.count() == 1
+    assert UserSocialAuth.objects.count() == 1
+    assert user2.pk == user1.pk
+    assert UserSocialAuth.objects.latest("modified").user_id == user2.pk
+
+    # We can't know if user "x" in GitHub is the same person as user "x"
+    # in Discord, so we need to create another user.
+    user3 = get_or_create_auth_user("discord", ui)
+    assert User.objects.count() == 2
+    assert UserSocialAuth.objects.count() == 2
+    assert user3.pk != user1.pk
+    assert UserSocialAuth.objects.latest("modified").user_id == user3.pk
+
+
+@pytest.mark.django_db
+def test_get_or_create_auth_user_updates_extra_data() -> None:
+    assert UserSocialAuth.objects.count() == 0
+
+    ui = UserInfoSchema.parse_obj(USER_INFO)
+    get_or_create_auth_user("github", ui)
+    assert UserSocialAuth.objects.count() == 1
+    usa1 = UserSocialAuth.objects.get()
+    assert usa1.extra_data["x"] == "y"
+
+    ui.extra_data = {"x": "z"}
+    get_or_create_auth_user("github", ui)
+    assert UserSocialAuth.objects.count() == 1
+    usa2 = UserSocialAuth.objects.get()
+    assert usa2.extra_data["x"] == "z"
+    assert usa2.modified > usa1.modified
 
 
 def _get_url(provider: str = "github") -> str:

--- a/django/thunderstore/social/tests/test_providers.py
+++ b/django/thunderstore/social/tests/test_providers.py
@@ -1,4 +1,3 @@
-import json
 from typing import List, Optional, Type
 from unittest.mock import Mock, patch
 
@@ -11,21 +10,6 @@ from thunderstore.social.providers import (
     GitHubOauthHelper,
     get_helper,
 )
-
-SECRET = "ABC123"
-PAYLOAD = json.dumps(
-    {
-        "code": "code",
-        "redirect_uri": "redirect_uri",
-        "secret": SECRET,
-    }
-)
-RETURN_VALUE = {
-    "email": "foo@bar.com",
-    "name": "Foo Bar",
-    "id": "5678",
-    "username": "Foo",
-}
 
 
 @patch.object(
@@ -76,6 +60,7 @@ def test_api_methods_check_for_token(
         json=lambda: {
             "email": "foo@bar.com",
             "id": "5678",
+            "something": "extra",
             "username": "Foo",
         }
     ),
@@ -88,6 +73,10 @@ def test_discord_get_user_info(mocked_request_get) -> None:
 
     mocked_request_get.assert_called_once()
     assert info.email == "foo@bar.com"
+    assert info.extra_data["email"] == "foo@bar.com"
+    assert info.extra_data["id"] == "5678"
+    assert info.extra_data["something"] == "extra"
+    assert info.extra_data["username"] == "Foo"
     assert info.name == ""
     assert info.uid == "5678"
     assert info.username == "Foo"
@@ -102,6 +91,7 @@ def test_discord_get_user_info(mocked_request_get) -> None:
             "id": "5678",
             "login": "Foo",
             "name": "Foo Bar",
+            "something": "extra",
         }
     ),
 )
@@ -113,6 +103,11 @@ def test_github_get_user_info_with_public_email(mocked_request_get) -> None:
 
     mocked_request_get.assert_called_once()
     assert info.email == "foo@bar.com"
+    assert info.extra_data["email"] == "foo@bar.com"
+    assert info.extra_data["id"] == "5678"
+    assert info.extra_data["login"] == "Foo"
+    assert info.extra_data["name"] == "Foo Bar"
+    assert info.extra_data["something"] == "extra"
     assert info.name == "Foo Bar"
     assert info.uid == "5678"
     assert info.username == "Foo"


### PR DESCRIPTION
Implemented in earlier commits (in UI repo):

1. User clicks an authentication link
2. User's browser stores a "state token" to local storage (for CSRF
   prevention) and redirects to OAuth provider's endpoint for login
3. After login, browser is redirected to client-side page, with query
   parameters containing the state token (which is validated) and a
   "code token"
4. Client-side page sends a request to Next.js API endpoint, which
   creates another request containing the code token and a "shared
   secret token" (for brute force prevention). For security reasons
   the latter token is not available client-side, which is why this
   sidestep is required
5. Next.js API endpoint sends the request to Django API endpoint
6. Django API endpoint validates the shared secret token
7. The endpoint sends a request containing the code token to OAuth
   provider, and receives an "access token"
8. The endpoint queries user's information from another API using the
   access token for authentication

This commit implements the following steps of the authentication flow:

9. If no account is found with the received information, one is created

In future commits:

10. Endpoint creates a session for the identified user
11. Endpoint returns session id to Next.js API endpoint
12. Next.js API endpoint relays the session id to the client-side page
13. Client-side page stores the session id
14. Client uses session id in the following requests

Refs TS-230, TS-355