### PR TITLE
Implement package management panel in React

### DIFF
--- a/builder/src/components/PackageManagement/CsrfInput.tsx
+++ b/builder/src/components/PackageManagement/CsrfInput.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+type CsrfInputProps = {
+    csrfToken: string;
+};
+export const CsrfInput: React.FC<CsrfInputProps> = (props) => {
+    return (
+        <input
+            type="hidden"
+            name="csrfmiddlewaretoken"
+            value={props.csrfToken}
+        />
+    );
+};

--- a/builder/src/components/PackageManagement/Deprecation.tsx
+++ b/builder/src/components/PackageManagement/Deprecation.tsx
@@ -1,0 +1,43 @@
+import React, { useMemo } from "react";
+import { CsrfInput } from "./CsrfInput";
+
+type Button = {
+    className: string;
+    name: string;
+};
+type DeprecationFormProps = {
+    canDeprecate: boolean;
+    canUndeprecate: boolean;
+    canUnlist: boolean;
+    csrfToken: string;
+};
+export const DeprecationForm: React.FC<DeprecationFormProps> = (props) => {
+    const buttons = useMemo(() => {
+        const result: Button[] = [];
+        if (props.canDeprecate) {
+            result.push({ name: "deprecate", className: "btn-warning" });
+        }
+        if (props.canUndeprecate) {
+            result.push({ name: "undeprecate", className: "btn-primary" });
+        }
+        if (props.canUnlist) {
+            result.push({ name: "unlist", className: "btn-danger" });
+        }
+        return result;
+    }, [props.canDeprecate, props.canUndeprecate, props.canUnlist]);
+
+    return (
+        <form method="POST" action="#">
+            <CsrfInput csrfToken={props.csrfToken} />
+            {buttons.map((x) => (
+                <input
+                    key={x.name}
+                    type="submit"
+                    className={`btn ${x.className} text-capitalize mr-2`}
+                    name={x.name}
+                    value={x.name}
+                />
+            ))}
+        </form>
+    );
+};

