### PR TITLE
Bump max readme size to 100kb

### DIFF
--- a/django/thunderstore/frontend/api/experimental/tests/test_markdown.py
+++ b/django/thunderstore/frontend/api/experimental/tests/test_markdown.py
@@ -46,5 +46,7 @@ def test_api_experimental_render_markdown_too_long(api_client: APIClient) -> Non
     print(response.content)
     assert response.status_code == 400
     assert response.json() == {
-        "markdown": ["Ensure this field has no more than 32768 characters."],
+        "markdown": [
+            f"Ensure this field has no more than {MAX_README_SIZE} characters."
+        ],
     }

--- a/django/thunderstore/repository/validation/readme.py
+++ b/django/thunderstore/repository/validation/readme.py
@@ -2,7 +2,7 @@ import codecs
 
 from django.core.exceptions import ValidationError
 
-MAX_README_SIZE = 32768
+MAX_README_SIZE = 1000 * 100  # 100kb
 
 
 def validate_readme(readme_data: bytes) -> str:


### PR DESCRIPTION
Increase the maximum valid readme size from around 32kb to 100kb

Refs TS-1398