### PR TITLE
Make PackageListing URLs community-aware

### DIFF
--- a/django/thunderstore/community/models/package_listing.py
+++ b/django/thunderstore/community/models/package_listing.py
@@ -12,6 +12,7 @@ from thunderstore.community.consts import PackageListingReviewStatus
 from thunderstore.core.mixins import TimestampMixin
 from thunderstore.core.types import UserType
 from thunderstore.core.utils import check_validity
+from thunderstore.frontend.url_reverse import get_community_url_reverse_args
 
 if TYPE_CHECKING:
     from thunderstore.community.models import PackageCategory
@@ -86,61 +87,36 @@ class PackageListing(TimestampMixin, models.Model):
     def __str__(self):
         return self.package.name
 
-    # TODO: Remove in the end of TS-272
     def get_absolute_url(self):
         return reverse(
-            "old_urls:packages.detail",
-            kwargs={"owner": self.package.owner.name, "name": self.package.name},
+            **get_community_url_reverse_args(
+                community=self.community,
+                viewname="packages.detail",
+                kwargs={"owner": self.package.owner.name, "name": self.package.name},
+            )
         )
 
-    @cached_property
-    def get_absolute_url_with_community_identifier(self):
-        return reverse(
-            "communities:community:packages.detail",
-            kwargs={
-                "owner": self.package.owner.name,
-                "name": self.package.name,
-                "community_identifier": self.community.identifier,
-            },
-        )
-
-    # TODO: Remove in the end of TS-272
     @cached_property
     def owner_url(self):
         return reverse(
-            "old_urls:packages.list_by_owner", kwargs={"owner": self.package.owner.name}
+            **get_community_url_reverse_args(
+                community=self.community,
+                viewname="packages.list_by_owner",
+                kwargs={"owner": self.package.owner.name},
+            )
         )
 
-    @cached_property
-    def owner_url_with_community_identifier(self):
-        return reverse(
-            "communities:community:packages.list_by_owner",
-            kwargs={
-                "owner": self.package.owner.name,
-                "community_identifier": self.community.identifier,
-            },
-        )
-
-    # TODO: Remove in the end of TS-272
     @cached_property
     def dependants_url(self):
         return reverse(
-            "old_urls:packages.list_by_dependency",
-            kwargs={
-                "owner": self.package.owner.name,
-                "name": self.package.name,
-            },
-        )
-
-    @cached_property
-    def dependants_url_with_community_identifier(self):
-        return reverse(
-            "communities:community:packages.list_by_dependency",
-            kwargs={
-                "owner": self.package.owner.name,
-                "name": self.package.name,
-                "community_identifier": self.community.identifier,
-            },
+            **get_community_url_reverse_args(
+                community=self.community,
+                viewname="packages.list_by_dependency",
+                kwargs={
+                    "owner": self.package.owner.name,
+                    "name": self.package.name,
+                },
+            )
         )
 
     @cached_property

--- a/django/thunderstore/community/templates/community/packagelisting_list.html
+++ b/django/thunderstore/community/templates/community/packagelisting_list.html
@@ -159,7 +159,7 @@
                     </div>
                 </div>
                 {% endif %}
-                <a href="{{ object.package.get_absolute_url }}">
+                <a href="{{ object.get_absolute_url }}">
                     <img class="w-100" src="{% thumbnail object.package.icon 256x256 crop %}" alt="{{ object.package }} icon">
                 </a>
             </div>

--- a/django/thunderstore/community/tests/test_package_listing.py
+++ b/django/thunderstore/community/tests/test_package_listing.py
@@ -4,7 +4,7 @@ from django.db import IntegrityError
 
 from conftest import TestUserTypes
 from thunderstore.community.consts import PackageListingReviewStatus
-from thunderstore.community.factories import CommunityFactory
+from thunderstore.community.factories import CommunityFactory, CommunitySiteFactory
 from thunderstore.community.models import (
     Community,
     CommunityMemberRole,
@@ -16,33 +16,93 @@ from thunderstore.repository.models import Package, TeamMember, TeamMemberRole
 
 
 @pytest.mark.django_db
-def test_package_listing_get_absolute_url_with_community_identifier(
+@pytest.mark.parametrize("with_site", (False, True))
+def test_package_listing_get_absolute_url(
     active_package_listing: PackageListing,
+    with_site: bool,
 ) -> None:
-    assert (
-        active_package_listing.get_absolute_url_with_community_identifier
-        == f"/c/{active_package_listing.community.identifier}/p/{active_package_listing.package.owner.name}/{active_package_listing.package.name}/"
-    )
+    if with_site:
+        CommunitySiteFactory(community=active_package_listing.community)
+        expected = "/".join(
+            [
+                "/package",
+                active_package_listing.package.owner.name,
+                active_package_listing.package.name,
+                "",
+            ]
+        )
+    else:
+        expected = "/".join(
+            [
+                "/c",
+                active_package_listing.community.identifier,
+                "p",
+                active_package_listing.package.owner.name,
+                active_package_listing.package.name,
+                "",
+            ]
+        )
+
+    assert active_package_listing.get_absolute_url() == expected
 
 
 @pytest.mark.django_db
-def test_package_listing_owner_url_with_community_identifier(
+@pytest.mark.parametrize("with_site", (False, True))
+def test_package_listing_owner_url(
     active_package_listing: PackageListing,
+    with_site: bool,
 ) -> None:
-    assert (
-        active_package_listing.owner_url_with_community_identifier
-        == f"/c/{active_package_listing.community.identifier}/p/{active_package_listing.package.owner.name}/"
-    )
+    if with_site:
+        CommunitySiteFactory(community=active_package_listing.community)
+        expected = "/".join(
+            [
+                "/package",
+                active_package_listing.package.owner.name,
+                "",
+            ]
+        )
+    else:
+        expected = "/".join(
+            [
+                "/c",
+                active_package_listing.community.identifier,
+                "p",
+                active_package_listing.package.owner.name,
+                "",
+            ]
+        )
+    assert active_package_listing.owner_url == expected
 
 
 @pytest.mark.django_db
-def test_package_listing_dependants_url_with_community_identifier(
+@pytest.mark.parametrize("with_site", (False, True))
+def test_package_listing_dependants_url(
     active_package_listing: PackageListing,
+    with_site: bool,
 ) -> None:
-    assert (
-        active_package_listing.dependants_url_with_community_identifier
-        == f"/c/{active_package_listing.community.identifier}/p/{active_package_listing.package.owner.name}/{active_package_listing.package.name}/dependants/"
-    )
+    if with_site:
+        CommunitySiteFactory(community=active_package_listing.community)
+        expected = "/".join(
+            [
+                "/package",
+                active_package_listing.package.owner.name,
+                active_package_listing.package.name,
+                "dependants/",
+            ]
+        )
+    else:
+        expected = "/".join(
+            [
+                "/c",
+                active_package_listing.community.identifier,
+                "p",
+                active_package_listing.package.owner.name,
+                active_package_listing.package.name,
+                "dependants/",
+            ]
+        )
+
+    assert active_package_listing.dependants_url == expected
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Make the URL helper methods of PackageListing objects community-aware and use the new URL schema if the community they belong to has them enabled.

Refs TS-1426