### PR TITLE
Improve upload page error handling

### DIFF
--- a/builder/src/api.ts
+++ b/builder/src/api.ts
@@ -8,6 +8,33 @@ type JSONValue =
     | JSONValue[]
     | { [key: string]: JSONValue };
 
+export const stringifyError = (
+    val: JSONValue,
+    parents?: string[]
+): string[] => {
+    if (val === null) {
+        return [];
+    } else if (typeof val === "object") {
+        const result = [];
+        if (Array.isArray(val)) {
+            for (const entry of val) {
+                result.push(...stringifyError(entry, parents));
+            }
+        } else {
+            Object.keys(val).forEach((key) => {
+                result.push(
+                    ...stringifyError(val[key]!, (parents || []).concat(key))
+                );
+            });
+        }
+        return result;
+    } else {
+        return [
+            `${parents?.join(": ")}${parents ? ": " : ""}${val.toString()}`,
+        ];
+    }
+};
+
 export class ThunderstoreApiError {
     message: string;
     response: Response;


### PR DESCRIPTION
Improve upload page error handling by ensuring some more obscure errors
that weren't previously shown anywhere on the UI get displayed along the
rest of the errors.

Additionally include a special case for handling ETag missing errors
which are usually caused by a browser extension such as ClearURLs
stripping the headers.

Refs TS-560