### PR TITLE
Add MirroredS3Storage

### DIFF
--- a/django/thunderstore/core/settings.py
+++ b/django/thunderstore/core/settings.py
@@ -2,11 +2,12 @@ import base64
 import json
 import os
 import sys
+from typing import Tuple
 
 import environ
 from django.http import HttpRequest
 
-from thunderstore.core.storage import get_storage_class_or_stub
+from thunderstore.core.storage import S3MirrorConfig, get_storage_class_or_stub
 from thunderstore.core.utils import validate_filepath_prefix
 
 try:
@@ -598,6 +599,23 @@ if all((AWS_S3_ENDPOINT_URL, AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID)):
 DEFAULT_FILE_STORAGE = get_storage_class_or_stub(DEFAULT_FILE_STORAGE)
 THUMBNAIL_DEFAULT_STORAGE = get_storage_class_or_stub(THUMBNAIL_DEFAULT_STORAGE)
 PACKAGE_FILE_STORAGE = get_storage_class_or_stub(PACKAGE_FILE_STORAGE)
+
+# For uploading files to multiple buckets at once.
+S3_MIRRORS: Tuple[S3MirrorConfig, ...] = (
+    # {
+    #     "access_key": env.str("..."),
+    #     "secret_key": env.str("..."),
+    #     "region_name": env.str("..."),
+    #     "bucket_name": env.str("..."),
+    #     "location": env.str("..."),
+    #     "custom_domain": env.str("..."),
+    #     "endpoint_url": env.str("..."),
+    #     "secure_urls": env.bool("..."),
+    #     "file_overwrite": env.bool("..."),
+    #     "default_acl": env.str("..."),
+    #     "object_parameters": AWS_S3_OBJECT_PARAMETERS,
+    # },
+)
 
 # Social auth
 

--- a/django/thunderstore/core/storage.py
+++ b/django/thunderstore/core/storage.py
@@ -1,10 +1,62 @@
+from typing import IO, Any, Dict, Optional, TypedDict
+
+from django.conf import settings
+from django.utils.deconstruct import deconstructible
+from storages.backends.s3boto3 import S3Boto3Storage  # type: ignore
+
+from thunderstore.utils.contexts import TemporarySpooledCopy
 from thunderstore.utils.makemigrations import is_migrate_check
+
 
 # These are required as a placeholder stub for migrations, otherwise Django thinks
 # something keeps changing due to settings being different.
-
-
 def get_storage_class_or_stub(storage_class: str) -> str:
     if is_migrate_check():
         return "thunderstore.utils.makemigrations.StubStorage"
     return storage_class
+
+
+class S3MirrorConfig(TypedDict):
+    access_key: str
+    secret_key: str
+    region_name: str
+    bucket_name: str
+    location: str
+    custom_domain: str
+    endpoint_url: str
+    secure_urls: bool
+    file_overwrite: bool
+    default_acl: str
+    object_parameters: Dict
+
+
+@deconstructible
+class MirroredS3Storage(S3Boto3Storage):
+    @property
+    def mirrors(self):
+        for mirror in settings.S3_MIRRORS:
+            yield S3Boto3Storage(**mirror)
+
+    def save(
+        self, name: str, content: IO[Any], max_length: Optional[int] = None
+    ) -> str:
+        """
+        Upload file to main S3 storage and all mirrors.
+
+        Calling .save() closes the file, so use temporary copies for
+        mirrors and call the main bucket with the actual file last.
+        """
+        for storage_mirror in self.mirrors:
+            with TemporarySpooledCopy(content) as tmp_content:
+                storage_mirror.save(name, tmp_content, max_length)
+
+        return super().save(name, content, max_length)
+
+    def delete(self, name: str) -> None:
+        """
+        Delete file from main S3 storage and all mirrors.
+        """
+        super().delete(name)
+
+        for storage_mirror in self.mirrors:
+            storage_mirror.delete(name)

--- a/django/thunderstore/core/tests/test_storage.py
+++ b/django/thunderstore/core/tests/test_storage.py
@@ -1,4 +1,11 @@
+import pytest
+from django.core.files.storage import default_storage
+from django.test import override_settings
+from PIL import Image  # type: ignore
+
 from thunderstore.core.storage import get_storage_class_or_stub
+from thunderstore.repository.factories import PackageVersionFactory
+from thunderstore.repository.models.package_version import get_version_png_filepath
 
 
 def test_get_storage_class_or_stub(mocker) -> None:
