### PR TITLE
Speculative fix to upload page error handling bug

### DIFF
--- a/builder/src/api.ts
+++ b/builder/src/api.ts
@@ -9,7 +9,7 @@ type JSONValue =
     | { [key: string]: JSONValue };
 
 export const stringifyError = (
-    val: JSONValue,
+    val: JSONValue | undefined,
     parents?: string[]
 ): string[] => {
     if (val === null) {
@@ -30,7 +30,9 @@ export const stringifyError = (
         return result;
     } else {
         return [
-            `${parents?.join(": ")}${parents ? ": " : ""}${val.toString()}`,
+            `${parents?.join(": ")}${parents ? ": " : ""}${
+                val ? val.toString() : "Unknown error"
+            }`,
         ];
     }
 };

--- a/builder/src/state/FileUpload.ts
+++ b/builder/src/state/FileUpload.ts
@@ -55,6 +55,7 @@ export class FileUpload {
 
     @action
     private logErrors(...errors: string[]) {
+        if (!errors || errors.length == 0) return;
         this.uploadErrors.push(...errors);
         console.error(errors);
     }
@@ -65,7 +66,7 @@ export class FileUpload {
             const flattened = stringifyError(error.errorObject);
             this.logErrors(...flattened);
         } else {
-            this.logErrors(error.message);
+            this.logErrors(error.message || "Unknown error");
             console.error(error, error.stack);
         }
     }


### PR DESCRIPTION
A user reported having their entire upload page break when attempting to upload a package, and the culprit for the breakage seems to be an undefined value ending in the list of errors when it should only contain strings.

The root cause was the user's network configuration eating the API response entirely, which somehow resulted in the above scenario and broke the page.

This commit is a speculative fix which should hopefully prevent similar breakage in the future

Refs TS-1479