### PR TITLE
Experimental API: add endpoint for checking session validity

### DIFF
--- a/django/thunderstore/social/api/experimental/urls.py
+++ b/django/thunderstore/social/api/experimental/urls.py
@@ -1,11 +1,19 @@
 from django.urls import path
 
-from thunderstore.social.api.experimental.views import CompleteLoginApiView
+from thunderstore.social.api.experimental.views import (
+    CompleteLoginApiView,
+    ValidateSessionApiView,
+)
 
 urls = [
     path(
         "auth/complete/<slug:provider>/",
         CompleteLoginApiView.as_view(),
         name="auth.complete",
+    ),
+    path(
+        "auth/validate/",
+        ValidateSessionApiView.as_view(),
+        name="auth.validate",
     ),
 ]

--- a/django/thunderstore/social/api/experimental/views/__init__.py
+++ b/django/thunderstore/social/api/experimental/views/__init__.py
@@ -1,7 +1,9 @@
 from .complete_login import CompleteLoginApiView
 from .current_user import CurrentUserExperimentalApiView
+from .validate_session import ValidateSessionApiView
 
 __all__ = [
     "CompleteLoginApiView",
     "CurrentUserExperimentalApiView",
+    "ValidateSessionApiView",
 ]

--- a/django/thunderstore/social/api/experimental/views/validate_session.py
+++ b/django/thunderstore/social/api/experimental/views/validate_session.py
@@ -1,0 +1,28 @@
+from django.http import HttpResponse
+from drf_yasg.utils import swagger_auto_schema  # type: ignore
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.status import HTTP_401_UNAUTHORIZED
+from rest_framework.views import APIView
+
+
+class ValidateSessionApiView(APIView):
+    """
+    Check that valid session key is provided in Authorization header.
+    """
+
+    @swagger_auto_schema(
+        operation_id="experimental.auth.validate",
+        responses={
+            200: "Session is valid",
+            401: "Session key is missing, invalid, or expired",
+        },
+    )
+    def get(self, request: Request) -> HttpResponse:
+        # UserSessionTokenAuthentication will automatically return 401
+        # if the given session key is not valid, but will do nothing if
+        # the session key isn't provided at all.
+        if request.user.is_authenticated:
+            return Response({"detail": "OK"})
+
+        return Response({"detail": "Invalid token."}, HTTP_401_UNAUTHORIZED)

--- a/django/thunderstore/social/tests/test_validate_session.py
+++ b/django/thunderstore/social/tests/test_validate_session.py
@@ -1,0 +1,69 @@
+from typing import Any, Dict, Optional
+
+import pytest
+from django.contrib.sessions.backends.db import SessionStore
+from django.test import override_settings
+from django.urls import reverse
+from rest_framework.response import Response
+from rest_framework.test import APIClient
+
+from thunderstore.core.types import UserType
+
+
+@pytest.mark.django_db
+def test_missing_session_key_causes_401_response(api_client: APIClient) -> None:
+    response = _get(api_client)
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid token."
+
+
+@pytest.mark.django_db
+def test_invalid_session_key_causes_401_response(api_client: APIClient) -> None:
+    response = _get(api_client, "potato")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid token."
+
+
+@pytest.mark.django_db
+@override_settings(SESSION_COOKIE_AGE=0)
+def test_expired_session_key_causes_401_response(
+    api_client: APIClient, user: UserType
+) -> None:
+    session_key = _create_session(user)
+
+    response = _get(api_client, session_key)
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid token."
+
+
+@pytest.mark.django_db
+def test_valid_session_key_causes_200_response(
+    api_client: APIClient, user: UserType
+) -> None:
+    session_key = _create_session(user)
+
+    response = _get(api_client, session_key)
+
+    assert response.status_code == 200
+    assert response.json()["detail"] == "OK"
+
+
+def _create_session(user: UserType) -> str:
+    store = SessionStore()
+    store.create()
+    store["_auth_user_id"] = user.pk
+    store.save()
+    return store.session_key
+
+
+def _get(client: APIClient, session_key: Optional[str] = None) -> Response:
+    url = reverse("api:experimental:auth.validate")
+    kwargs: Dict[str, Any] = {"content_type": "application/json"}
+
+    if session_key:
+        kwargs["HTTP_AUTHORIZATION"] = f"Session {session_key}"
+
+    return client.get(url, **kwargs)


### PR DESCRIPTION
Simple endpoint for checking if the user is authenticated, i.e. if the
session key sent in the authorization header is related to active
session stored in the database.

The new UI will use this to check that the session key stored in the
localStorage is still current.

Refs TS-230, TS-358