### PR TITLE
Add multi-community category select support to the upload page

### DIFF
--- a/builder/src/api.ts
+++ b/builder/src/api.ts
@@ -287,7 +287,7 @@ class ExperimentalApiImpl extends ThunderstoreApi {
     submitPackage = async (props: {
         data: {
             author_name: string;
-            categories: string[];
+            community_categories: { [key: string]: string[] };
             communities: string[];
             has_nsfw_content: boolean;
             upload_uuid: string;

--- a/builder/src/components/CommunitySelector.tsx
+++ b/builder/src/components/CommunitySelector.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useState } from "react";
+import { FormSelectField } from "./FormSelectField";
+import { ExperimentalApi, PackageCategory } from "../api";
+import { Control } from "react-hook-form/dist/types";
+import { FormRow } from "./FormRow";
+
+interface CategorySelectorProps {
+    community: { value: string; label: string };
+    control: Control;
+}
+const CategorySelector: React.FC<CategorySelectorProps> = ({
+    community,
+    control,
+}) => {
+    const [categories, setCategories] = useState<PackageCategory[]>([]);
+
+    const enumerateCategories = (
+        current: PackageCategory[],
+        communityIdentifier: string,
+        cursor?: string
+    ) => {
+        const promise = cursor
+            ? ExperimentalApi.getNextPage<PackageCategory>(cursor)
+            : ExperimentalApi.listCategories({ communityIdentifier });
+
+        promise.then((result) => {
+            const next = current.concat(result.results);
+            setCategories(next);
+            if (result.pagination.next_link) {
+                enumerateCategories(
+                    next,
+                    communityIdentifier,
+                    result.pagination.next_link
+                );
+            }
+        });
+    };
+    useEffect(() => {
+        enumerateCategories([], community.value);
+    }, [community.value]);
+
+    const inputName = community.value;
+    return (
+        <FormRow
+            label={community.label}
+            labelFor={inputName}
+            error={null}
+            wrap={true}
+        >
+            <FormSelectField
+                className={"select-category"}
+                control={control}
+                name={inputName}
+                data={categories}
+                getOption={(x) => {
+                    return {
+                        value: x.slug,
+                        label: x.name,
+                    };
+                }}
+                isMulti={true}
+            />
+        </FormRow>
+    );
+};
+
+interface CommunityCategorySelectorProps {
+    selectedCommunities: { value: string; label: string }[];
+    control: Control;
+}
+export const CommunityCategorySelector: React.FC<CommunityCategorySelectorProps> = ({
+    selectedCommunities,
+    control,
+}) => {
+    if (selectedCommunities.length == 0) {
+        return (
+            <p className={"select-community"}>
+                Select a community to view available categories
+            </p>
+        );
+    }
+
+    return (
+        <div className={"field-row d-flex flex-column"}>
+            <div className={"w-100"}>
+                {selectedCommunities.map((x) => {
+                    return (
+                        <CategorySelector
+                            key={x.value}
+                            community={x}
+                            control={control}
+                        />
+                    );
+                })}
+            </div>
+        </div>
+    );
+};

--- a/builder/src/components/FormRow.tsx
+++ b/builder/src/components/FormRow.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+interface FormRowProps {
+    label: string;
+    labelFor: string;
+    error: string | null;
+    wrap?: boolean;
+}
+
+export const FormRow: React.FC<FormRowProps> = (props) => {
+    return (
+        <div className="field-wrapper">
+            <div className={`field-row ${props.wrap ? "flex-wrap" : ""}`}>
+                <label htmlFor={props.labelFor}>{props.label}</label>
+                {props.children}
+            </div>
+            {props.error && (
+                <div className="text-danger field-errors">{props.error}</div>
+            )}
+        </div>
+    );
+};

--- a/builder/src/components/FormSelectField.tsx
+++ b/builder/src/components/FormSelectField.tsx
@@ -4,6 +4,7 @@ import { Controller } from "react-hook-form";
 import Select from "react-select";
 
 interface FormSelectFieldProps<T, F> {
+    className?: string;
     control: Control<F>;
     name: string;
     data: T[];
@@ -27,7 +28,7 @@ export const FormSelectField: React.FC<FormSelectFieldProps<any, any>> = (
     }, [props.default, props.getOption, props.isMulti]);
 
     return (
-        <div className="w-100">
+        <div className={props.className ?? "w-100"}>
             <div style={{ color: "#666" }}>
                 <Controller
                     name={props.name}

--- a/builder/src/scss/forms.scss
+++ b/builder/src/scss/forms.scss
@@ -28,6 +28,7 @@
 .field-row {
     width: 100%;
     display: flex;
+    gap: 5px;
     flex-direction: row;
     align-items: center;
     justify-content: flex-start;
@@ -41,4 +42,18 @@
         width: 32px;
         height: 32px;
     }
+}
+
+.select-category {
+    min-width: 250px;
+    flex: 1;
+}
+
+.select-community {
+    margin-top: 10px;
+    margin-bottom: 10px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    height: 38px;
 }

--- a/django/thunderstore/community/factories.py
+++ b/django/thunderstore/community/factories.py
@@ -4,7 +4,7 @@ from factory.django import DjangoModelFactory
 
 from thunderstore.repository.factories import PackageVersionFactory
 
-from .models import Community, CommunitySite, PackageListing
+from .models import Community, CommunitySite, PackageCategory, PackageListing
 
 
 class SiteFactory(DjangoModelFactory):
@@ -21,6 +21,15 @@ class CommunityFactory(DjangoModelFactory):
 
     name = factory.Sequence(lambda n: f"TestCommunity{n}")
     identifier = factory.Sequence(lambda n: f"test-community-{n}")
+
+
+class PackageCategoryFactory(DjangoModelFactory):
+    class Meta:
+        model = PackageCategory
+
+    community = factory.SubFactory(CommunityFactory)
+    name = factory.Sequence(lambda n: f"TestCategory{n}")
+    slug = factory.Sequence(lambda n: f"test-category-{n}")
 
 
 class CommunitySiteFactory(DjangoModelFactory):

--- a/django/thunderstore/repository/api/experimental/serializers/main.py
+++ b/django/thunderstore/repository/api/experimental/serializers/main.py
@@ -171,6 +171,7 @@ class PackageUploadMetadataSerializer(serializers.Serializer):
             to_field="slug",
         ),
         allow_empty=True,
+        required=False,
     )
     communities = serializers.ListField(
         child=ModelChoiceField(
@@ -193,7 +194,7 @@ class PackageUploadSerializerExperiemental(serializers.Serializer):
             user=request.user,
             community=request.community,
             data={
-                "categories": metadata.get("categories"),
+                "categories": metadata.get("categories", []),
                 "has_nsfw_content": metadata.get("has_nsfw_content"),
                 "team": metadata.get("author_name"),
                 "communities": metadata.get("communities"),
@@ -215,6 +216,13 @@ class PackageUploadSerializerExperiemental(serializers.Serializer):
 
 class PackageSubmissionMetadataSerializer(PackageUploadMetadataSerializer):
     upload_uuid = serializers.UUIDField()
+    community_categories = serializers.DictField(
+        child=serializers.ListField(
+            child=serializers.CharField(allow_blank=False, required=True),
+            allow_empty=True,
+        ),
+        required=False,
+    )
 
 
 class AvailableCommunitySerializer(serializers.Serializer):

--- a/django/thunderstore/repository/api/experimental/views/submit.py
+++ b/django/thunderstore/repository/api/experimental/views/submit.py
@@ -88,7 +88,8 @@ class SubmitPackageApiView(APIView):
             user=self.request.user,
             community=self.request.community,
             data={
-                "categories": data.get("categories"),
+                "categories": data.get("categories", []),
+                "community_categories": data.get("community_categories", {}),
                 "has_nsfw_content": data.get("has_nsfw_content"),
                 "team": data.get("author_name"),
                 "communities": data.get("communities"),

--- a/django/thunderstore/repository/validation/categories.py
+++ b/django/thunderstore/repository/validation/categories.py
@@ -1,0 +1,42 @@
+from collections import defaultdict
+from typing import Dict, List, Optional
+
+from django.core.exceptions import ValidationError
+from django.db.models import F, Q
+
+from thunderstore.community.models import PackageCategory
+
+
+def clean_community_categories(
+    community_categories: Optional[Dict[str, List[str]]]
+) -> Optional[Dict[str, List[PackageCategory]]]:
+    if not community_categories:
+        return {}
+
+    query = Q()
+    errors = []
+    result = defaultdict(list)
+
+    for community, categories in community_categories.items():
+        query |= Q(community__identifier=community, slug__in=categories)
+    queryset = PackageCategory.objects.filter(query).annotate(
+        community_identifier=F("community__identifier")
+    )
+    matches = {(x.community_identifier, x.slug): x for x in queryset}
+
+    for community, categories in community_categories.items():
+        for category in categories:
+            match = matches.get((community, category))
+            if not match:
+                errors.append(
+                    ValidationError(
+                        f"Category {category} does not exist in community {community}"
+                    )
+                )
+            else:
+                result[community].append(match)
+
+    if errors:
+        raise ValidationError(errors)
+
+    return result

--- a/django/thunderstore/repository/validation/tests/test_categories.py
+++ b/django/thunderstore/repository/validation/tests/test_categories.py
@@ -1,0 +1,48 @@
+import pytest
+from django.core.exceptions import ValidationError
+
+from thunderstore.community.factories import CommunityFactory, PackageCategoryFactory
+from thunderstore.repository.validation.categories import clean_community_categories
+
+
+@pytest.mark.django_db
+def test_clean_community_categories_valid():
+    c1 = CommunityFactory()
+    c2 = CommunityFactory()
+    cat1 = PackageCategoryFactory(community=c1)
+    cat2 = PackageCategoryFactory(community=c2)
+    result = clean_community_categories(
+        {
+            c1.identifier: [cat1.slug],
+            c2.identifier: [cat2.slug],
+        }
+    )
+    assert result == {
+        c1.identifier: [cat1],
+        c2.identifier: [cat2],
+    }
+
+
+def test_clean_community_categories_empty():
+    assert clean_community_categories(None) == {}
+
+
+@pytest.mark.django_db
+def test_clean_community_categories_invalid():
+    c1 = CommunityFactory()
+    c2 = CommunityFactory()
+    cat1 = PackageCategoryFactory(community=c1)
+    cat2 = PackageCategoryFactory(community=c1)
+    cat3 = PackageCategoryFactory(community=c2, slug=cat1.slug)
+    serialized = {
+        c1.identifier: [cat1.slug],
+        c2.identifier: [cat2.slug, cat3.slug],
+    }
+    with pytest.raises(ValidationError) as e:
+        clean_community_categories(serialized)
+
+    assert len(e.value.error_list) == 1
+    assert (
+        e.value.error_list[0].message
+        == f"Category {cat2.slug} does not exist in community {c2.identifier}"
+    )


### PR DESCRIPTION
Allow selection of categories for all communities a package will be
submitted to instead of just the currently active community.