@@ -8,3 +15,43 @@ def test_get_storage_class_or_stub(mocker) -> None:
         get_storage_class_or_stub("non.stub.class")
         == "thunderstore.utils.makemigrations.StubStorage"
     )
+
+
+@override_settings(
+    DEFAULT_FILE_STORAGE="thunderstore.core.storage.MirroredS3Storage",
+    S3_MIRRORS=(
+        {
+            "access_key": "thunderstore",
+            "secret_key": "thunderstore",
+            "region_name": "",
+            "bucket_name": "test",
+            "location": "test",
+            "custom_domain": "localhost:9000/thunderstore",
+            "endpoint_url": "http://minio:9000/",
+            "secure_urls": False,
+            "file_overwrite": True,
+            "default_acl": "",
+            "object_parameters": {},
+        },
+    ),
+)
+@pytest.mark.django_db
+def test_mirrored_storage(dummy_image: Image) -> None:
+    pv = PackageVersionFactory(icon=None)
+    icon_path = get_version_png_filepath(pv, "")
+
+    assert hasattr(default_storage, "mirrors")
+    assert not default_storage.exists(icon_path)
+    for mirror_storage in default_storage.mirrors:
+        assert not mirror_storage.exists(icon_path)
+
+    pv.icon = dummy_image
+    pv.save()
+    assert default_storage.exists(icon_path)
+    for mirror_storage in default_storage.mirrors:
+        assert mirror_storage.exists(icon_path)
+
+    pv.icon.delete()
+    assert not default_storage.exists(icon_path)
+    for mirror_storage in default_storage.mirrors:
+        assert not mirror_storage.exists(icon_path)

--- a/django/thunderstore/utils/contexts.py
+++ b/django/thunderstore/utils/contexts.py
@@ -1,0 +1,20 @@
+from contextlib import contextmanager
+from tempfile import SpooledTemporaryFile
+from typing import IO, Any
+
+
+@contextmanager
+def TemporarySpooledCopy(source_file: IO[Any]):
+    """
+    Context with a temporary copy of the given file.
+    """
+    try:
+        original_pos = source_file.tell()
+        source_file.seek(0)
+        temp_file = SpooledTemporaryFile()
+        temp_file.write(source_file.read())
+        temp_file.seek(0)
+        source_file.seek(original_pos)
+        yield temp_file
+    finally:
+        temp_file.close()

--- a/django/thunderstore/utils/tests/test_contexts.py
+++ b/django/thunderstore/utils/tests/test_contexts.py
@@ -1,0 +1,30 @@
+from io import BytesIO
+from tempfile import TemporaryFile
+
+from thunderstore.utils.contexts import TemporarySpooledCopy
+
+
+def test_content_is_copied():
+    original_content = b"Lorem ipsum"
+
+    with BytesIO() as original:
+        original.write(original_content)
+
+        with TemporarySpooledCopy(original) as tmp:
+            tmp_content = tmp.read()
+
+    assert tmp_content == original_content
+
+
+def test_original_file_is_unaffected():
+    position = 123
+
+    with TemporaryFile() as original:
+        original.truncate(1023)
+        original.seek(position)
+
+        with TemporarySpooledCopy(original) as tmp:
+            tmp.seek(999)
+
+        assert not original.closed
+        assert original.tell() == position

--- a/minio/thunderstore-entrypoint.sh
+++ b/minio/thunderstore-entrypoint.sh
@@ -5,7 +5,9 @@ while ! nc -z minio 9000; do echo 'Wait minio to startup...' && sleep 0.1; done;
 sleep 2
 mc alias set thunderstore http://127.0.0.1:9000 $MINIO_ROOT_USER $MINIO_ROOT_PASSWORD;
 mc mb thunderstore/thunderstore;
+mc mb thunderstore/test;
 mc policy set download thunderstore/thunderstore;
+mc policy set download thunderstore/test;
 kill $MINIO_PID
 wait $MINIO_PID
 source /usr/bin/docker-entrypoint.sh "$@"


### PR DESCRIPTION
Revisited version after #626. Changes:

* Moved `TemporarySpooledCopy` to a separate file and added two simple test cases
* `MirroredS3Storage` now uses the higher-level methods instead of poking the internals, which makes for much simpler code 👍🏻 

`MirroredS3Storage` currently has no unit tests of its own - should it?