### PR TITLE
Add a PackageListing update API endpoint

### DIFF
--- a/django/thunderstore/community/api/experimental/serializers.py
+++ b/django/thunderstore/community/api/experimental/serializers.py
@@ -1,0 +1,16 @@
+from rest_framework import serializers
+
+from thunderstore.community.models import PackageCategory
+from thunderstore.repository.api.experimental.serializers import (
+    CommunityFilteredModelChoiceField,
+)
+
+
+class PackageListingUpdateRequestSerializer(serializers.Serializer):
+    categories = serializers.ListField(
+        child=CommunityFilteredModelChoiceField(
+            queryset=PackageCategory.objects.all(),
+            to_field="slug",
+        ),
+        allow_empty=True,
+    )

--- a/django/thunderstore/community/api/experimental/tests/test_api_package_listing.py
+++ b/django/thunderstore/community/api/experimental/tests/test_api_package_listing.py
@@ -1,0 +1,71 @@
+import json
+
+import pytest
+from rest_framework.test import APIClient
+
+from conftest import TestUserTypes
+from thunderstore.community.models import PackageCategory, PackageListing
+from thunderstore.repository.models import TeamMember
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("user_type", TestUserTypes.options())
+def test_api_experimental_package_listing_update_user_types(
+    api_client: APIClient,
+    user_type: str,
+    active_package_listing: PackageListing,
+):
+    user = TestUserTypes.get_user_by_type(user_type)
+    if user not in TestUserTypes.fake_users():
+        api_client.force_authenticate(user=user)
+
+    response = api_client.post(
+        f"/api/experimental/package-listing/{active_package_listing.pk}/update/",
+        data=json.dumps({"categories": []}),
+        content_type="application/json",
+    )
+
+    expected_results = {
+        TestUserTypes.no_user: False,
+        TestUserTypes.unauthenticated: False,
+        TestUserTypes.regular_user: False,
+        TestUserTypes.deactivated_user: False,
+        TestUserTypes.service_account: False,
+        TestUserTypes.site_admin: True,
+        TestUserTypes.superuser: True,
+    }
+    should_succeed = expected_results[user_type]
+
+    print(response.content)
+    if should_succeed:
+        assert response.status_code == 200
+        assert response.json()["name"] == active_package_listing.package.name
+    else:
+        assert response.status_code == 403
+        assert (
+            response.json()["detail"]
+            == "You do not have permission to perform this action."
+        )
+
+
+@pytest.mark.django_db
+def test_api_experimental_package_listing_update(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+    team_owner: TeamMember,
+    package_category: PackageCategory,
+):
+    assert team_owner.team == active_package_listing.package.owner
+    assert package_category.community == active_package_listing.community
+    assert active_package_listing.categories.count() == 0
+    api_client.force_authenticate(user=team_owner.user)
+    response = api_client.post(
+        f"/api/experimental/package-listing/{active_package_listing.pk}/update/",
+        data=json.dumps({"categories": [package_category.slug]}),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    assert response.json()["categories"] == [package_category.name]
+    assert active_package_listing.categories.count() == 1
+    assert package_category in active_package_listing.categories.all()

--- a/django/thunderstore/community/api/experimental/urls.py
+++ b/django/thunderstore/community/api/experimental/urls.py
@@ -4,6 +4,7 @@ from thunderstore.community.api.experimental.views import (
     CommunitiesExperimentalApiView,
     CurrentCommunityExperimentalApiView,
     PackageCategoriesExperimentalApiView,
+    PackageListingUpdateApiView,
 )
 
 urls = [
@@ -21,5 +22,10 @@ urls = [
         "current-community/",
         CurrentCommunityExperimentalApiView.as_view(),
         name="current-community",
+    ),
+    path(
+        "package-listing/<int:pk>/update/",
+        PackageListingUpdateApiView.as_view(),
+        name="package-listing.update",
     ),
 ]

--- a/django/thunderstore/repository/api/experimental/serializers/main.py
+++ b/django/thunderstore/repository/api/experimental/serializers/main.py
@@ -152,6 +152,10 @@ class JSONSerializerField(serializers.JSONField):
 
 class CommunityFilteredModelChoiceField(ModelChoiceField):
     def get_queryset(self):
+        if "community" in self.context:
+            return self.queryset.exclude(
+                ~Q(community=self.context["community"]),
+            )
         return self.queryset.exclude(
             ~Q(community=self.context["request"].community),
         )


### PR DESCRIPTION
Implement a PackageListing update API endpoint which can be used to
update the categories set to the PackageListing.

Refs TS-1338