### PR TITLE
Strip unnecessary query parameters with qurl

### DIFF
--- a/django/thunderstore/community/templates/community/packagelisting_list.html
+++ b/django/thunderstore/community/templates/community/packagelisting_list.html
@@ -31,7 +31,7 @@
 <div class="m-0 mb-2 p-0 w-100">
     <div class="btn-group d-flex" role="group" aria-label="Result ordering">
         {% for entry in sections %}
-            <a href="{% qurl section entry.0 page %}" class="btn btn-primary {% if active_section == entry.0 %}active{% endif %}">
+            <a href="{% qurl allowed_params section entry.0 page %}" class="btn btn-primary {% if active_section == entry.0 %}active{% endif %}">
                 {{ entry.1 }}
             </a>
         {% endfor %}
@@ -42,7 +42,7 @@
 <div class="m-0 mb-2 p-0 w-100">
     <div class="btn-group d-flex" role="group" aria-label="Result ordering">
         {% for entry in ordering_modes %}
-            <a href="{% qurl ordering entry.0 page %}" class="btn btn-secondary {% if active_ordering == entry.0 %}active{% endif %}">
+            <a href="{% qurl allowed_params ordering entry.0 page %}" class="btn btn-secondary {% if active_ordering == entry.0 %}active{% endif %}">
                 {{ entry.1 }}
             </a>
         {% endfor %}
@@ -57,6 +57,7 @@
                 <div class="col-7 m-0 p-0 pr-2">
                     <input class="form-control w-100" type="search" name="q" placeholder="Search" aria-label="Search" value="{{ current_search }}">
                     <input type="hidden" name="ordering" value="{{ active_ordering }}">
+                    <input type="hidden" name="section" value="{{ active_section }}">
                 </div>
                 <div class="col-3 m-0 p-0 pr-1">
                     <button class="btn btn-success w-100" type="submit">Search</button>

--- a/django/thunderstore/frontend/tests/test_qurl.py
+++ b/django/thunderstore/frontend/tests/test_qurl.py
@@ -1,0 +1,117 @@
+from io import BytesIO
+
+import pytest
+from django.test import RequestFactory
+from django.urls import reverse
+from lxml import etree
+from rest_framework.test import APIClient
+
+from thunderstore.community.factories import PackageListingFactory
+from thunderstore.community.models import CommunitySite, PackageListingSection
+from thunderstore.frontend.templatetags.qurl import QurlNode
+
+TEST_PARAMS = [
+    ("page", True),
+    ("q", True),
+    ("included_categories", True),
+    ("excluded_categories", True),
+    ("nsfw", True),
+    ("deprecated", True),
+    ("ordering", True),
+    ("section", True),
+    ("foo", False),
+    ("jwoejfiwejof", False),
+]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("param, should_exist", TEST_PARAMS)
+def test_qurl_parameter_filtering_package_listing_view(
+    client: APIClient,
+    community_site: CommunitySite,
+    param: str,
+    should_exist: bool,
+) -> None:
+    # Param has to be a valid value or it won't be rendered
+    param_val = "foo"
+
+    # Section select needs to exist -> create enough sections
+    for i in range(2):
+        slug = f"section-{i}"
+        PackageListingSection.objects.create(
+            community=community_site.community,
+            name=f"Section {i}",
+            slug=slug,
+        )
+        param_val = slug
+
+    # Pagination has to exist -> create enough packages
+    if param == "page":
+        for i in range(25):
+            PackageListingFactory(community=community_site.community)
+        param_val = "1"
+
+    response = client.get(
+        reverse(
+            "communities:community:packages.list",
+            kwargs={"community_identifier": community_site.community.identifier},
+        )
+        + f"?{param}={param_val}",
+        HTTP_HOST=community_site.site.domain,
+    )
+
+    buffer = BytesIO(response.content)
+    tree = etree.parse(buffer, etree.HTMLParser())
+
+    param_found = False
+    for entry in tree.findall(".//a"):
+        href = entry.get("href", "")
+        if param in href and "/auth/login" not in href:
+            param_found = True
+            break
+
+    if should_exist:
+        assert param_found is True
+    else:
+        assert param_found is False
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("param, should_exist", TEST_PARAMS)
+def test_qurl_parameter_filtering_static(
+    rf: RequestFactory,
+    community_site: CommunitySite,
+    param: str,
+    should_exist: bool,
+) -> None:
+    url = (
+        reverse(
+            "communities:community:packages.list",
+            kwargs={"community_identifier": community_site.community.identifier},
+        )
+        + f"?{param}=1"
+    )
+    context = {
+        "allowed_params": {
+            "q",
+            "ordering",
+            "deprecated",
+            "nsfw",
+            "excluded_categories",
+            "included_categories",
+            "section",
+            "page",
+        },
+        "request": rf.get(url),
+    }
+
+    class FilterStub:
+        def resolve(self, context):
+            return "noop"
+
+    qurl = QurlNode("allowed_params", "noop", FilterStub(), [])
+    result = qurl.render(context)
+    if should_exist:
+        assert param in result
+    else:
+        assert param not in result

