### PR TITLE
Overwrite full community context in CommunityMixin

### DIFF
--- a/django/thunderstore/community/context_processors.py
+++ b/django/thunderstore/community/context_processors.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from django.conf import settings
 from django.db.models import Count
 from django.templatetags.static import static
@@ -5,10 +7,11 @@ from django.templatetags.static import static
 from thunderstore.community.models.community import Community
 
 
-def community_site(request):
-    if hasattr(request, "community") and request.community:
-        community = request.community
+def get_community_context(community: Optional[Community]):
+    if community:
         result = {
+            "community": community,
+            "community_identifier": community.identifier,
             "site_name": settings.SITE_NAME,
             "site_slogan": community.slogan or "",
             "site_description": community.description or "",
@@ -18,7 +21,7 @@ def community_site(request):
         if community.icon:
             url = community.icon.url
             if not (url.startswith("http://") or url.startswith("https://")):
-                url = f"{request.scheme}://{request.get_host()}{url}"
+                url = f"{settings.PROTOCOL}{settings.PRIMARY_HOST}{url}"
             result.update(
                 {
                     "site_icon": url,
@@ -29,7 +32,7 @@ def community_site(request):
         else:
             result.update(
                 {
-                    "site_icon": f"{request.scheme}://{request.get_host()}{static('icon.png')}",
+                    "site_icon": f"{settings.PROTOCOL}{settings.PRIMARY_HOST}{static('icon.png')}",
                     "site_icon_width": "1000",
                     "site_icon_height": "1000",
                 }
@@ -37,15 +40,21 @@ def community_site(request):
         return result
     else:
         return {
+            "community": None,
+            "community_identifier": None,
             "site_name": settings.SITE_NAME,
             "site_slogan": settings.SITE_SLOGAN,
             "site_description": settings.SITE_DESCRIPTION,
-            "site_icon": f"{request.scheme}://{request.get_host()}{static('icon.png')}",
+            "site_icon": f"{settings.PROTOCOL}{settings.PRIMARY_HOST}{static('icon.png')}",
             "site_icon_width": "1000",
             "site_icon_height": "1000",
             "site_discord_url": "https://discord.gg/5MbXZvd",
             "site_wiki_url": "https://github.com/risk-of-thunder/R2Wiki/wiki",
         }
+
+
+def community_site(request):
+    return get_community_context(getattr(request, "community", None))
 
 
 def selectable_communities(request):

--- a/django/thunderstore/frontend/templates/base.html
+++ b/django/thunderstore/frontend/templates/base.html
@@ -30,9 +30,9 @@
         <script src="{% static 'js/all.js' %}"></script>
     </head>
     <body>
-        {% if request.community.background_image %}
+        {% if community.background_image %}
             <div class="background">
-                <div class="image" style="background: url({{ request.community.background_image.url }});"></div>
+                <div class="image" style="background: url({{ community.background_image.url }});"></div>
                 <div class="tint"></div>
             </div>
         {% endif %}

--- a/django/thunderstore/repository/mixins.py
+++ b/django/thunderstore/repository/mixins.py
@@ -1,6 +1,7 @@
 from django.http import Http404
 from django.utils.functional import cached_property
 
+from thunderstore.community.context_processors import get_community_context
 from thunderstore.community.models.community import Community
 from thunderstore.community.models.community_site import CommunitySite
 
@@ -26,8 +27,7 @@ class CommunityMixin:
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
-        context["community_identifier"] = self.community_identifier
-        context["community"] = self.community
+        context.update(get_community_context(self.community))
         return context
 
     def get_serializer_context(self):

--- a/django/thunderstore/repository/templates/repository/package_create_old.html
+++ b/django/thunderstore/repository/templates/repository/package_create_old.html
@@ -52,8 +52,8 @@
                     <div class="w-100">
                         {# Manual rendering due to different set being displayed than validated #}
                         <select class="slimselect-lg" name="communities" id="{{ form.communities.auto_id }}" multiple>
-                            {% for community in selectable_communities %}
-                            <option value="{{ community.identifier }}" {% if community == request.community %}selected{% endif %}>{{ community.name }}</option>
+                            {% for opt in selectable_communities %}
+                            <option value="{{ opt.identifier }}" {% if opt == community %}selected{% endif %}>{{ opt.name }}</option>
                             {% endfor %}
                         </select>
                     </div>
@@ -68,7 +68,7 @@
                         {{ form.categories }}
                         <p class="mt-1 mb-2">
                             Note that the selected categories are applied only to the
-                            <kbd class="text-info">{{ request.community.name }}</kbd> community.
+                            <kbd class="text-info">{{ community.name }}</kbd> community.
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
Have the CommunityMixin overwrite the full community context rather than only parts of it. Also remove some reliance on request variables in places where context variables can be relied on instead.

Refs TS-1496