### PR TITLE
Improve navbar community select

### DIFF
--- a/builder/src/scss/all.scss
+++ b/builder/src/scss/all.scss
@@ -14,11 +14,14 @@
 
 // Custom Markdown
 @import "./markdown";
+
+// Other custom
 @import "./settings";
 @import "./general";
 @import "./package-list";
 @import "./forms";
 @import "./slimselect";
+@import "./navbar";
 
 // Code Input
 @import "./code-input";

--- a/builder/src/scss/navbar.scss
+++ b/builder/src/scss/navbar.scss
@@ -1,0 +1,40 @@
+.communities-dropdown {
+    padding: 0;
+    margin: 0;
+
+    .section {
+        padding: 1.5rem 1.75rem;
+
+        .grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 0 1rem;
+
+            @media (max-width: 720px) {
+                grid-template-columns: 1fr;
+            }
+
+            .grid-item {
+                padding: 0.25rem 0.25rem;
+                color: white;
+                text-decoration: none;
+                min-width: 300px;
+
+                &:hover {
+                    background-color: #375a7f;
+                    text-decoration: none;
+                }
+            }
+        }
+
+        &:not(:first-child) {
+            border-top: 1px solid #444;
+        }
+
+        .title {
+            padding: 0 0.25rem;
+            opacity: 0.5;
+            margin-bottom: 0.75rem;
+        }
+    }
+}

--- a/django/thunderstore/community/context_processors.py
+++ b/django/thunderstore/community/context_processors.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.db.models import Count
 from django.templatetags.static import static
 
 from thunderstore.community.models import CommunitySite
@@ -49,7 +50,8 @@ def community_site(request):
 
 def selectable_sites(request):
     return {
-        "selectable_community_sites": CommunitySite.objects.exclude(
-            is_listed=False
-        ).select_related("community", "site")
+        "selectable_community_sites": CommunitySite.objects.exclude(is_listed=False)
+        .select_related("community", "site")
+        .annotate(package_count=Count("community__package_listings"))
+        .order_by("-package_count", "datetime_created")
     }

--- a/django/thunderstore/frontend/templates/base.html
+++ b/django/thunderstore/frontend/templates/base.html
@@ -48,10 +48,25 @@
                         <a href="#" role="button" id="communitiesMenu" data-toggle="dropdown" aria-haspopup="true"
                            aria-expanded="false" class="nav-link dropdown-toggle">Communities</a>
                         {% if selectable_community_sites %}
-                        <div class="dropdown-menu" aria-labelledby="communitiesMenu">
-                            {% for site in selectable_community_sites|dictsort:"community.name" %}
-                                <a class="dropdown-item" href="{{ site.full_url }}">{{ site.community.name }}</a>
-                            {% endfor %}
+                        <div class="dropdown-menu communities-dropdown" aria-labelledby="communitiesMenu">
+                            <div class="section">
+                                <h6 class="title">Popular communities</h6>
+                                <div class="grid">
+                                    {% for site in selectable_community_sites|slice:":6"|dictsort:"community.name" %}
+                                        <a class="grid-item" href="{{ site.full_url }}">{{ site.community.name }}</a>
+                                    {% endfor %}
+                                </div>
+                            </div>
+                            {% if selectable_community_sites|length > 6 %}
+                                <div class="section">
+                                    <h6 class="title">Other communities</h6>
+                                    <div class="grid">
+                                        {% for site in selectable_community_sites|slice:"6:"|dictsort:"community.name" %}
+                                            <a class="grid-item" href="{{ site.full_url }}">{{ site.community.name }}</a>
+                                        {% endfor %}
+                                    </div>
+                                </div>
+                            {% endif %}
                         </div>
                         {% endif %}
                     </div>


### PR DESCRIPTION
Use a two-column layout for the navbar community selection menu and
include some categorization to make finding the most used communities
easier.

Example screenshot:
![image](https://user-images.githubusercontent.com/8225825/182246632-15921334-b58d-4cb6-90e7-c594e49eeb76.png)
