### PR TITLE
Use a 3-column layout on community dropdown

### DIFF
--- a/builder/src/scss/navbar.scss
+++ b/builder/src/scss/navbar.scss
@@ -7,8 +7,12 @@
 
         .grid {
             display: grid;
-            grid-template-columns: 1fr 1fr;
+            grid-template-columns: 1fr 1fr 1fr;
             gap: 0 1rem;
+
+            @media (max-width: 1160px) {
+                grid-template-columns: 1fr 1fr;
+            }
 
             @media (max-width: 720px) {
                 grid-template-columns: 1fr;


### PR DESCRIPTION
Expand the community dropdown from 2 columns to 3 columns. It would be ideally sorted alphabetically per-column, but that's a more complex change in comparison to this one and can be done separately.

Example:
![image](https://user-images.githubusercontent.com/8225825/207101368-6ff1f5a6-e681-4f76-b586-899f8bab0298.png)