--- a/builder/src/components/PackageManagement/Panel.tsx
+++ b/builder/src/components/PackageManagement/Panel.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { DeprecationForm } from "./Deprecation";
+
+type PackageManagementPanelProps = {
+    isDeprecated: boolean;
+    canDeprecate: boolean;
+    canUndeprecate: boolean;
+    canUnlist: boolean;
+    canUpdateCategories: boolean;
+    csrfToken: string;
+};
+export const PackageManagementPanel: React.FC<PackageManagementPanelProps> = (
+    props
+) => {
+    const StatusText: React.FC = () => {
+        if (props.isDeprecated) {
+            return (
+                <>
+                    Current status:{" "}
+                    <span className="badge badge-pill badge-danger">
+                        deprecated
+                    </span>
+                </>
+            );
+        } else {
+            return (
+                <>
+                    Current status:{" "}
+                    <span className="badge badge-pill badge-primary">
+                        active
+                    </span>
+                </>
+            );
+        }
+    };
+
+    return (
+        <div className="card text-white bg-info mt-2">
+            <div className="card-body">
+                <h4 className="card-title">Manage package</h4>
+                <p className="card-text">
+                    Changes might take several minutes to show publicly! This
+                    card is always up to date.
+                </p>
+                <div className="mt-3">
+                    <h5>Status</h5>
+                    <p className="card-text">
+                        <StatusText />
+                    </p>
+                    <DeprecationForm {...props} />
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/builder/src/main.ts
+++ b/builder/src/main.ts
@@ -6,6 +6,7 @@ import React, { ComponentClass, FunctionComponent } from "react";
 import * as Sentry from "@sentry/react";
 import { MarkdownPreviewPage } from "./markdown";
 import { ManifestValidationPage } from "./manifest";
+import { PackageManagementPanel } from "./components/PackageManagement/Panel";
 
 Sentry.init({
     // TODO: Add as a build variable instead
@@ -16,9 +17,15 @@ Sentry.init({
     allowUrls: [window.location.origin],
 });
 
-const CreateComponent = (component: FunctionComponent | ComponentClass) => {
-    return (element: Element) => {
-        ReactDOM.render(React.createElement(component), element);
+const CreateComponent = (
+    component: FunctionComponent<any> | ComponentClass
+) => {
+    return (element: Element, encodedProps?: string) => {
+        let props: any = undefined;
+        if (encodedProps) {
+            props = JSON.parse(atob(encodedProps));
+        }
+        ReactDOM.render(React.createElement(component, props), element);
     };
 };
 
@@ -26,4 +33,5 @@ const CreateComponent = (component: FunctionComponent | ComponentClass) => {
     UploadPage: CreateComponent(UploadPage),
     MarkdownPreviewPage: CreateComponent(MarkdownPreviewPage),
     ManifestValidationPage: CreateComponent(ManifestValidationPage),
+    PackageManagementPanel: CreateComponent(PackageManagementPanel),
 };

--- a/django/poetry.lock
+++ b/django/poetry.lock
@@ -79,7 +79,7 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
+dev = ["coverage[toml] (>=5.0.2)", "furo", "hypothesis", "pre-commit", "pympler", "pytest (>=4.3.0)", "six", "sphinx", "zope.interface"]
 docs = ["furo", "sphinx", "zope.interface"]
 tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
@@ -177,7 +177,7 @@ vine = ">=5.0.0,<6.0"
 [package.extras]
 arangodb = ["pyArango (>=1.3.2)"]
 auth = ["cryptography"]
-azureblockblob = ["azure-storage (==0.36.0)", "azure-common (==1.1.5)", "azure-storage-common (==1.1.0)"]
+azureblockblob = ["azure-common (==1.1.5)", "azure-storage (==0.36.0)", "azure-storage-common (==1.1.0)"]
 brotli = ["brotli (>=1.0.0)", "brotlipy (>=0.7.0)"]
 cassandra = ["cassandra-driver (<3.21.0)"]
 consul = ["python-consul"]
@@ -274,7 +274,7 @@ python-versions = "*"
 click = ">=4.0"
 
 [package.extras]
-dev = ["pytest (>=3.6)", "pytest-cov", "wheel", "coveralls"]
+dev = ["coveralls", "pytest (>=3.6)", "pytest-cov", "wheel"]
 
 [[package]]
 name = "click-repl"
@@ -346,11 +346,11 @@ cffi = ">=1.12"
 
 [package.extras]
 docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx-rtd-theme"]
-docstest = ["doc8", "pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
+docstest = ["doc8", "pyenchant (>=1.6.11)", "sphinxcontrib-spelling (>=4.0.1)", "twine (>=1.12.0)"]
 pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
 sdist = ["setuptools-rust (>=0.11.4)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["pytest (>=6.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
+test = ["hypothesis (>=1.11.4,!=3.79.2)", "iso8601", "pretend", "pytest (>=6.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pytz"]
 
 [[package]]
 name = "defusedxml"
@@ -602,7 +602,7 @@ python-versions = ">=3.6"
 Faker = ">=0.7.0"
 
 [package.extras]
-dev = ["coverage", "django", "flake8", "isort", "pillow", "sqlalchemy", "mongoengine", "wheel (>=0.32.0)", "tox", "zest.releaser"]
+dev = ["coverage", "django", "flake8", "isort", "mongoengine", "pillow", "sqlalchemy", "tox", "wheel (>=0.32.0)", "zest.releaser"]
 doc = ["sphinx", "sphinx-rtd-theme", "sphinxcontrib-spelling"]
 
 [[package]]
@@ -673,7 +673,7 @@ attrs = ">=19.2.0"
 flake8 = ">=3.0.0"
 
 [package.extras]
-dev = ["coverage", "black", "hypothesis", "hypothesmith"]
+dev = ["black", "coverage", "hypothesis", "hypothesmith"]
 
 [[package]]
 name = "flake8-builtins"
@@ -789,8 +789,8 @@ greenlet = {version = ">=0.4.17,<2.0", markers = "platform_python_implementation
 dnspython = ["dnspython (>=1.16.0,<2.0)", "idna"]
 docs = ["repoze.sphinx.autointerface", "sphinxcontrib-programoutput", "zope.schema"]
 monitor = ["psutil (>=5.7.0)"]
-recommended = ["dnspython (>=1.16.0,<2.0)", "idna", "cffi (>=1.12.2)", "selectors2", "backports.socketpair", "psutil (>=5.7.0)"]
-test = ["dnspython (>=1.16.0,<2.0)", "idna", "requests", "objgraph", "cffi (>=1.12.2)", "selectors2", "futures", "mock", "backports.socketpair", "contextvars (==2.4)", "coverage (>=5.0)", "coveralls (>=1.7.0)", "psutil (>=5.7.0)"]
+recommended = ["backports.socketpair", "cffi (>=1.12.2)", "dnspython (>=1.16.0,<2.0)", "idna", "psutil (>=5.7.0)", "selectors2"]
+test = ["backports.socketpair", "cffi (>=1.12.2)", "contextvars (==2.4)", "coverage (>=5.0)", "coveralls (>=1.7.0)", "dnspython (>=1.16.0,<2.0)", "futures", "idna", "mock", "objgraph", "psutil (>=5.7.0)", "requests", "selectors2"]
 
 [[package]]
 name = "greenlet"
@@ -864,9 +864,9 @@ optional = false
 python-versions = ">=3.6,<4.0"
 
 [package.extras]
-pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
-requirements_deprecated_finder = ["pipreqs", "pip-api"]
 colors = ["colorama (>=0.4.3,<0.5.0)"]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
+requirements_deprecated_finder = ["pip-api", "pipreqs"]
 
 [[package]]
 name = "itypes"
@@ -938,9 +938,23 @@ uc-micro-py = "*"
 
 [package.extras]
 benchmark = ["pytest", "pytest-benchmark"]
-dev = ["pre-commit", "isort", "flake8", "black"]
-doc = ["sphinx", "sphinx-book-theme", "myst-parser"]
+dev = ["black", "flake8", "isort", "pre-commit"]
+doc = ["myst-parser", "sphinx", "sphinx-book-theme"]
 test = ["coverage", "pytest", "pytest-cov"]
+
+[[package]]
+name = "lxml"
+version = "4.9.1"
+description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, != 3.4.*"
+
+[package.extras]
+cssselect = ["cssselect (>=0.7)"]
+html5 = ["html5lib"]
+htmlsoup = ["beautifulsoup4"]
+source = ["Cython (>=0.29.7)"]
 
 [[package]]
 name = "markdown-it-py"
@@ -961,7 +975,7 @@ compare = ["commonmark (>=0.9.1,<0.10.0)", "markdown (>=3.3.6,<3.4.0)", "mistlet
 linkify = ["linkify-it-py (>=1.0,<2.0)"]
 plugins = ["mdit-py-plugins"]
 profiling = ["gprof2dot"]
-rtd = ["attrs", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinx-book-theme"]
+rtd = ["attrs", "myst-parser", "pyyaml", "sphinx", "sphinx-book-theme", "sphinx-copybutton", "sphinx-design"]
 testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
 
 [[package]]
@@ -1185,9 +1199,9 @@ cryptography = {version = ">=3.3.1,<4.0.0", optional = true, markers = "extra ==
 
 [package.extras]
 crypto = ["cryptography (>=3.3.1,<4.0.0)"]
-dev = ["sphinx", "sphinx-rtd-theme", "zope.interface", "cryptography (>=3.3.1,<4.0.0)", "pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)", "mypy", "pre-commit"]
+dev = ["coverage[toml] (==5.0.4)", "cryptography (>=3.3.1,<4.0.0)", "mypy", "pre-commit", "pytest (>=6.0.0,<7.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
 docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
-tests = ["pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)"]
+tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
 
 [[package]]
 name = "pyparsing"
@@ -1231,7 +1245,7 @@ coverage = ">=5.2.1"
 pytest = ">=4.6"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests (==2.0.2)", "six", "pytest-xdist", "virtualenv"]
+testing = ["fields", "hunter", "process-tests (==2.0.2)", "pytest-xdist", "six", "virtualenv"]
 
 [[package]]
 name = "pytest-django"
@@ -1295,7 +1309,7 @@ python-versions = ">=3.5"
 pytest = ">=5.0"
 
 [package.extras]
-dev = ["pre-commit", "tox", "pytest-asyncio"]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
 name = "pytest-split"
@@ -1417,7 +1431,7 @@ idna = ">=2.5,<3"
 urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
-security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
+security = ["cryptography (>=1.3.4)", "pyOpenSSL (>=0.14)"]
 socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 
 [[package]]
@@ -1489,11 +1503,11 @@ celery = ["celery (>=3)"]
 chalice = ["chalice (>=1.16.0)"]
 django = ["django (>=1.8)"]
 falcon = ["falcon (>=1.4)"]
-flask = ["flask (>=0.11)", "blinker (>=1.1)"]
+flask = ["blinker (>=1.1)", "flask (>=0.11)"]
 httpx = ["httpx (>=0.16.0)"]
-pure_eval = ["pure-eval", "executing", "asttokens"]
+pure_eval = ["asttokens", "executing", "pure-eval"]
 pyspark = ["pyspark (>=2.4.4)"]
-quart = ["quart (>=0.16.1)", "blinker (>=1.1)"]
+quart = ["blinker (>=1.1)", "quart (>=0.16.1)"]
 rq = ["rq (>=0.6)"]
 sanic = ["sanic (>=0.8)"]
 sqlalchemy = ["sqlalchemy (>=1.2)"]
@@ -1536,8 +1550,8 @@ requests = ">=2.9.1"
 requests-oauthlib = ">=0.6.1"
 
 [package.extras]
-all = ["python-jose (>=3.0.0)", "python3-saml (>=1.2.1)", "cryptography (>=2.1.1)"]
-allpy3 = ["python-jose (>=3.0.0)", "python3-saml (>=1.2.1)", "cryptography (>=2.1.1)"]
+all = ["cryptography (>=2.1.1)", "python-jose (>=3.0.0)", "python3-saml (>=1.2.1)"]
+allpy3 = ["cryptography (>=2.1.1)", "python-jose (>=3.0.0)", "python3-saml (>=1.2.1)"]
 azuread = ["cryptography (>=2.1.1)"]
 openidconnect = ["python-jose (>=3.0.0)"]
 saml = ["python3-saml (>=1.2.1)"]
@@ -1619,7 +1633,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
-secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
@@ -1646,7 +1660,7 @@ six = ">=1.9.0,<2"
 
 [package.extras]
 docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=19.9.0rc1)"]
-testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "packaging (>=20.0)", "xonsh (>=0.9.16)"]
+testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "packaging (>=20.0)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "xonsh (>=0.9.16)"]
 
 [[package]]
 name = "watchdog"
@@ -1711,14 +1725,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-docs = ["sphinx", "repoze.sphinx.autointerface"]
+docs = ["repoze.sphinx.autointerface", "sphinx"]
 test = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "6f4409d347d6cc59ad1859ac07302366e122722450625a9af9eae4581af0a34a"
+content-hash = "4fd14c520d566a894beaad264e5dd019b8ee9fe7413930f2339331da12947440"
 
 [metadata.files]
 abyss = []
@@ -2187,6 +2201,78 @@ kombu = [
 linkify-it-py = [
     {file = "linkify-it-py-1.0.1.tar.gz", hash = "sha256:90b632ee516bf523c007ee96aa14ffc7efe1ca4074a80b0df366d66922d6d087"},
     {file = "linkify_it_py-1.0.1-py3-none-any.whl", hash = "sha256:29ba044d36f0ff938730a8167b7341a7caffc3e11666f9009996af6b82b61dfc"},
+]
+lxml = [
+    {file = "lxml-4.9.1-cp27-cp27m-macosx_10_15_x86_64.whl", hash = "sha256:98cafc618614d72b02185ac583c6f7796202062c41d2eeecdf07820bad3295ed"},
+    {file = "lxml-4.9.1-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c62e8dd9754b7debda0c5ba59d34509c4688f853588d75b53c3791983faa96fc"},
+    {file = "lxml-4.9.1-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:21fb3d24ab430fc538a96e9fbb9b150029914805d551deeac7d7822f64631dfc"},
+    {file = "lxml-4.9.1-cp27-cp27m-win32.whl", hash = "sha256:86e92728ef3fc842c50a5cb1d5ba2bc66db7da08a7af53fb3da79e202d1b2cd3"},
+    {file = "lxml-4.9.1-cp27-cp27m-win_amd64.whl", hash = "sha256:4cfbe42c686f33944e12f45a27d25a492cc0e43e1dc1da5d6a87cbcaf2e95627"},
+    {file = "lxml-4.9.1-cp27-cp27mu-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:dad7b164905d3e534883281c050180afcf1e230c3d4a54e8038aa5cfcf312b84"},
+    {file = "lxml-4.9.1-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a614e4afed58c14254e67862456d212c4dcceebab2eaa44d627c2ca04bf86837"},
+    {file = "lxml-4.9.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:f9ced82717c7ec65a67667bb05865ffe38af0e835cdd78728f1209c8fffe0cad"},
+    {file = "lxml-4.9.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:d9fc0bf3ff86c17348dfc5d322f627d78273eba545db865c3cd14b3f19e57fa5"},
+    {file = "lxml-4.9.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:e5f66bdf0976ec667fc4594d2812a00b07ed14d1b44259d19a41ae3fff99f2b8"},
+    {file = "lxml-4.9.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:fe17d10b97fdf58155f858606bddb4e037b805a60ae023c009f760d8361a4eb8"},
+    {file = "lxml-4.9.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8caf4d16b31961e964c62194ea3e26a0e9561cdf72eecb1781458b67ec83423d"},
+    {file = "lxml-4.9.1-cp310-cp310-win32.whl", hash = "sha256:4780677767dd52b99f0af1f123bc2c22873d30b474aa0e2fc3fe5e02217687c7"},
+    {file = "lxml-4.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:b122a188cd292c4d2fcd78d04f863b789ef43aa129b233d7c9004de08693728b"},
+    {file = "lxml-4.9.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:be9eb06489bc975c38706902cbc6888f39e946b81383abc2838d186f0e8b6a9d"},
+    {file = "lxml-4.9.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:f1be258c4d3dc609e654a1dc59d37b17d7fef05df912c01fc2e15eb43a9735f3"},
+    {file = "lxml-4.9.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:927a9dd016d6033bc12e0bf5dee1dde140235fc8d0d51099353c76081c03dc29"},
+    {file = "lxml-4.9.1-cp35-cp35m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9232b09f5efee6a495a99ae6824881940d6447debe272ea400c02e3b68aad85d"},
+    {file = "lxml-4.9.1-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:04da965dfebb5dac2619cb90fcf93efdb35b3c6994fea58a157a834f2f94b318"},
+    {file = "lxml-4.9.1-cp35-cp35m-win32.whl", hash = "sha256:4d5bae0a37af799207140652a700f21a85946f107a199bcb06720b13a4f1f0b7"},
+    {file = "lxml-4.9.1-cp35-cp35m-win_amd64.whl", hash = "sha256:4878e667ebabe9b65e785ac8da4d48886fe81193a84bbe49f12acff8f7a383a4"},
+    {file = "lxml-4.9.1-cp36-cp36m-macosx_10_15_x86_64.whl", hash = "sha256:1355755b62c28950f9ce123c7a41460ed9743c699905cbe664a5bcc5c9c7c7fb"},
+    {file = "lxml-4.9.1-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:bcaa1c495ce623966d9fc8a187da80082334236a2a1c7e141763ffaf7a405067"},
+    {file = "lxml-4.9.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6eafc048ea3f1b3c136c71a86db393be36b5b3d9c87b1c25204e7d397cee9536"},
+    {file = "lxml-4.9.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:13c90064b224e10c14dcdf8086688d3f0e612db53766e7478d7754703295c7c8"},
+    {file = "lxml-4.9.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:206a51077773c6c5d2ce1991327cda719063a47adc02bd703c56a662cdb6c58b"},
+    {file = "lxml-4.9.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:e8f0c9d65da595cfe91713bc1222af9ecabd37971762cb830dea2fc3b3bb2acf"},
+    {file = "lxml-4.9.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:8f0a4d179c9a941eb80c3a63cdb495e539e064f8054230844dcf2fcb812b71d3"},
+    {file = "lxml-4.9.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:830c88747dce8a3e7525defa68afd742b4580df6aa2fdd6f0855481e3994d391"},
+    {file = "lxml-4.9.1-cp36-cp36m-win32.whl", hash = "sha256:1e1cf47774373777936c5aabad489fef7b1c087dcd1f426b621fda9dcc12994e"},
+    {file = "lxml-4.9.1-cp36-cp36m-win_amd64.whl", hash = "sha256:5974895115737a74a00b321e339b9c3f45c20275d226398ae79ac008d908bff7"},
+    {file = "lxml-4.9.1-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:1423631e3d51008871299525b541413c9b6c6423593e89f9c4cfbe8460afc0a2"},
+    {file = "lxml-4.9.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:2aaf6a0a6465d39b5ca69688fce82d20088c1838534982996ec46633dc7ad6cc"},
+    {file = "lxml-4.9.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:9f36de4cd0c262dd9927886cc2305aa3f2210db437aa4fed3fb4940b8bf4592c"},
+    {file = "lxml-4.9.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:ae06c1e4bc60ee076292e582a7512f304abdf6c70db59b56745cca1684f875a4"},
+    {file = "lxml-4.9.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:57e4d637258703d14171b54203fd6822fda218c6c2658a7d30816b10995f29f3"},
+    {file = "lxml-4.9.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6d279033bf614953c3fc4a0aa9ac33a21e8044ca72d4fa8b9273fe75359d5cca"},
+    {file = "lxml-4.9.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:a60f90bba4c37962cbf210f0188ecca87daafdf60271f4c6948606e4dabf8785"},
+    {file = "lxml-4.9.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:6ca2264f341dd81e41f3fffecec6e446aa2121e0b8d026fb5130e02de1402785"},
+    {file = "lxml-4.9.1-cp37-cp37m-win32.whl", hash = "sha256:27e590352c76156f50f538dbcebd1925317a0f70540f7dc8c97d2931c595783a"},
+    {file = "lxml-4.9.1-cp37-cp37m-win_amd64.whl", hash = "sha256:eea5d6443b093e1545ad0210e6cf27f920482bfcf5c77cdc8596aec73523bb7e"},
+    {file = "lxml-4.9.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:f05251bbc2145349b8d0b77c0d4e5f3b228418807b1ee27cefb11f69ed3d233b"},
+    {file = "lxml-4.9.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:487c8e61d7acc50b8be82bda8c8d21d20e133c3cbf41bd8ad7eb1aaeb3f07c97"},
+    {file = "lxml-4.9.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:8d1a92d8e90b286d491e5626af53afef2ba04da33e82e30744795c71880eaa21"},
+    {file = "lxml-4.9.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:b570da8cd0012f4af9fa76a5635cd31f707473e65a5a335b186069d5c7121ff2"},
+    {file = "lxml-4.9.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ef87fca280fb15342726bd5f980f6faf8b84a5287fcc2d4962ea8af88b35130"},
+    {file = "lxml-4.9.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:93e414e3206779ef41e5ff2448067213febf260ba747fc65389a3ddaa3fb8715"},
+    {file = "lxml-4.9.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:6653071f4f9bac46fbc30f3c7838b0e9063ee335908c5d61fb7a4a86c8fd2036"},
+    {file = "lxml-4.9.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:32a73c53783becdb7eaf75a2a1525ea8e49379fb7248c3eeefb9412123536387"},
+    {file = "lxml-4.9.1-cp38-cp38-win32.whl", hash = "sha256:1a7c59c6ffd6ef5db362b798f350e24ab2cfa5700d53ac6681918f314a4d3b94"},
+    {file = "lxml-4.9.1-cp38-cp38-win_amd64.whl", hash = "sha256:1436cf0063bba7888e43f1ba8d58824f085410ea2025befe81150aceb123e345"},
+    {file = "lxml-4.9.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:4beea0f31491bc086991b97517b9683e5cfb369205dac0148ef685ac12a20a67"},
+    {file = "lxml-4.9.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:41fb58868b816c202e8881fd0f179a4644ce6e7cbbb248ef0283a34b73ec73bb"},
+    {file = "lxml-4.9.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:bd34f6d1810d9354dc7e35158aa6cc33456be7706df4420819af6ed966e85448"},
+    {file = "lxml-4.9.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:edffbe3c510d8f4bf8640e02ca019e48a9b72357318383ca60e3330c23aaffc7"},
+    {file = "lxml-4.9.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6d949f53ad4fc7cf02c44d6678e7ff05ec5f5552b235b9e136bd52e9bf730b91"},
+    {file = "lxml-4.9.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:079b68f197c796e42aa80b1f739f058dcee796dc725cc9a1be0cdb08fc45b000"},
+    {file = "lxml-4.9.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9c3a88d20e4fe4a2a4a84bf439a5ac9c9aba400b85244c63a1ab7088f85d9d25"},
+    {file = "lxml-4.9.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4e285b5f2bf321fc0857b491b5028c5f276ec0c873b985d58d7748ece1d770dd"},
+    {file = "lxml-4.9.1-cp39-cp39-win32.whl", hash = "sha256:ef72013e20dd5ba86a8ae1aed7f56f31d3374189aa8b433e7b12ad182c0d2dfb"},
+    {file = "lxml-4.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:10d2017f9150248563bb579cd0d07c61c58da85c922b780060dcc9a3aa9f432d"},
+    {file = "lxml-4.9.1-pp37-pypy37_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0538747a9d7827ce3e16a8fdd201a99e661c7dee3c96c885d8ecba3c35d1032c"},
+    {file = "lxml-4.9.1-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:0645e934e940107e2fdbe7c5b6fb8ec6232444260752598bc4d09511bd056c0b"},
+    {file = "lxml-4.9.1-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:6daa662aba22ef3258934105be2dd9afa5bb45748f4f702a3b39a5bf53a1f4dc"},
+    {file = "lxml-4.9.1-pp38-pypy38_pp73-macosx_10_15_x86_64.whl", hash = "sha256:603a464c2e67d8a546ddaa206d98e3246e5db05594b97db844c2f0a1af37cf5b"},
+    {file = "lxml-4.9.1-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:c4b2e0559b68455c085fb0f6178e9752c4be3bba104d6e881eb5573b399d1eb2"},
+    {file = "lxml-4.9.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:0f3f0059891d3254c7b5fb935330d6db38d6519ecd238ca4fce93c234b4a0f73"},
+    {file = "lxml-4.9.1-pp39-pypy39_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:c852b1530083a620cb0de5f3cd6826f19862bafeaf77586f1aef326e49d95f0c"},
+    {file = "lxml-4.9.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:287605bede6bd36e930577c5925fcea17cb30453d96a7b4c63c14a257118dbb9"},
+    {file = "lxml-4.9.1.tar.gz", hash = "sha256:fe749b052bb7233fe5d072fcb549221a8cb1a16725c47c37e42b0b9cb3ff2c3f"},
 ]
 markdown-it-py = [
     {file = "markdown-it-py-2.1.0.tar.gz", hash = "sha256:cf7e59fed14b5ae17c0006eff14a2d9a00ed5f3a846148153899a0224e2c07da"},

--- a/django/pyproject.toml
+++ b/django/pyproject.toml
@@ -33,6 +33,7 @@ boto3 = "^1.17.47"
 bleach = "^3.3.0"
 markdown-it-py = {version = "2.1.0", extras = ["linkify"]}
 abyss = {git = "https://github.com/akx/abyss.git", rev = "4352e557f25a303f718ec1bf82ea0ca545ebc077"}
+lxml = "^4.9.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2"

--- a/django/thunderstore/community/templates/community/packagelisting_detail.html
+++ b/django/thunderstore/community/templates/community/packagelisting_detail.html
@@ -4,6 +4,7 @@
 {% load markdownify %}
 {% load get_urls %}
 {% load cache_until %}
+{% load encode_props %}
 
 {% block title %}{{ object.package.display_name }}{% endblock %}
 {% block description %}{{ object.package.description }}{% endblock %}
@@ -21,36 +22,14 @@
 {% endblock %}
 
 {% block content %}
-{% if can_manage %}
-<div class="card text-white bg-info mt-2">
-    <div class="card-body">
-        <h4 class="card-title">
-            Manage package deprecation
-        </h4>
-        <p class="card-text">
-            Changes might take several minutes to show publicly! This card is always up to date.
-        </p>
-        <p class="card-text">
-            {% if object.package.is_deprecated %}
-            Current status: <span class="badge badge-pill badge-danger">deprecated</span>
-            {% else %}
-            Current status: <span class="badge badge-pill badge-primary">active</span>
-            {% endif %}
-        </p>
-        <form method="POST" action="#">
-            {% csrf_token %}
-            {% if can_deprecate %}
-            <input type="submit" class="btn btn-warning" name="deprecate" value="Deprecate">
-            {% endif %}
-            {% if can_undeprecate %}
-            <input type="submit" class="btn btn-primary" name="undeprecate" value="Undeprecate">
-            {% endif %}
-            {% if can_unlist %}
-            <input type="submit" class="btn btn-danger" name="unlist" value="Unlist">
-            {% endif %}
-        </form>
-    </div>
-</div>
+{% if show_management_panel %}
+<div id="package-management-panel"></div>
+<script type="text/javascript">
+window.ts.PackageManagementPanel(
+    document.getElementById("package-management-panel"),
+    {{ management_panel_props|encode_props }}
+);
+</script>
 {% endif %}
 {% cache_until "any_package_updated" "mod-detail" 300 object.package.pk community_identifier %}
 

--- a/django/thunderstore/frontend/extract_props.py
+++ b/django/thunderstore/frontend/extract_props.py
@@ -1,0 +1,48 @@
+import base64
+import json
+import re
+from io import StringIO
+from typing import Any, Iterable, Optional
+
+from lxml import etree
+
+REGEX_TEMPLATE = r"window\.ts\.{component}\(\s+document\.getElementById\(\"{id}\"\),\s+\"([a-zA-Z0-9=]+)\"\s+\);"
+
+# Sourced from https://mathiasbynens.be/demo/javascript-mime-type
+#    snapshot: http://web.archive.org/web/20221111201024/https://mathiasbynens.be/demo/javascript-mime-type
+VALID_SCRIPT_TYPES = {
+    "",
+    "application/ecmascript",
+    "application/javascript",
+    "application/x-ecmascript",
+    "application/x-javascript",
+    "text/ecmascript",
+    "text/javascript",
+    "text/jscript",
+    "text/x-ecmascript",
+    "text/x-javascript",
+}
+
+
+def enumerate_scripts(html: str) -> Iterable[str]:
+    buffer = StringIO(html)
+    tree = etree.parse(buffer, etree.HTMLParser())
+    for entry in tree.findall(".//script"):
+        if entry.get("type", "").lower() in VALID_SCRIPT_TYPES and entry.text:
+            yield entry.text
+
+
+def decode_props(props: str) -> Any:
+    return json.loads(base64.b64decode(props))
+
+
+def extract_props_from_html(
+    html: str, component_name: str, component_id: str
+) -> Optional[Any]:
+    pattern = re.compile(
+        REGEX_TEMPLATE.format(component=component_name, id=component_id)
+    )
+    for script in enumerate_scripts(html):
+        result = re.search(pattern, script)
+        if result:
+            return decode_props(result.group(1))

--- a/django/thunderstore/frontend/templatetags/encode_props.py
+++ b/django/thunderstore/frontend/templatetags/encode_props.py
@@ -1,0 +1,15 @@
+import base64
+import json
+
+from django import template
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+
+@register.filter
+def encode_props(props):
+    # Dump to JSON and encode as Base64 to avoid escaping issues.
+    # The React components handle decoding in reverse
+    encoded = base64.b64encode(json.dumps(props).encode()).decode()
+    return mark_safe(f'"{encoded}"')

--- a/django/thunderstore/frontend/tests/data/scripts.html
+++ b/django/thunderstore/frontend/tests/data/scripts.html
@@ -1,0 +1,311 @@
+
+
+
+
+<!doctype html>
+<html lang="en">
+    <head>
+
+
+        <title>Test Package 0 | Thunderstore</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <meta name="description" content="Example mod 5">
+        <link rel="icon" type="image/png" href="http://thunderstore.localhost/static/icon.png" />
+
+
+<meta property="og:title" content="Test Package 0 v2.0.0" />
+<meta property="og:type" content="website" />
+<meta property="og:url" content="http://thunderstore.localhost/package/Test_Team_5/Test_Package_0/" />
+<meta property="og:image" content="http://localhost:9000/thunderstore/development/repository/icons/Test_Team_5-Test_Package_0-2.0.0.png.256x256_q95.jpg" />
+<meta property="og:image:width" content="256" />
+<meta property="og:image:height" content="256" />
+
+<meta property="og:description" content="Example mod 5" />
+<meta property="og:site_name" content="Thunderstore" />
+
+
+
+        <link rel="stylesheet" href="/static/css/all.css">
+        <script src="/static/js/all.js"></script>
+        <script>const test = "test";</script>
+        <script type="application/x-rust">const TEST: String = String::from("b");</script>
+        <script type="text/javascript"></script>
+    </head>
+    <body>
+
+            <div class="background">
+                <div class="image" style="background: url(http://localhost:9000/thunderstore/development/community/riskofrain2/risk-of-rain-2-1.jpg);"></div>
+                <div class="tint"></div>
+            </div>
+
+
+
+        <nav class="navbar navbar-expand-sm navbar-dark bg-primary">
+            <a class="navbar-brand d-none d-md-block" href="/">
+                Thunderstore
+            </a>
+            <ul class="navbar-nav">
+                <li class="nav-item">
+                    <div class="dropdown">
+                        <a href="#" role="button" id="communitiesMenu" data-toggle="dropdown" aria-haspopup="true"
+                           aria-expanded="false" class="nav-link dropdown-toggle">Communities</a>
+
+                        <div class="dropdown-menu communities-dropdown" aria-labelledby="communitiesMenu">
+                            <div class="section">
+                                <h6 class="title">Popular communities</h6>
+                                <div class="grid">
+
+                                        <a class="grid-item" href="http://thunderstore.localhost/">Risk of Rain 2</a>
+
+                                </div>
+                            </div>
+
+                        </div>
+
+                    </div>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="/package/">Browse</a>
+                </li>
+
+                    <li class="nav-item">
+                        <a class="nav-link" href="/package/create/">Upload</a>
+                    </li>
+
+                <li class="nav-item">
+                    <div class="dropdown">
+                        <a href="#" role="button" id="developersMenu" data-toggle="dropdown" aria-haspopup="true"
+                           aria-expanded="false" class="nav-link dropdown-toggle">Developers</a>
+                        <div class="dropdown-menu" aria-labelledby="developersMenu">
+
+                            <a class="dropdown-item" href="/api/docs/">API Docs</a>
+                            <a class="dropdown-item" href="https://github.com/thunderstore-io/Thunderstore">GitHub Repo</a>
+                            <a class="dropdown-item" href="/package/create/docs/">Package Format Docs</a>
+                            <a class="dropdown-item" href="/tools/markdown-preview/">Markdown Preview</a>
+                            <a class="dropdown-item" href="/tools/manifest-v1-validator/">Manifest Validator</a>
+                        </div>
+                    </div>
+                </li>
+
+            </ul>
+            <ul class="navbar-nav ml-auto">
+
+                    <li class="nav-item">
+                        <a href="/package/admin@example.com/" class="nav-link text-dark">admin@example.com</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="/settings/linked-accounts/" class="nav-link">Settings</a>
+                    </li>
+
+                    <li class="nav-item">
+                        <a href="/djangoadmin/" class="nav-link">Admin</a>
+                    </li>
+
+                    <li class="nav-item">
+                        <a href="/logout/" class="nav-link">Logout</a>
+                    </li>
+
+            </ul>
+        </nav>
+        <div class="main">
+            <div class="main_content_left"></div>
+            <div class="container">
+
+
+
+                    <div class="alert alert-info mt-3" role="alert" id="thunderstore-mod-manager-ad-alert">
+<p class="mb-0">We recommend using the <a href="https://www.overwolf.com/app/Thunderstore-Thunderstore_Mod_Manager">Thunderstore Mod Manager</a> or an alternative for installing mods</p></div>
+
+
+
+
+<div id="package-management-panel"></div>
+<script type="text/javascript">
+window.ts.PackageManagementPanel(
+    document.getElementById("package-management-panel"),
+    "eyJpc0RlcHJlY2F0ZWQiOiBmYWxzZSwgImNhbkRlcHJlY2F0ZSI6IHRydWUsICJjYW5VbmRlcHJlY2F0ZSI6IGZhbHNlfQ=="
+);
+</script>
+
+
+
+<nav class="mt-3" aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><a href="/package/">Packages</a></li>
+    <li class="breadcrumb-item"><a href="/package/Test_Team_5/">Test_Team_5</a></li>
+    <li class="breadcrumb-item active" aria-current="page">Test Package 0</li>
+  </ol>
+</nav>
+
+
+
+
+
+
+
+<div class="card bg-light mt-2">
+    <div class="card-header">
+        <div class="media">
+            <img class="align-self-center mr-3" src="http://localhost:9000/thunderstore/development/repository/icons/Test_Team_5-Test_Package_0-2.0.0.png.128x128_q95.jpg" alt="Test_Team_5-Test_Package_0 icon">
+            <div class="media-body">
+                <h1 class="mt-0">Test Package 0</h1>
+                <p>Example mod 5</p>
+                <div class="d-flex w-100 justify-content-between">
+                    <h5 class="mb-1">By <a href="/package/Test_Team_5/">Test_Team_5</a></h5>
+
+                    <a class="text-nowrap" href="https://example.org">
+                      <span class="fa fa-globe-americas fa-fw"></span>
+                      https://example.org</a>
+
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="card-body pb-1">
+        <table class="table mb-0">
+            <tr>
+                <td>Last updated</td>
+                <td>5 days ago</td>
+            </tr>
+            <tr>
+                <td>Total downloads</td>
+                <td>0</td>
+            </tr>
+            <tr>
+                <td>Total rating</td>
+                <td><span id="package-rating-416f763b-229e-4f2d-b4ce-3f78fcf63b30">0</span>&nbsp;<i class="fas fa-thumbs-up text-dark ml-1" data-action="package.rate" data-target="416f763b-229e-4f2d-b4ce-3f78fcf63b30"></i></td>
+            </tr>
+            <tr>
+                <td>Categories</td>
+                <td>
+
+                </td>
+            </tr>
+            <tr>
+                <td>Dependency string</td>
+                <td>Test_Team_5-Test_Package_0-2.0.0</td>
+            </tr>
+            <tr>
+                <td>Dependants</td>
+                <td><a href="/package/Test_Team_5/Test_Package_0/dependants/">0 other mods depend on this mod</a>
+            </tr>
+        </table>
+    </div>
+</div>
+
+<div class="row my-2">
+    <div class="col-12 col-sm-6 px-3 pl-sm-3 pr-sm-1">
+        <a href="ror2mm://v1/install/thunderstore.localhost/Test_Team_5/Test_Package_0/2.0.0/" type="button" class="btn btn-primary w-100 text-large">
+            <i class="fa fa-rocket mr-2" aria-hidden="true"></i>Install with Mod Manager
+        </a>
+    </div>
+    <div class="col-12 col-sm-6 px-3 pr-sm-3 pl-sm-1 mt-1 mt-sm-0">
+        <a href="/package/download/Test_Team_5/Test_Package_0/2.0.0/" type="button" class="btn btn-primary w-100 text-large">
+            <i class="fa fa-download mr-2" aria-hidden="true"></i>Manual Download
+        </a>
+    </div>
+
+</div>
+
+
+
+
+
+<div class="card bg-light mb-2 mt-2">
+    <div class="card-header"><h4 class="mb-0">README</h4></div>
+    <div class="card-body markdown-body">
+        <h1>This is an example mod number 5</h1>
+
+    </div>
+</div>
+
+<div class="card bg-light mt-2 mb-4">
+    <div class="card-header">
+        <h2 class="mb-0">Available versions</h2>
+    </div>
+    <div class="card-body pb-1">
+        <p>
+            Please note that the install buttons only work if you have compatible client
+            software installed, such as the
+            <a href="https://www.overwolf.com/app/Thunderstore-Thunderstore_Mod_Manager">Thunderstore Mod Manager</a>.
+            Otherwise use the zip download links instead.
+        </p>
+        <table class="table mb-0">
+            <tr>
+                <th>Upload date</th>
+                <th>Version number</th>
+                <th>Downloads</th>
+                <th>Download link</th>
+                <th>&nbsp;</th>
+            </tr>
+
+            <tr>
+                <td>2022-11-29</td>
+                <td>2.0.0</td>
+                <td>0</td>
+                <td><a href="/package/download/Test_Team_5/Test_Package_0/2.0.0/">Version 2.0.0</a></td>
+                <td><a href="ror2mm://v1/install/thunderstore.localhost/Test_Team_5/Test_Package_0/2.0.0/" type="button" class="btn btn-primary">Install</a></td>
+            </tr>
+
+            <tr>
+                <td>2022-11-29</td>
+                <td>1.0.0</td>
+                <td>0</td>
+                <td><a href="/package/download/Test_Team_5/Test_Package_0/1.0.0/">Version 1.0.0</a></td>
+                <td><a href="ror2mm://v1/install/thunderstore.localhost/Test_Team_5/Test_Package_0/1.0.0/" type="button" class="btn btn-primary">Install</a></td>
+            </tr>
+
+            <tr>
+                <td>2022-11-29</td>
+                <td>0.0.0</td>
+                <td>0</td>
+                <td><a href="/package/download/Test_Team_5/Test_Package_0/0.0.0/">Version 0.0.0</a></td>
+                <td><a href="ror2mm://v1/install/thunderstore.localhost/Test_Team_5/Test_Package_0/0.0.0/" type="button" class="btn btn-primary">Install</a></td>
+            </tr>
+
+        </table>
+    </div>
+</div>
+
+
+
+
+
+
+
+            </div>
+            <div class="main_content_right"></div>
+        </div>
+        <div class="footer">
+            <div class="footer_top">
+
+
+
+            </div>
+            <div class="container footer_content">
+                <div class="footer_content_left">
+                    <img class="thunderstore_logo" src="/static/ts-logo-horizontal.svg" />
+
+
+
+                </div>
+                <div class="footer_content_right">
+                    <div class="footer_right_developers">
+                        <h2>Developers</h2>
+                        <a href="/api/docs/">API Docs</a>
+                        <a href="https://github.com/thunderstore-io/Thunderstore">GitHub Repo</a>
+                        <a href="/package/create/docs/">Package Format Docs</a>
+                        <a href="/tools/markdown-preview/">Markdown Preview</a>
+                        <a href="/tools/manifest-v1-validator/">Manifest Validator</a>
+                    </div>
+                </div>
+            </div>
+            <div class="container footer_links">
+                <p>Thunderstore 2022</p>
+                <div>
+                    <a class="nav-link" href="https://discord.gg/UWpWhjZken"><span class="fab fa-discord"></span></a>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/django/thunderstore/frontend/tests/test_encode_props.py
+++ b/django/thunderstore/frontend/tests/test_encode_props.py
@@ -1,0 +1,26 @@
+import base64
+import json
+from typing import Any
+
+import pytest
+from django.utils.safestring import SafeString
+
+from thunderstore.frontend.extract_props import decode_props
+from thunderstore.frontend.templatetags.encode_props import encode_props
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"isDeprecated": True, "canDeprecate": False, "canUndeprecate": True},
+        "This is a string, not JSON",
+    ],
+)
+def test_encode_props(data: Any):
+    encoded = encode_props(data)
+    assert isinstance(encoded, SafeString)
+    assert encoded.startswith('"')
+    assert encoded.endswith('"')
+    decoded = json.loads(base64.b64decode(encoded[1:-1]))
+    assert decoded == data
+    assert decoded == decode_props(encoded[1:-1])

--- a/django/thunderstore/frontend/tests/test_extract_props.py
+++ b/django/thunderstore/frontend/tests/test_extract_props.py
@@ -1,0 +1,64 @@
+import os
+from typing import Any
+
+import pytest
+
+from thunderstore.frontend.extract_props import (
+    decode_props,
+    enumerate_scripts,
+    extract_props_from_html,
+)
+
+
+def _load_test_data(path: str) -> str:
+    full_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), path)
+    with open(full_path, "r") as f:
+        return f.read()
+
+
+@pytest.mark.parametrize(
+    "encoded, expected",
+    [
+        (
+            "eyJpc0RlcHJlY2F0ZWQiOiB0cnVlLCAiY2FuRGVwcmVjYXRlIjogZmFsc2UsICJjYW5VbmRlcHJlY2F0ZSI6IHRydWV9",
+            {"isDeprecated": True, "canDeprecate": False, "canUndeprecate": True},
+        ),
+        (
+            "ImhlbGxvIg==",
+            "hello",
+        ),
+    ],
+)
+def test_decode_props(encoded: str, expected: Any) -> None:
+    assert decode_props(encoded) == expected
+
+
+def test_enumerate_scripts() -> None:
+    test_html = _load_test_data("data/scripts.html")
+    scripts = list(enumerate_scripts(test_html))
+    expected = [
+        'const test = "test";',
+        """
+window.ts.PackageManagementPanel(
+    document.getElementById("package-management-panel"),
+    "eyJpc0RlcHJlY2F0ZWQiOiBmYWxzZSwgImNhbkRlcHJlY2F0ZSI6IHRydWUsICJjYW5VbmRlcHJlY2F0ZSI6IGZhbHNlfQ=="
+);
+""",
+    ]
+
+    assert len(scripts) == len(expected)
+    for found, expected in zip(scripts, expected):
+        assert found.strip() == expected.strip()
+
+
+def test_extract_props_from_html() -> None:
+    test_html = _load_test_data("data/scripts.html")
+    expected = {"isDeprecated": False, "canDeprecate": True, "canUndeprecate": False}
+    props = extract_props_from_html(
+        test_html, "PackageManagementPanel", "package-management-panel"
+    )
+    assert props == expected
+    assert extract_props_from_html(test_html, "PackageManagementPanel", "wrong") is None
+    assert (
+        extract_props_from_html(test_html, "wrong", "package-management-panel") is None
+    )

--- a/django/thunderstore/repository/tests/test_views.py
+++ b/django/thunderstore/repository/tests/test_views.py
@@ -21,6 +21,7 @@ from ...community.models import (
     PackageListingReviewStatus,
 )
 from ...core.types import UserType
+from ...frontend.extract_props import extract_props_from_html
 from ..factories import PackageFactory, PackageVersionFactory, TeamFactory
 from ..models import Team, TeamMember, TeamMemberRole
 from ..package_upload import PackageUploadForm
@@ -460,19 +461,21 @@ def test_view_package_detail_management_option_visibility_without_team(
         TestUserTypes.superuser: True,
     }[user_type]
 
-    expected = b"Manage package deprecation"
+    expected = b'<div id="package-management-panel"></div>'
     if expected_management_visibility is False:
         assert expected not in response.content
     else:
         assert expected in response.content
 
-    expected = (
-        b'<input type="submit" class="btn btn-danger" name="unlist" value="Unlist">'
+    props = extract_props_from_html(
+        html=response.content.decode(),
+        component_name="PackageManagementPanel",
+        component_id="package-management-panel",
     )
-    if expected_unlist_visibility is False:
-        assert expected not in response.content
+    if expected_management_visibility:
+        assert props["canUnlist"] is expected_unlist_visibility
     else:
-        assert expected in response.content
+        assert props is None
 
 
 @pytest.mark.django_db
@@ -517,19 +520,21 @@ def test_view_package_detail_management_option_visibility_with_team(
         TeamMemberRole.member: True,
     }[role] or superuser is True
 
-    expected = b"Manage package deprecation"
+    expected = b'<div id="package-management-panel"></div>'
     if expected_management_visibility is False:
         assert expected not in response.content
     else:
         assert expected in response.content
 
-    expected = (
-        b'<input type="submit" class="btn btn-danger" name="unlist" value="Unlist">'
+    props = extract_props_from_html(
+        html=response.content.decode(),
+        component_name="PackageManagementPanel",
+        component_id="package-management-panel",
     )
-    if superuser is False:
-        assert expected not in response.content
+    if expected_management_visibility:
+        assert props["canUnlist"] is superuser
     else:
-        assert expected in response.content
+        assert props is None
 
 
 @pytest.mark.django_db

--- a/django/thunderstore/repository/views/repository.py
+++ b/django/thunderstore/repository/views/repository.py
@@ -1,4 +1,3 @@
-import time
 from typing import List, Optional, Set, Tuple
 
 from django.conf import settings
@@ -6,11 +5,11 @@ from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.db.models import Count, Q, Sum
 from django.http import Http404
+from django.middleware import csrf
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse_lazy
 from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
-from django.utils.http import urlencode
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.generic import TemplateView, View
 from django.views.generic.detail import DetailView
@@ -460,10 +459,14 @@ class PackageDetailView(CommunityMixin, DetailView):
 
         context["dependants_string"] = dependants_string
 
-        context["can_manage"] = self.can_manage
-        context["can_deprecate"] = self.can_deprecate
-        context["can_undeprecate"] = self.can_undeprecate
-        context["can_unlist"] = self.can_unlist
+        context["show_management_panel"] = self.can_manage
+        context["management_panel_props"] = {
+            "isDeprecated": package_listing.package.is_deprecated,
+            "canDeprecate": self.can_deprecate,
+            "canUndeprecate": self.can_undeprecate,
+            "canUnlist": self.can_unlist,
+            "csrfToken": csrf.get_token(self.request),
+        }
         return context
 
     def post_deprecate(self):


### PR DESCRIPTION
**Note to reviewer:** a large bulk of the changes here are either generated files or tests, don't be fazed by the LoC on diffs

Replace the package management panel with a version that's implemented in React as opposed to using Django templates.

Additionally include an easy way to pass data between Django and React

Refs TS-1352