### PR TITLE
Experimental API: WIP implementation for authentication, pt4

### DIFF
--- a/django/thunderstore/social/api/experimental/views/complete_login.py
+++ b/django/thunderstore/social/api/experimental/views/complete_login.py
@@ -1,7 +1,7 @@
 from typing import Sequence, Type
 from uuid import uuid4
 
-from django.contrib.auth import get_user_model
+from django.contrib.auth import get_user_model, login
 from django.db import transaction
 from django.http import HttpResponse
 from django.utils.text import slugify
@@ -56,13 +56,13 @@ class CompleteLoginApiView(APIView):
         if not helper_class:
             return Response("Unsupported OAuth provider", HTTP_400_BAD_REQUEST)
 
-        # TODO: create a new session for the user and return session id.
         helper = helper_class(code, redirect_uri)
         helper.complete_login()
         user_info = helper.get_user_info()
         user = get_or_create_auth_user(user_info)
+        login(request, user, "django.contrib.auth.backends.ModelBackend")
 
-        return Response({"session_id": "TODO"})
+        return Response({"session_id": request.session.session_key})
 
 
 @transaction.atomic

--- a/django/thunderstore/social/tests/test_complete_login.py
+++ b/django/thunderstore/social/tests/test_complete_login.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.contrib.sessions.models import Session
 from django.urls import reverse
 from rest_framework.response import Response
 from rest_framework.test import APIClient
@@ -213,12 +214,13 @@ def test_unknown_providers_are_rejected(api_client: APIClient) -> None:
 @pytest.mark.django_db
 @pytest.mark.parametrize("provider", ("github", "discord"))
 def test_valid_request(api_client: APIClient, provider: str) -> None:
+    assert not Session.objects.exists()
     url = _get_url(provider)
 
     response = _post(api_client, url)
 
     assert (response.status_code) == 200
-    assert (response.json()["session_id"]) == "TODO"
+    assert Session.objects.filter(pk=response.json()["session_id"]).exists()
 
 
 def test_get_unique_username_rejects_empty_usernames() -> None:


### PR DESCRIPTION
Implemented in earlier commits (in UI repo):

1. User clicks an authentication link
2. User's browser stores a "state token" to local storage (for CSRF
   prevention) and redirects to OAuth provider's endpoint for login
3. After login, browser is redirected to client-side page, with query
   parameters containing the state token (which is validated) and a
   "code token"
4. Client-side page sends a request to Next.js API endpoint, which
   creates another request containing the code token and a "shared
   secret token" (for brute force prevention). For security reasons
   the latter token is not available client-side, which is why this
   sidestep is required
5. Next.js API endpoint sends the request to Django API endpoint
6. Django API endpoint validates the shared secret token
7. The endpoint sends a request containing the code token to OAuth
   provider, and receives an "access token"
8. The endpoint queries user's information from another API using the
   access token for authentication
9. If no account is found with the received information, one is created

This commit implements the following steps of the authentication flow:

10. Endpoint creates a session for the identified user
11. Endpoint returns session id to Next.js API endpoint

In future commits:

12. Next.js API endpoint relays the session id to the client-side page
13. Client-side page stores the session id
14. Client uses session id in the following requests

Refs TS-230, TS-460