### PR TITLE
Use 404 instead of 403 to avoid leaking information

### DIFF
--- a/django/thunderstore/frontend/api/experimental/tests/test_package_details.py
+++ b/django/thunderstore/frontend/api/experimental/tests/test_package_details.py
@@ -46,9 +46,9 @@ def test_unlisted_community_returns_404(api_client: APIClient) -> None:
         (PackageListingReviewStatus.approved, False, 200),
         (PackageListingReviewStatus.approved, True, 200),
         (PackageListingReviewStatus.unreviewed, False, 200),
-        (PackageListingReviewStatus.unreviewed, True, 403),
-        (PackageListingReviewStatus.rejected, False, 403),
-        (PackageListingReviewStatus.rejected, True, 403),
+        (PackageListingReviewStatus.unreviewed, True, 404),
+        (PackageListingReviewStatus.rejected, False, 404),
+        (PackageListingReviewStatus.rejected, True, 404),
     ),
 )
 def test_listing_approval_status_is_checked(

--- a/django/thunderstore/frontend/api/experimental/views/package_details.py
+++ b/django/thunderstore/frontend/api/experimental/views/package_details.py
@@ -1,6 +1,5 @@
-from django.core.exceptions import PermissionDenied
 from django.db.models import Count, QuerySet, Sum
-from django.http import HttpRequest, HttpResponse
+from django.http import Http404, HttpRequest, HttpResponse
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
 from rest_framework.generics import get_object_or_404
@@ -44,7 +43,7 @@ class PackageDetailApiView(APIView):
         )
 
         if not listing.can_be_viewed_by_user(request.user):
-            raise PermissionDenied()
+            raise Http404()
 
         serializer = self.serialize_results(listing)
 


### PR DESCRIPTION
Refs TS-230, TS-465