### PR TITLE
Add an API endpoint for package changelogs

### DIFF
--- a/django/thunderstore/repository/api/experimental/serializers/__init__.py
+++ b/django/thunderstore/repository/api/experimental/serializers/__init__.py
@@ -1,1 +1,2 @@
 from .main import *
+from .markdown import *

--- a/django/thunderstore/repository/api/experimental/serializers/markdown.py
+++ b/django/thunderstore/repository/api/experimental/serializers/markdown.py
@@ -1,0 +1,5 @@
+from rest_framework import serializers
+
+
+class MarkdownResponseSerializer(serializers.Serializer):
+    markdown = serializers.CharField(required=True, allow_null=True)

--- a/django/thunderstore/repository/api/experimental/tests/test_api_package_changelog.py
+++ b/django/thunderstore/repository/api/experimental/tests/test_api_package_changelog.py
@@ -1,0 +1,25 @@
+from typing import Optional
+
+import pytest
+from rest_framework.test import APIClient
+
+from thunderstore.repository.models import PackageVersion
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("changelog", (None, "# Test changelog"))
+def test_api_experimental_package_version_changelog(
+    api_client: APIClient, package_version: PackageVersion, changelog: Optional[str]
+) -> None:
+    package_version.changelog = changelog
+    package_version.save()
+    response = api_client.get(
+        f"/api/experimental/package/"
+        f"{package_version.package.owner.name}/"
+        f"{package_version.package.name}/"
+        f"{package_version.version_number}/"
+        "changelog/"
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert result["markdown"] == changelog

--- a/django/thunderstore/repository/api/experimental/urls.py
+++ b/django/thunderstore/repository/api/experimental/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from thunderstore.repository.api.experimental.views import (
     PackageDetailApiView,
     PackageListApiView,
+    PackageVersionChangelogApiView,
     PackageVersionDetailApiView,
     UploadPackageApiView,
 )
@@ -28,6 +29,11 @@ urls = [
         "package/<str:namespace>/<str:name>/<str:version>/",
         PackageVersionDetailApiView.as_view(),
         name="package-version-detail",
+    ),
+    path(
+        "package/<str:namespace>/<str:name>/<str:version>/changelog/",
+        PackageVersionChangelogApiView.as_view(),
+        name="package-version-changelog",
     ),
     path(
         "submission/submit/", SubmitPackageApiView.as_view(), name="submission.submit"

--- a/django/thunderstore/repository/api/experimental/views/__init__.py
+++ b/django/thunderstore/repository/api/experimental/views/__init__.py
@@ -1,10 +1,11 @@
 from .package import PackageDetailApiView, PackageListApiView
-from .package_version import PackageVersionDetailApiView
+from .package_version import PackageVersionChangelogApiView, PackageVersionDetailApiView
 from .upload import UploadPackageApiView
 
 __all__ = [
     "PackageListApiView",
     "PackageDetailApiView",
+    "PackageVersionChangelogApiView",
     "PackageVersionDetailApiView",
     "UploadPackageApiView",
 ]


### PR DESCRIPTION
Add an experimental API endpoint which can be used to fetch a package version's changelog, if any exists.

Refs TS-1414
Resolves #430