### PR TITLE
Fix flake8 pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     hooks:
       - id: prettier
         exclude: "^(django/|builder/src/[a-z]+/vendor/)"
-  - repo: https://gitlab.com/PyCQA/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: "3.8.4"
     hooks:
       - id: flake8


### PR DESCRIPTION
As the GitLab hosted flake8 repository is no longer public, change the pre-commit hook to use the GitHub repository instead.