### PR TITLE
Experimental API: store all data received from OAuth response

### DIFF
--- a/django/thunderstore/social/api/experimental/views/complete_login.py
+++ b/django/thunderstore/social/api/experimental/views/complete_login.py
@@ -1,6 +1,12 @@
 from typing import Sequence, Type
+from uuid import uuid4
 
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import User as DjangoUser
+from django.db import connection, transaction
 from django.http import HttpResponse
+from django.utils import timezone
+from django.utils.text import slugify
 from drf_yasg.utils import swagger_auto_schema  # type: ignore
 from rest_framework import serializers
 from rest_framework.permissions import BasePermission
@@ -10,7 +16,9 @@ from rest_framework.status import HTTP_400_BAD_REQUEST
 from rest_framework.views import APIView
 
 from thunderstore.social.permissions import OauthSharedSecretPermission
-from thunderstore.social.providers import get_helper
+from thunderstore.social.providers import UserInfoSchema, get_helper
+
+User = get_user_model()
 
 
 class RequestBody(serializers.Serializer):
@@ -48,10 +56,87 @@ class CompleteLoginApiView(APIView):
         if not helper_class:
             return Response("Unsupported OAuth provider", HTTP_400_BAD_REQUEST)
 
-        # TODO: get or create a user account based on user_info, create
-        # a new session for the user and return session id.
+        # TODO: create a new session for the user and return session id.
         helper = helper_class(code, redirect_uri)
         helper.complete_login()
         user_info = helper.get_user_info()
+        user = get_or_create_auth_user(provider, user_info)
 
         return Response({"session_id": "TODO"})
+
+
+@transaction.atomic
+def get_or_create_auth_user(provider: str, user_info: UserInfoSchema) -> DjangoUser:
+    """
+    Return local user object based on OAuth user data.
+
+    The "local" user object is the one defined in Django config. We keep
+    additional OAuth related data in a separate table, which is a relic
+    from using Social Auth library to handle the authentication.
+    """
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT user_id FROM social_auth_usersocialauth
+            WHERE provider=%s AND uid=%s
+            LIMIT 1;
+            """,
+            [provider, user_info.uid],
+        )
+        row = cursor.fetchone()
+
+    user = User.objects.get(pk=row[0]) if row else None
+
+    if user is None:
+        username = get_unique_username(user_info.username)
+        full = user_info.name
+        first, last = full.split(" ", 1) if " " in full else (full, "")
+
+        user = User(
+            email=user_info.email,
+            first_name=first,
+            last_name=last,
+            username=username,
+        )
+        user.set_unusable_password()
+        user.save()
+
+        now = timezone.now()
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                INSERT INTO social_auth_usersocialauth
+                    (provider, uid, extra_data, user_id, created, modified)
+                VALUES
+                    (%s, %s, %s, %s, %s, %s);
+                """,
+                [provider, user_info.uid, '""', user.id, now, now],
+            )
+
+    return user
+
+
+def get_unique_username(original_username: str) -> str:
+    """
+    Add random suffix to username when needed to make it unique.
+
+    This imitates how Social Auth library implements a similar method,
+    minus all the configurability.
+    """
+    if original_username == "":
+        raise ValueError("Username may not be empty")
+
+    max_length = User._meta.get_field("username").max_length or 150
+    suffix_length = 16
+    slugified = slugify(original_username)[:max_length]
+    username = slugified
+    attempts_remaining = 10  # Prevent infinite loops in case of bugs.
+
+    while attempts_remaining and User.objects.filter(username=username).exists():
+        suffix = uuid4().hex[:suffix_length]
+        username = slugified[: (max_length - suffix_length)] + suffix
+        attempts_remaining -= 1
+
+    return username

