### PR TITLE
Order community select column-first

### DIFF
--- a/builder/src/scss/navbar.scss
+++ b/builder/src/scss/navbar.scss
@@ -6,19 +6,18 @@
         padding: 1.5rem 1.75rem;
 
         .grid {
-            display: grid;
-            grid-template-columns: 1fr 1fr 1fr;
-            gap: 0 1rem;
+            column-count: 3;
 
             @media (max-width: 1160px) {
-                grid-template-columns: 1fr 1fr;
+                column-count: 2;
             }
 
             @media (max-width: 720px) {
-                grid-template-columns: 1fr;
+                column-count: 1;
             }
 
             .grid-item {
+                display: block;
                 padding: 0.25rem 0.25rem;
                 color: white;
                 text-decoration: none;

--- a/django/thunderstore/frontend/templates/base.html
+++ b/django/thunderstore/frontend/templates/base.html
@@ -51,18 +51,18 @@
                         <div class="dropdown-menu communities-dropdown" aria-labelledby="communitiesMenu">
                             <div class="section">
                                 <h6 class="title">Popular communities</h6>
-                                <div class="grid">
+                                <div class="grid" role="list">
                                     {% for site in selectable_community_sites|slice:":6"|dictsort:"community.name" %}
-                                        <a class="grid-item" href="{{ site.full_url }}">{{ site.community.name }}</a>
+                                        <a class="grid-item" href="{{ site.full_url }}" role="listitem">{{ site.community.name }}</a>
                                     {% endfor %}
                                 </div>
                             </div>
                             {% if selectable_community_sites|length > 6 %}
                                 <div class="section">
                                     <h6 class="title">Other communities</h6>
-                                    <div class="grid">
+                                    <div class="grid" role="list">
                                         {% for site in selectable_community_sites|slice:"6:"|dictsort:"community.name" %}
-                                            <a class="grid-item" href="{{ site.full_url }}">{{ site.community.name }}</a>
+                                            <a class="grid-item" href="{{ site.full_url }}" role="listitem">{{ site.community.name }}</a>
                                         {% endfor %}
                                     </div>
                                 </div>


### PR DESCRIPTION
Change the community select dropdown to use a column-first ordering, which should be a bit easier to read through.

Refs TS-1373

Example: 
![image](https://user-images.githubusercontent.com/8225825/207121812-0c591446-4e2f-4170-97a4-8b7ae8aee6a6.png)