--- a/django/thunderstore/repository/templates/repository/includes/pagination.html
+++ b/django/thunderstore/repository/templates/repository/includes/pagination.html
@@ -3,7 +3,7 @@
 <ul class="pagination my-3">
     {% if page_obj.has_previous %}
         <li class="page-item">
-            <a class="page-link" href="{% qurl page page_obj.previous_page_number %}"><i class="fa fa-chevron-left" aria-hidden="true"></i></a>
+            <a class="page-link" href="{% qurl allowed_params page page_obj.previous_page_number %}"><i class="fa fa-chevron-left" aria-hidden="true"></i></a>
         </li>
     {% else %}
         <li class="page-item disabled">
@@ -12,10 +12,10 @@
     {% endif %}
 
     {% if page_obj.number|add:'-3' > 1 %}
-        <li><a class="page-link" href="{% qurl page 1 %}">1</a></li>
+        <li><a class="page-link" href="{% qurl allowed_params page 1 %}">1</a></li>
     {% endif %}
     {% if page_obj.number|add:'-4' > 1 %}
-        <li><a class="page-link" href="{% qurl page page_obj.number|add:'-4' %}">&hellip;</a></li>
+        <li><a class="page-link" href="{% qurl allowed_params page page_obj.number|add:'-4' %}">&hellip;</a></li>
     {% endif %}
 
     {% for i in paginator.page_range %}
@@ -25,21 +25,21 @@
             </li>
         {% elif i > page_obj.number|add:'-4' and i < page_obj.number|add:'4' %}
             <li class="page-item">
-                <a class="page-link" href="{% qurl page i %}">{{ i }}</a>
+                <a class="page-link" href="{% qurl allowed_params page i %}">{{ i }}</a>
             </li>
         {% endif %}
     {% endfor %}
 
     {% if page_obj.paginator.num_pages > page_obj.number|add:'4' %}
-        <li><a class="page-link" href="{% qurl page page_obj.number|add:'4' %}">&hellip;</a></li>
+        <li><a class="page-link" href="{% qurl allowed_params page page_obj.number|add:'4' %}">&hellip;</a></li>
     {% endif %}
     {% if page_obj.number|add:'3' < paginator.num_pages %}
-        <li><a class="page-link" href="{% qurl page paginator.num_pages %}">{{ paginator.num_pages }}</a></li>
+        <li><a class="page-link" href="{% qurl allowed_params page paginator.num_pages %}">{{ paginator.num_pages }}</a></li>
     {% endif %}
 
     {% if page_obj.has_next %}
         <li class="page-item">
-            <a class="page-link" href="{% qurl page page_obj.next_page_number %}"><i class="fa fa-chevron-right" aria-hidden="true"></i></a>
+            <a class="page-link" href="{% qurl allowed_params page page_obj.next_page_number %}"><i class="fa fa-chevron-right" aria-hidden="true"></i></a>
         </li>
     {% else %}
         <li class="page-item disabled">

--- a/django/thunderstore/repository/views/repository.py
+++ b/django/thunderstore/repository/views/repository.py
@@ -300,6 +300,16 @@ class PackageListSearchView(CommunityMixin, ListView):
         context["active_section"] = self.active_section_slug
         context["active_ordering"] = self.get_active_ordering()
         context["current_search"] = self.get_search_query()
+        context["allowed_params"] = {
+            "q",
+            "ordering",
+            "deprecated",
+            "nsfw",
+            "excluded_categories",
+            "included_categories",
+            "section",
+            "page",
+        }
         breadcrumbs = self.get_breadcrumbs()
         if len(breadcrumbs) > 1:
             context["breadcrumbs"] = breadcrumbs


### PR DESCRIPTION
Update the qurl template filter to strip unknown query parameters when building new URLs.

Also fix a bug where the search form would reset the section input entirely.

Refs TS-72