--- a/django/thunderstore/social/permissions.py
+++ b/django/thunderstore/social/permissions.py
@@ -1,0 +1,47 @@
+from abc import abstractmethod
+
+from django.conf import settings
+from rest_framework.exceptions import APIException, AuthenticationFailed
+from rest_framework.permissions import BasePermission
+
+
+class ImproperlyConfigured(APIException):
+    default_code = "improperly_configured"
+    default_detail = "Server is improperly configured"
+    status_code = 500
+
+
+class SharedSecretPermission(BasePermission):
+    """
+    Compares secret received in a header to one configured on the server.
+
+    Should be used for rudimentary access validation for endpoints that
+    are called by another one of our servers that has no access to user
+    credentials.
+    """
+
+    @property
+    @abstractmethod
+    def SHARED_SECRET(self) -> str:
+        """
+        Local value, against which the submitted value is checked.
+        """
+
+    def has_permission(self, request, view) -> bool:
+        if not self.SHARED_SECRET:
+            raise ImproperlyConfigured
+
+        header = request.META.get("HTTP_AUTHORIZATION")
+
+        if header is None or header != f"TS-Secret {self.SHARED_SECRET}":
+            raise AuthenticationFailed
+
+        return True
+
+
+class OauthSharedSecretPermission(SharedSecretPermission):
+    """
+    For completing OAuth login.
+    """
+
+    SHARED_SECRET = settings.OAUTH_SHARED_SECRET

