### PR TITLE
Fix CommunitySiteMiddleware redirects

### DIFF
--- a/django/pytest.ini
+++ b/django/pytest.ini
@@ -9,3 +9,5 @@ env =
     CELERY_TASK_ALWAYS_EAGER=True
     CELERY_EAGER_PROPAGATES_EXCEPTIONS=True
     DATABASE_URL=psql://django:django@db/django
+    AUTH_EXCLUSIVE_HOST=auth.testsite.test
+    SESSION_COOKIE_DOMAIN=testsite.test

--- a/django/thunderstore/community/tests/test_middleware.py
+++ b/django/thunderstore/community/tests/test_middleware.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import pytest
+from django.test import RequestFactory
 from django.utils.encoding import iri_to_uri
 
 from thunderstore.community.middleware import CommunitySiteMiddleware
@@ -8,7 +9,7 @@ from thunderstore.community.middleware import CommunitySiteMiddleware
 
 @pytest.mark.parametrize("protocol", ("http://", "https://"))
 @pytest.mark.parametrize(
-    "cookie_domain, status, content",
+    "primary_domain, status, content",
     (
         (None, 404, b"Community not found"),
         ("localhost", 302, None),
@@ -17,16 +18,17 @@ from thunderstore.community.middleware import CommunitySiteMiddleware
 )
 def test_community_site_middleware_get_404(
     protocol: str,
-    cookie_domain: str,
+    primary_domain: str,
     status: int,
     content: bytes,
     settings: Any,
 ) -> None:
-    settings.SESSION_COOKIE_DOMAIN = cookie_domain
+    settings.PRIMARY_HOST = primary_domain
     settings.PROTOCOL = protocol
-    response = CommunitySiteMiddleware(None).get_404()
+    request = RequestFactory().get("", secure=protocol == "https://")
+    response = CommunitySiteMiddleware(None).get_404(request)
     assert response.status_code == status
     if content:
         assert content in response.content
     if status == 302:
-        assert response["Location"] == iri_to_uri(f"{protocol}{cookie_domain}")
+        assert response["Location"] == iri_to_uri(f"{protocol}{primary_domain}/")


### PR DESCRIPTION
Fix the test for CommunitySiteMiddleware redirects as well as an
edge-case redirect loop that could occur if the PRIMARY_HOST setting is
set to the same value as AUTH_EXCLUSIVE_HOST