### PR TITLE
Experimental API: remove discriminator from Discord username

### DIFF
--- a/django/thunderstore/social/providers.py
+++ b/django/thunderstore/social/providers.py
@@ -129,7 +129,6 @@ class DiscordOauthHelper(BaseOauthHelper):
             https://github.com/discord/discord-api-docs/blob/main/docs/resources/User.md
             """
 
-            discriminator: int
             email: str
             id: str
             username: str
@@ -141,7 +140,7 @@ class DiscordOauthHelper(BaseOauthHelper):
                 "email": data.email,
                 "name": "",
                 "uid": data.id,
-                "username": f"{data.username}#{data.discriminator}",
+                "username": data.username,
             }
         )
 

--- a/django/thunderstore/social/tests/test_providers.py
+++ b/django/thunderstore/social/tests/test_providers.py
@@ -74,7 +74,6 @@ def test_api_methods_check_for_token(
     "get",
     return_value=Mock(
         json=lambda: {
-            "discriminator": "1234",
             "email": "foo@bar.com",
             "id": "5678",
             "username": "Foo",
@@ -91,7 +90,7 @@ def test_discord_get_user_info(mocked_request_get) -> None:
     assert info.email == "foo@bar.com"
     assert info.name == ""
     assert info.uid == "5678"
-    assert info.username == "Foo#1234"
+    assert info.username == "Foo"
 
 
 @patch.object(


### PR DESCRIPTION
It was assumed the local username created by Discord OAuth-based login
would include the discriminator number, e.g. "Foo#1234". But when you
assume things, you make an ass out of u and me.

Refs TS-230, TS-354

This PR replaces #584 