--- a/django/thunderstore/social/providers.py
+++ b/django/thunderstore/social/providers.py
@@ -129,7 +129,6 @@ class DiscordOauthHelper(BaseOauthHelper):
             https://github.com/discord/discord-api-docs/blob/main/docs/resources/User.md
             """
 
-            discriminator: int
             email: str
             id: str
             username: str
@@ -141,7 +140,7 @@ class DiscordOauthHelper(BaseOauthHelper):
                 "email": data.email,
                 "name": "",
                 "uid": data.id,
-                "username": f"{data.username}#{data.discriminator}",
+                "username": data.username,
             }
         )
 

--- a/django/thunderstore/social/tests/test_complete_login.py
+++ b/django/thunderstore/social/tests/test_complete_login.py
@@ -3,16 +3,25 @@ from typing import Any, Optional
 from unittest.mock import Mock, patch
 
 import pytest
+from django.contrib.auth import get_user_model
+from django.db import connection
 from django.urls import reverse
 from rest_framework.response import Response
 from rest_framework.test import APIClient
 
+from thunderstore.social.api.experimental.views.complete_login import (
+    get_or_create_auth_user,
+    get_unique_username,
+)
 from thunderstore.social.permissions import OauthSharedSecretPermission
 from thunderstore.social.providers import (
     DiscordOauthHelper,
     GitHubOauthHelper,
     UserInfoSchema,
 )
+
+User = get_user_model()
+
 
 SECRET = "ABC123"
 PAYLOAD = json.dumps(
@@ -200,6 +209,84 @@ def test_valid_request(api_client: APIClient, provider: str) -> None:
 
     assert (response.status_code) == 200
     assert (response.json()["session_id"]) == "TODO"
+
+
+def test_get_unique_username_rejects_empty_usernames() -> None:
+    with pytest.raises(ValueError, match="Username may not be empty"):
+        get_unique_username("")
+
+
+@pytest.mark.django_db
+def test_get_unique_username_clips_usernames_only_when_needed() -> None:
+    max_length = User._meta.get_field("username").max_length
+    max_str = "x" * max_length
+
+    assert get_unique_username(max_str) == max_str
+    assert get_unique_username(f"{max_str}!") == max_str
+
+
+@pytest.mark.django_db
+def test_get_unique_username_adds_random_suffixes_only_when_needed() -> None:
+    username1 = get_unique_username("Fabio")
+    User.objects.create(username=username1)
+    username2 = get_unique_username("Fabio")
+    User.objects.create(username=username2)
+    username3 = get_unique_username(username2)
+
+    assert username2 != username1
+    assert username3 != username1
+    assert username3 != username2
+
+
+@pytest.mark.django_db
+def test_get_or_create_auth_user_creates_user_without_password() -> None:
+    ui = UserInfoSchema(email="x@example.org", name="X Y", uid="uid", username="x")
+
+    user = get_or_create_auth_user("github", ui)
+
+    assert not user.has_usable_password()
+
+
+@pytest.mark.django_db
+def test_get_or_create_auth_user_creates_user_only_when_needed() -> None:
+    assert User.objects.count() == 0
+    assert _get_social_auth_row_count() == 0
+
+    # Create original user.
+    ui = UserInfoSchema(email="x@example.org", name="X Y", uid="uid", username="x")
+    user1 = get_or_create_auth_user("github", ui)
+    assert User.objects.count() == 1
+    assert _get_social_auth_row_count() == 1
+    assert _get_latest_social_auth_rows_user_FK() == user1.pk
+
+    # Using the same information should return the original user.
+    user2 = get_or_create_auth_user("github", ui)
+    assert User.objects.count() == 1
+    assert _get_social_auth_row_count() == 1
+    assert user2.pk == user1.pk
+    assert _get_latest_social_auth_rows_user_FK() == user2.pk
+
+    # We can't know if user "x" in GitHub is the same person as user "x"
+    # in Discord, so we need to create another user.
+    user3 = get_or_create_auth_user("discord", ui)
+    assert User.objects.count() == 2
+    assert _get_social_auth_row_count() == 2
+    assert user3.pk != user1.pk
+    assert _get_latest_social_auth_rows_user_FK() == user3.pk
+
+
+def _get_social_auth_row_count() -> int:
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT COUNT(*) FROM social_auth_usersocialauth;")
+        return cursor.fetchone()[0]
+
+
+def _get_latest_social_auth_rows_user_FK() -> int:
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT user_id FROM social_auth_usersocialauth ORDER BY id DESC LIMIT 1;"
+        )
+        return cursor.fetchone()[0]
 
 
 def _get_url(provider: str = "github") -> str:

--- a/django/thunderstore/social/tests/test_providers.py
+++ b/django/thunderstore/social/tests/test_providers.py
@@ -74,7 +74,6 @@ def test_api_methods_check_for_token(
     "get",
     return_value=Mock(
         json=lambda: {
-            "discriminator": "1234",
             "email": "foo@bar.com",
             "id": "5678",
             "username": "Foo",
@@ -91,7 +90,7 @@ def test_discord_get_user_info(mocked_request_get) -> None:
     assert info.email == "foo@bar.com"
     assert info.name == ""
     assert info.uid == "5678"
-    assert info.username == "Foo#1234"
+    assert info.username == "Foo"
 
 
 @patch.object(

--- a/django/thunderstore/social/tests/test_providers.py
+++ b/django/thunderstore/social/tests/test_providers.py
@@ -1,4 +1,3 @@
-import json
 from typing import List, Optional, Type
 from unittest.mock import Mock, patch
 
@@ -11,21 +10,6 @@ from thunderstore.social.providers import (
     GitHubOauthHelper,
     get_helper,
 )
-
-SECRET = "ABC123"
-PAYLOAD = json.dumps(
-    {
-        "code": "code",
-        "redirect_uri": "redirect_uri",
-        "secret": SECRET,
-    }
-)
-RETURN_VALUE = {
-    "email": "foo@bar.com",
-    "name": "Foo Bar",
-    "id": "5678",
-    "username": "Foo",
-}
 
 
 @patch.object(
@@ -76,6 +60,7 @@ def test_api_methods_check_for_token(
         json=lambda: {
             "email": "foo@bar.com",
             "id": "5678",
+            "something": "extra",
             "username": "Foo",
         }
     ),
@@ -88,6 +73,10 @@ def test_discord_get_user_info(mocked_request_get) -> None:
 
     mocked_request_get.assert_called_once()
     assert info.email == "foo@bar.com"
+    assert info.extra_data["email"] == "foo@bar.com"
+    assert info.extra_data["id"] == "5678"
+    assert info.extra_data["something"] == "extra"
+    assert info.extra_data["username"] == "Foo"
     assert info.name == ""
     assert info.uid == "5678"
     assert info.username == "Foo"
@@ -102,6 +91,7 @@ def test_discord_get_user_info(mocked_request_get) -> None:
             "id": "5678",
             "login": "Foo",
             "name": "Foo Bar",
+            "something": "extra",
         }
     ),
 )
@@ -113,6 +103,11 @@ def test_github_get_user_info_with_public_email(mocked_request_get) -> None:
 
     mocked_request_get.assert_called_once()
     assert info.email == "foo@bar.com"
+    assert info.extra_data["email"] == "foo@bar.com"
+    assert info.extra_data["id"] == "5678"
+    assert info.extra_data["login"] == "Foo"
+    assert info.extra_data["name"] == "Foo Bar"
+    assert info.extra_data["something"] == "extra"
     assert info.name == "Foo Bar"
     assert info.uid == "5678"
     assert info.username == "Foo"


### PR DESCRIPTION
Old implementation picked only the data we needed from the OAuth
response. We now store the whole response payload in database to keep
it consistent with the way the previously used social auth library does
things.

Refs TS-230, TS-355