### PR TITLE
Fix celery_post celery task

### DIFF
--- a/django/thunderstore/core/tasks.py
+++ b/django/thunderstore/core/tasks.py
@@ -9,8 +9,8 @@ def celery_post(
     webhook_url: str,
     data: Optional[str] = None,
     headers: Union[Dict, None] = None,
-):
-    return requests.post(
+) -> None:
+    requests.post(
         webhook_url,
         data=data,
         headers=headers,

--- a/django/thunderstore/core/tests/test_celery.py
+++ b/django/thunderstore/core/tests/test_celery.py
@@ -103,5 +103,4 @@ def test_celery_post(
 ):
     celery_response = celery_post.delay("http://localhost:8888")
     assert celery_response.state == "SUCCESS"
-    assert celery_response.result.status_code == 200
     assert isinstance(celery_response, celery.result.EagerResult)


### PR DESCRIPTION
Fixes an issue where the celery_post task was attempting to return
a HTTP response object, which is not possible to serialize into JSON.
It's not easy to write a test which fails for this behavior, as when
the task is eagerly executed (such as during tests) the serialization
step is skipped.

Refs TS-558