### PR TITLE
Implement community URL usage in templates

### DIFF
--- a/django/thunderstore/community/templates/community/packagelisting_detail.html
+++ b/django/thunderstore/community/templates/community/packagelisting_detail.html
@@ -5,6 +5,7 @@
 {% load get_urls %}
 {% load cache_until %}
 {% load encode_props %}
+{% load community_url %}
 
 {% block title %}{{ object.package.display_name }}{% endblock %}
 {% block description %}{{ object.package.description }}{% endblock %}
@@ -35,8 +36,8 @@ window.ts.PackageManagementPanel(
 
 <nav class="mt-3" aria-label="breadcrumb">
   <ol class="breadcrumb">
-    <li class="breadcrumb-item"><a href="{% url "old_urls:packages.list" %}">Packages</a></li>
-    <li class="breadcrumb-item"><a href="{% url "old_urls:packages.list_by_owner" object.package.owner.name %}">{{ object.package.owner.name }}</a></li>
+    <li class="breadcrumb-item"><a href="{% community_url "packages.list" %}">Packages</a></li>
+    <li class="breadcrumb-item"><a href="{% community_url "packages.list_by_owner" owner=object.package.owner.name %}">{{ object.package.owner.name }}</a></li>
     <li class="breadcrumb-item active" aria-current="page">{{ object.package.display_name }}</li>
   </ol>
 </nav>
@@ -115,7 +116,7 @@ window.ts.PackageManagementPanel(
                 <td>Categories</td>
                 <td>
                     {% for category in object.categories.all %}
-                        <a href="{% url "old_urls:packages.list" %}?included_categories={{ category.pk }}"><span class="badge badge-pill badge-secondary">{{ category.name }}</span></a>
+                        <a href="{% community_url "packages.list" %}?included_categories={{ category.pk }}"><span class="badge badge-pill badge-secondary">{{ category.name }}</span></a>
                     {% endfor %}
                 </td>
             </tr>

--- a/django/thunderstore/community/templates/community/packagelisting_list.html
+++ b/django/thunderstore/community/templates/community/packagelisting_list.html
@@ -3,6 +3,7 @@
 {% load arrow %}
 {% load cache_until %}
 {% load qurl %}
+{% load community_url %}
 
 {% block title %}{{ page_title }}{% endblock %}
 
@@ -65,7 +66,7 @@
                     <button class="btn btn-success w-100" type="submit">Search</button>
                 </div>
                 <div class="col-2 m-0 p-0">
-                    <a href="{% url 'old_urls:packages.list' %}" class="btn btn-success w-100">Clear</a>
+                    <a href="{% community_url 'packages.list' %}" class="btn btn-success w-100">Clear</a>
                 </div>
                 <button class="btn m-0 p-0 search-options-btn" type="button" data-toggle="collapse" data-target="#advancedSearch"
                         aria-expanded="{% if included_categories or excluded_categories or nsfw_included or deprecated_included %}true{% else %}false{% endif %}"
@@ -179,7 +180,7 @@
             </div>
             <div class="category-badge-container bg-light px-2 pt-2 flex-grow-1 d-flex flex-row flex-wrap align-items-end align-content-end ">
                 {% for category in object.categories.all %}
-                    <a href="{% url "old_urls:packages.list" %}?included_categories={{ category.pk }}"><span class="badge badge-pill badge-secondary category-badge">{{ category.name }}</span></a>
+                    <a href="{% community_url "packages.list" %}?included_categories={{ category.pk }}"><span class="badge badge-pill badge-secondary category-badge">{{ category.name }}</span></a>
                 {% endfor %}
             </div>
             <div class="bg-light p-2">

--- a/django/thunderstore/community/tests/test_community.py
+++ b/django/thunderstore/community/tests/test_community.py
@@ -123,3 +123,21 @@ def test_community_full_url(
     else:
         expected = f"/c/{community.identifier}/"
     assert community.full_url == expected
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("has_site", (False, True))
+def test_community_should_use_old_urls(
+    community: Community,
+    has_site: bool,
+) -> None:
+    if has_site:
+        CommunitySiteFactory(community=community)
+        expected = True
+    else:
+        expected = False
+    assert Community.should_use_old_urls(community) is expected
+
+
+def test_community_should_use_old_urls_no_community() -> None:
+    assert Community.should_use_old_urls(None) is True

--- a/django/thunderstore/frontend/templates/base.html
+++ b/django/thunderstore/frontend/templates/base.html
@@ -1,5 +1,5 @@
 {% load static %}
-{% load dynamic_html auth_login %}
+{% load dynamic_html auth_login community_url %}
 
 <!doctype html>
 <html lang="en">
@@ -72,11 +72,11 @@
                     </div>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="{% url 'old_urls:packages.list' %}">Browse</a>
+                    <a class="nav-link" href="{% community_url 'packages.list' %}">Browse</a>
                 </li>
                 {% if request.user.is_authenticated %}
                     <li class="nav-item">
-                        <a class="nav-link" href="{% url 'old_urls:packages.create' %}">Upload</a>
+                        <a class="nav-link" href="{% community_url 'packages.create' %}">Upload</a>
                     </li>
                 {% endif %}
                 <li class="nav-item">
@@ -89,7 +89,7 @@
                             {% endif %}
                             <a class="dropdown-item" href="{% url 'swagger' %}">API Docs</a>
                             <a class="dropdown-item" href="https://github.com/thunderstore-io/Thunderstore">GitHub Repo</a>
-                            <a class="dropdown-item" href="{% url 'old_urls:packages.create.docs' %}">Package Format Docs</a>
+                            <a class="dropdown-item" href="{% community_url 'packages.create.docs' %}">Package Format Docs</a>
                             <a class="dropdown-item" href="{% url 'tools.markdown-preview' %}">Markdown Preview</a>
                             <a class="dropdown-item" href="{% url 'tools.manifest-v1-validator' %}">Manifest Validator</a>
                         </div>
@@ -104,7 +104,7 @@
             <ul class="navbar-nav ml-auto">
                 {% if request.user.is_authenticated %}
                     <li class="nav-item">
-                        <a href="{% url 'old_urls:packages.list_by_owner' team %}" class="nav-link text-dark">{{ request.user.username }}</a>
+                        <a href="{% community_url 'packages.list_by_owner' owner=team %}" class="nav-link text-dark">{{ request.user.username }}</a>
                     </li>
                     <li class="nav-item">
                         <a href="{% url "settings.linked-accounts" %}" class="nav-link">Settings</a>
@@ -165,7 +165,7 @@
                         <h2>Developers</h2>
                         <a href="{% url 'swagger' %}">API Docs</a>
                         <a href="https://github.com/thunderstore-io/Thunderstore">GitHub Repo</a>
-                        <a href="{% url 'old_urls:packages.create.docs' %}">Package Format Docs</a>
+                        <a href="{% community_url 'packages.create.docs' %}">Package Format Docs</a>
                         <a href="{% url 'tools.markdown-preview' %}">Markdown Preview</a>
                         <a href="{% url 'tools.manifest-v1-validator' %}">Manifest Validator</a>
                     </div>

--- a/django/thunderstore/frontend/templatetags/community_url.py
+++ b/django/thunderstore/frontend/templatetags/community_url.py
@@ -1,0 +1,40 @@
+from django.template import Library, TemplateSyntaxError
+from django.template.base import Node
+from django.template.defaulttags import url
+from django.utils.html import conditional_escape
+
+from thunderstore.frontend.url_reverse import get_community_url_reverse_args
+
+register = Library()
+
+
+class CommunityURLNode(Node):
+    def __init__(self, view_name, kwargs):
+        self.view_name = view_name
+        self.kwargs = kwargs
+
+    def render(self, context):
+        from django.urls import reverse
+
+        url = reverse(
+            **get_community_url_reverse_args(
+                community=context.get("community"),
+                viewname=self.view_name.resolve(context),
+                kwargs={k: v.resolve(context) for k, v in self.kwargs.items()},
+            )
+        )
+        return conditional_escape(url) if context.autoescape else url
+
+
+@register.tag
+def community_url(parser, token):
+    url_node = url(parser, token)
+    if url_node.args:
+        raise TemplateSyntaxError("Only kwargs are supported by 'community_url'")
+    if url_node.asvar:
+        raise TemplateSyntaxError("'as' is not supported by 'community_url'")
+
+    return CommunityURLNode(
+        view_name=url_node.view_name,
+        kwargs=url_node.kwargs,
+    )

--- a/django/thunderstore/frontend/templatetags/tests/test_community_url.py
+++ b/django/thunderstore/frontend/templatetags/tests/test_community_url.py
@@ -1,0 +1,53 @@
+import pytest
+from django.template import Context, Template, TemplateSyntaxError
+from django.urls import URLPattern, reverse
+
+from thunderstore.community.factories import CommunitySiteFactory
+from thunderstore.community.models import Community
+from thunderstore.frontend.url_reverse import get_community_url_reverse_args
+from thunderstore.repository.urls import package_urls
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("url_pattern", [x for x in package_urls if hasattr(x, "name")])
+@pytest.mark.parametrize("with_site", (False, True))
+def test_tag_community_url_valid(
+    community: Community,
+    url_pattern: URLPattern,
+    with_site: bool,
+) -> None:
+    if with_site:
+        CommunitySiteFactory(community=community)
+
+    kwargs = {k: "test" for k in url_pattern.pattern.regex.groupindex.keys()}
+    args = " ".join([f"{k}='{v}'" for k, v in kwargs.items()])
+    template = (
+        f"{{% load community_url %}}{{% community_url '{url_pattern.name}' {args} %}}"
+    )
+
+    rendered = Template(template).render(Context({"community": community}))
+    expected = reverse(
+        **get_community_url_reverse_args(
+            community=community,
+            viewname=url_pattern.name,
+            kwargs=kwargs,
+        )
+    )
+
+    assert expected in rendered
+
+
+def test_tag_community_url_no_args():
+    template = "{% load community_url %}{% community_url 'packages.list' 'test' %}"
+    with pytest.raises(
+        TemplateSyntaxError, match="Only kwargs are supported by 'community_url'"
+    ):
+        Template(template).render(Context({}))
+
+
+def test_tag_community_url_no_asvar():
+    template = "{% load community_url %}{% community_url 'packages.list' as url %}"
+    with pytest.raises(
+        TemplateSyntaxError, match="'as' is not supported by 'community_url'"
+    ):
+        Template(template).render(Context({}))

--- a/django/thunderstore/frontend/tests/test_url_reverse.py
+++ b/django/thunderstore/frontend/tests/test_url_reverse.py
@@ -1,0 +1,44 @@
+import pytest
+from django.urls import URLPattern, reverse
+
+from thunderstore.community.factories import CommunitySiteFactory
+from thunderstore.community.models import Community
+from thunderstore.frontend.url_reverse import get_community_url_reverse_args
+from thunderstore.repository.urls import package_urls
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("url_pattern", [x for x in package_urls if hasattr(x, "name")])
+@pytest.mark.parametrize("with_site", (False, True))
+def test_get_community_url_reverse_args(
+    community: Community,
+    url_pattern: URLPattern,
+    with_site: bool,
+) -> None:
+
+    # Use "test" for all URL kwargs if required
+    required_kwargs = {k: "test" for k in url_pattern.pattern.regex.groupindex.keys()}
+    required_kwargs = required_kwargs if required_kwargs else None
+
+    if with_site:
+        CommunitySiteFactory(community=community)
+        expected_kwargs = required_kwargs
+        expected_prefix = "old_urls:"
+    else:
+        expected_kwargs = {
+            **(required_kwargs or {}),
+            **{"community_identifier": community.identifier},
+        }
+        expected_prefix = "communities:community:"
+
+    result = get_community_url_reverse_args(
+        community=community,
+        viewname=url_pattern.name,
+        kwargs=required_kwargs,
+    )
+
+    assert result == {
+        "viewname": f"{expected_prefix}{url_pattern.name}",
+        "kwargs": expected_kwargs,
+    }
+    assert reverse(**result) is not None

--- a/django/thunderstore/frontend/url_reverse.py
+++ b/django/thunderstore/frontend/url_reverse.py
@@ -1,0 +1,23 @@
+from typing import Dict, Optional
+
+from thunderstore.community.models import Community
+
+
+def get_community_url_reverse_args(
+    community: Optional[Community],
+    viewname: str,
+    kwargs: Optional[Dict] = None,
+) -> Dict:
+    if Community.should_use_old_urls(community):
+        return {
+            "viewname": f"old_urls:{viewname}",
+            "kwargs": kwargs,
+        }
+    else:
+        if kwargs is None:
+            kwargs = dict()
+        kwargs["community_identifier"] = community.identifier
+        return {
+            "viewname": f"communities:community:{viewname}",
+            "kwargs": kwargs,
+        }

--- a/django/thunderstore/repository/templates/repository/package_create.html
+++ b/django/thunderstore/repository/templates/repository/package_create.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load community_url %}
 
 {% block title %}Upload{% endblock %}
 
@@ -11,14 +12,14 @@
 <div class="mb-3 mt-3 alert alert-info" role="alert">
     <p class="mb-0">
         Looking for package format documentation?
-        <a href="{% url 'old_urls:packages.create.docs' %}">You can find it here</a>
+        <a href="{% community_url 'packages.create.docs' %}">You can find it here</a>
     </p>
 </div>
 <div class="mb-3 mt-3 alert alert-info" role="alert">
     <ul class="mb-0 pl-3">
         <li>
             New upload handler not working?
-            <a href="{% url 'old_urls:packages.create.old' %}">Try the old one here</a>
+            <a href="{% community_url 'packages.create.old' %}">Try the old one here</a>
         </li>
         <li>
             Preview your readme before upload using the

--- a/django/thunderstore/repository/templates/repository/package_create_old.html
+++ b/django/thunderstore/repository/templates/repository/package_create_old.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load community_url %}
 
 {% block title %}Upload{% endblock %}
 
@@ -11,12 +12,12 @@
 <div class="mb-3 mt-3 alert alert-info" role="alert">
     <p class="mb-0">
         Looking for package format documentation?
-        <a href="{% url 'old_urls:packages.create.docs' %}">You can find it here</a>
+        <a href="{% community_url 'packages.create.docs' %}">You can find it here</a>
     </p>
 </div>
 <div class="mb-3 mt-3 alert alert-info" role="alert">
     <p class="mb-0">
-        <a href="{% url 'old_urls:packages.create' %}">Looking for the new upload handler?</a>
+        <a href="{% community_url 'packages.create' %}">Looking for the new upload handler?</a>
     </p>
 </div>
 <form class="mt-2" method="post" enctype="multipart/form-data" novalidate>

--- a/django/thunderstore/repository/templates/repository/packageversion_detail.html
+++ b/django/thunderstore/repository/templates/repository/packageversion_detail.html
@@ -3,6 +3,7 @@
 {% load arrow %}
 {% load markdownify %}
 {% load cache_until %}
+{% load community_url %}
 
 {% block title %}{{ object.display_name }}{% endblock %}
 {% block description %}{{ object.description }}{% endblock %}
@@ -20,12 +21,12 @@
 {% endblock %}
 
 {% block content %}
-{% cache_until "any_package_updated" "mod-version-detail" 300 object.pk %}
+{% cache_until "any_package_updated" "mod-version-detail" 300 object.pk community_identifier %}
 
 <nav class="mt-3" aria-label="breadcrumb">
   <ol class="breadcrumb">
-    <li class="breadcrumb-item"><a href="{% url "old_urls:packages.list" %}">Packages</a></li>
-    <li class="breadcrumb-item"><a href="{% url "old_urls:packages.list_by_owner" object.owner.name %}">{{ object.owner.name }}</a></li>
+    <li class="breadcrumb-item"><a href="{% community_url "packages.list" %}">Packages</a></li>
+    <li class="breadcrumb-item"><a href="{% community_url "packages.list_by_owner" owner=object.owner.name %}">{{ object.owner.name }}</a></li>
     {% if object.package.is_effectively_active %}
     <li class="breadcrumb-item"><a href="{{ object.package.get_absolute_url }}">{{ object.package.display_name }}</a></li>
     {% else %}


### PR DESCRIPTION
Implement a template tag that will generate appropriate community-specific URLs depending on whether the community has a CommunitySite associated with it or not.

Refs TS-1424