### PR TITLE
Filter out rejected package listings from webhooks

### DIFF
--- a/django/thunderstore/community/admin/package_listing.py
+++ b/django/thunderstore/community/admin/package_listing.py
@@ -2,8 +2,9 @@ from django.contrib import admin
 from django.db import transaction
 from django.db.models import QuerySet
 
+from ..consts import PackageListingReviewStatus
 from ..forms import PackageListingForm
-from ..models.package_listing import PackageListing, PackageListingReviewStatus
+from ..models.package_listing import PackageListing
 
 
 @transaction.atomic

--- a/django/thunderstore/community/consts.py
+++ b/django/thunderstore/community/consts.py
@@ -1,0 +1,7 @@
+from thunderstore.core.utils import ChoiceEnum
+
+
+class PackageListingReviewStatus(ChoiceEnum):
+    unreviewed = "unreviewed"
+    approved = "approved"
+    rejected = "rejected"

--- a/django/thunderstore/community/models/community.py
+++ b/django/thunderstore/community/models/community.py
@@ -5,6 +5,7 @@ from django.db import models
 from django.db.models import Manager, QuerySet
 from django.utils.functional import cached_property
 
+from thunderstore.community.consts import PackageListingReviewStatus
 from thunderstore.community.models.community_membership import (
     CommunityMemberRole,
     CommunityMembership,
@@ -129,3 +130,12 @@ class Community(TimestampMixin, models.Model):
 
     def can_user_manage_packages(self, user: Optional[UserType]) -> bool:
         return check_validity(lambda: self.ensure_user_can_manage_packages(user))
+
+    @property
+    def valid_review_statuses(self):
+        if self.require_package_listing_approval:
+            return (PackageListingReviewStatus.approved,)
+        return (
+            PackageListingReviewStatus.approved,
+            PackageListingReviewStatus.unreviewed,
+        )

--- a/django/thunderstore/community/models/package_listing.py
+++ b/django/thunderstore/community/models/package_listing.py
@@ -8,9 +8,10 @@ from django.utils.functional import cached_property
 
 from thunderstore.cache.enums import CacheBustCondition
 from thunderstore.cache.tasks import invalidate_cache_on_commit_async
+from thunderstore.community.consts import PackageListingReviewStatus
 from thunderstore.core.mixins import TimestampMixin
 from thunderstore.core.types import UserType
-from thunderstore.core.utils import ChoiceEnum, check_validity
+from thunderstore.core.utils import check_validity
 
 if TYPE_CHECKING:
     from thunderstore.community.models import PackageCategory
@@ -24,12 +25,6 @@ class PackageListingQueryset(models.QuerySet):
 
     def approved(self):
         return self.exclude(~Q(review_status=PackageListingReviewStatus.approved))
-
-
-class PackageListingReviewStatus(ChoiceEnum):
-    unreviewed = "unreviewed"
-    approved = "approved"
-    rejected = "rejected"
 
 
 # TODO: Add a db constraint that ensures a package listing and it's categories

--- a/django/thunderstore/community/tests/test_admin_package_listing.py
+++ b/django/thunderstore/community/tests/test_admin_package_listing.py
@@ -5,11 +5,8 @@ from thunderstore.community.admin.package_listing import (
     approve_listing,
     reject_listing,
 )
-from thunderstore.community.models import (
-    Community,
-    PackageListing,
-    PackageListingReviewStatus,
-)
+from thunderstore.community.consts import PackageListingReviewStatus
+from thunderstore.community.models import Community, PackageListing
 from thunderstore.repository.factories import NamespaceFactory
 from thunderstore.repository.models import Package, Team
 

--- a/django/thunderstore/community/tests/test_community.py
+++ b/django/thunderstore/community/tests/test_community.py
@@ -2,6 +2,7 @@ import pytest
 from django.core.exceptions import ValidationError
 
 from conftest import TestUserTypes
+from thunderstore.community.consts import PackageListingReviewStatus
 from thunderstore.community.factories import CommunityFactory, CommunitySiteFactory
 from thunderstore.community.models import (
     Community,
@@ -92,3 +93,19 @@ def test_community_get_community_filepath(community: Community) -> None:
         get_community_filepath(community, "lol.png")
         == f"community/{community.identifier}/lol.png"
     )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("require_approval", (False, True))
+def test_community_valid_review_statuses(
+    community: Community, require_approval: bool
+) -> None:
+    community.require_package_listing_approval = require_approval
+    community.save()
+    if require_approval:
+        assert community.valid_review_statuses == (PackageListingReviewStatus.approved,)
+    else:
+        assert community.valid_review_statuses == (
+            PackageListingReviewStatus.approved,
+            PackageListingReviewStatus.unreviewed,
+        )

--- a/django/thunderstore/community/tests/test_package_listing.py
+++ b/django/thunderstore/community/tests/test_package_listing.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 
 from conftest import TestUserTypes
+from thunderstore.community.consts import PackageListingReviewStatus
 from thunderstore.community.factories import CommunityFactory
 from thunderstore.community.models import (
     Community,
@@ -10,7 +11,6 @@ from thunderstore.community.models import (
     CommunityMembership,
     PackageCategory,
     PackageListing,
-    PackageListingReviewStatus,
 )
 from thunderstore.repository.models import Package, TeamMember, TeamMemberRole
 

--- a/django/thunderstore/frontend/api/experimental/tests/test_community_package_list.py
+++ b/django/thunderstore/frontend/api/experimental/tests/test_community_package_list.py
@@ -6,12 +6,9 @@ from rest_framework.test import APIClient
 
 from thunderstore.cache.enums import CacheBustCondition
 from thunderstore.cache.tasks import invalidate_cache
+from thunderstore.community.consts import PackageListingReviewStatus
 from thunderstore.community.factories import CommunitySiteFactory, PackageListingFactory
-from thunderstore.community.models import (
-    PackageCategory,
-    PackageListingReviewStatus,
-    PackageListingSection,
-)
+from thunderstore.community.models import PackageCategory, PackageListingSection
 from thunderstore.community.models.package_listing import PackageListing
 from thunderstore.frontend.api.experimental.views import CommunityPackageListApiView
 from thunderstore.repository.factories import (

--- a/django/thunderstore/frontend/api/experimental/tests/test_package_details.py
+++ b/django/thunderstore/frontend/api/experimental/tests/test_package_details.py
@@ -4,8 +4,9 @@ import pytest
 from django.urls import reverse
 from rest_framework.test import APIClient
 
+from thunderstore.community.consts import PackageListingReviewStatus
 from thunderstore.community.factories import PackageListingFactory
-from thunderstore.community.models import PackageListing, PackageListingReviewStatus
+from thunderstore.community.models import PackageListing
 from thunderstore.repository.factories import (
     PackageRatingFactory,
     PackageVersionFactory,

--- a/django/thunderstore/frontend/api/experimental/views/community_package_list.py
+++ b/django/thunderstore/frontend/api/experimental/views/community_package_list.py
@@ -12,11 +12,8 @@ from rest_framework.views import APIView
 
 from thunderstore.cache.enums import CacheBustCondition
 from thunderstore.cache.pagination import CachedPaginator
-from thunderstore.community.models import (
-    Community,
-    PackageListingReviewStatus,
-    PackageListingSection,
-)
+from thunderstore.community.consts import PackageListingReviewStatus
+from thunderstore.community.models import Community, PackageListingSection
 from thunderstore.frontend.api.experimental.serializers.views import (
     CommunityPackageListSerializer,
     PackageCategorySerializer,

--- a/django/thunderstore/repository/cache.py
+++ b/django/thunderstore/repository/cache.py
@@ -1,4 +1,5 @@
-from thunderstore.community.models import PackageListing, PackageListingReviewStatus, Q
+from thunderstore.community.consts import PackageListingReviewStatus
+from thunderstore.community.models import PackageListing, Q
 
 
 def get_package_listing_queryset(community_identifier: str):

--- a/django/thunderstore/repository/tests/test_views.py
+++ b/django/thunderstore/repository/tests/test_views.py
@@ -14,13 +14,9 @@ from thunderstore.core.factories import UserFactory
 
 from ...cache.enums import CacheBustCondition
 from ...cache.tasks import invalidate_cache
+from ...community.consts import PackageListingReviewStatus
 from ...community.factories import CommunitySiteFactory, SiteFactory
-from ...community.models import (
-    CommunitySite,
-    PackageCategory,
-    PackageListing,
-    PackageListingReviewStatus,
-)
+from ...community.models import CommunitySite, PackageCategory, PackageListing
 from ...core.types import UserType
 from ...frontend.extract_props import extract_props_from_html
 from ..factories import PackageFactory, PackageVersionFactory, TeamFactory

--- a/django/thunderstore/repository/views/repository.py
+++ b/django/thunderstore/repository/views/repository.py
@@ -19,11 +19,11 @@ from django.views.generic.list import ListView
 from thunderstore.cache.cache import cache_function_result
 from thunderstore.cache.enums import CacheBustCondition
 from thunderstore.cache.pagination import CachedPaginator
+from thunderstore.community.consts import PackageListingReviewStatus
 from thunderstore.community.models import (
     Community,
     PackageCategory,
     PackageListing,
-    PackageListingReviewStatus,
     PackageListingSection,
 )
 from thunderstore.repository.mixins import CommunityMixin


### PR DESCRIPTION
Exclude rejected package listings from posting webhook updates to the communites they've been rejected from.

Refs TS-1358