### PR TITLE
Fix UserMedia abort_multipart_upload bug

### DIFF
--- a/django/thunderstore/usermedia/s3_upload.py
+++ b/django/thunderstore/usermedia/s3_upload.py
@@ -222,21 +222,22 @@ def download_file(
     return fileobj
 
 
-def ensure_multipart_upload_aborted(client, bucket_name, user_media):
-    if user_media.upload_id is not None:
-        try:
-            client.abort_multipart_upload(
-                Bucket=bucket_name,
-                Key=user_media.key,
-                UploadId=user_media.upload_id,
-            )
-        except ClientError as e:
-            code = e.response.get("Error", {}).get("Code", None)
-            if code != "NoSuchUpload":  # pragma: no cover
-                raise e
-    # Upload has never existed so just pass
-    else:
-        pass
+def ensure_multipart_upload_aborted(
+    client: Client, bucket_name: str, user_media: UserMedia
+):
+    if user_media.upload_id is None:
+        # Upload has never existed so just pass
+        return
+    try:
+        client.abort_multipart_upload(
+            Bucket=bucket_name,
+            Key=user_media.key,
+            UploadId=user_media.upload_id,
+        )
+    except ClientError as e:
+        code = e.response.get("Error", {}).get("Code", None)
+        if code != "NoSuchUpload":  # pragma: no cover
+            raise e
 
 
 def cleanup_expired_upload(user_media: UserMedia, client: Client):

--- a/django/thunderstore/usermedia/tests/test_cleanup.py
+++ b/django/thunderstore/usermedia/tests/test_cleanup.py
@@ -90,3 +90,4 @@ def test_usermedia_cleanup() -> None:
             Key=bad_upload_id_upload.key,
             UploadId="",
         )
+    assert bad_upload_id_upload not in UserMedia.objects.all()


### PR DESCRIPTION
Fix error with abort_multipart_upload when UserMedia.upload_id is None
From now on we go with the default of None in upload_id means that the
upload doesn't exist

refs TS-589