### PR TITLE
sort communities in community dropdown

### DIFF
--- a/django/thunderstore/frontend/templates/base.html
+++ b/django/thunderstore/frontend/templates/base.html
@@ -49,7 +49,7 @@
                            aria-expanded="false" class="nav-link dropdown-toggle">Communities</a>
                         {% if selectable_community_sites %}
                         <div class="dropdown-menu" aria-labelledby="communitiesMenu">
-                            {% for site in selectable_community_sites %}
+                            {% for site in selectable_community_sites|dictsort:"community.name" %}
                                 <a class="dropdown-item" href="{{ site.full_url }}">{{ site.community.name }}</a>
                             {% endfor %}
                         </div>


### PR DESCRIPTION
From discord:
> Wildbook
 > [..] right now it's in the order the communities were added. This is pretty suboptimal, and the entire list is way too long by now anyway so it should ideally be completely replaced imo.
 > 
 > cyber
>  the first suggestion (alphabetical communities dropdown) sounds like a pretty simple pr :ravythink:
> 
> Wildbook 
> Yeah, the issue is mainly with people not having time and the people who do have time wanting to work on the UI rework rather than fixing up the current version of the site 😅
If you want to go make a PR for it I'm pretty sure no one would mind