### PR TITLE
Improve community context handling for upload page

### DIFF
--- a/builder/src/upload.tsx
+++ b/builder/src/upload.tsx
@@ -82,13 +82,12 @@ enum SubmissionStatus {
 
 interface SubmissionFormProps {
     onSubmissionComplete?: (result: PackageSubmissionResult) => void;
+    currentCommunity: Community;
 }
 const SubmissionForm: React.FC<SubmissionFormProps> = observer((props) => {
+    const currentCommunity = props.currentCommunity;
     const [communities, setCommunities] = useState<Community[] | null>(null);
     const [categories, setCategories] = useState<PackageCategory[] | null>(
-        null
-    );
-    const [currentCommunity, setCurrentCommunity] = useState<Community | null>(
         null
     );
     const [teams, setTeams] = useState<string[] | null>(null);
@@ -316,11 +315,8 @@ const SubmissionForm: React.FC<SubmissionFormProps> = observer((props) => {
             setCommunities(r.results)
         );
         enumerateCommunities([]);
+        enumerateCategories([], currentCommunity.identifier);
         ExperimentalApi.currentUser().then((r) => setTeams(r.teams));
-        ExperimentalApi.currentCommunity().then((community) => {
-            setCurrentCommunity(community);
-            enumerateCategories([], community.identifier);
-        });
     }, []);
 
     return (
@@ -549,7 +545,10 @@ export const SubmissionResults: React.FC<SubmissionResultsProps> = ({
     );
 };
 
-export const UploadPage: React.FC = () => {
+interface UploadPageProps {
+    currentCommunity: Community;
+}
+export const UploadPage: React.FC<UploadPageProps> = (props) => {
     const [
         submissionResult,
         setSubmissionResult,
@@ -567,6 +566,7 @@ export const UploadPage: React.FC = () => {
                 <div className="card-header">Submit Package</div>
                 <div className="card-body py-2 px-2">
                     <SubmissionForm
+                        currentCommunity={props.currentCommunity}
                         onSubmissionComplete={onSubmissionComplete}
                     />
                 </div>

--- a/django/thunderstore/repository/templates/repository/package_create.html
+++ b/django/thunderstore/repository/templates/repository/package_create.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load community_url %}
+{% load encode_props %}
 
 {% block title %}Upload{% endblock %}
 
@@ -34,7 +35,10 @@
 
 <div id="upload-page"></div>
 <script type="text/javascript">
-window.ts.UploadPage(document.getElementById("upload-page"));
+window.ts.UploadPage(
+    document.getElementById("upload-page"),
+    {{ upload_page_props|encode_props }}
+);
 </script>
 
 {% endblock %}

--- a/django/thunderstore/repository/templates/repository/package_create_old.html
+++ b/django/thunderstore/repository/templates/repository/package_create_old.html
@@ -63,20 +63,6 @@
 
             <div class="field-wrapper">
                 <div class="field-row">
-                    <label for="{{ form.categories.id_for_label }}">Categories</label>
-                    <div class="w-100">
-                        {{ form.categories }}
-                        <p class="mt-1 mb-2">
-                            Note that the selected categories are applied only to the
-                            <kbd class="text-info">{{ community.name }}</kbd> community.
-                        </p>
-                    </div>
-                </div>
-                <div class="text-danger field-errors">{{ form.categories.errors }}</div>
-            </div>
-
-            <div class="field-wrapper">
-                <div class="field-row">
                     <label for="{{ form.has_nsfw_content.id_for_label }}">Contains NSFW content</label>
                     {{ form.has_nsfw_content }}
                 </div>
@@ -89,9 +75,6 @@
 
 <script type="text/javascript">
 
-new SlimSelect({
-    select: "#{{ form.categories.auto_id }}"
-});
 new SlimSelect({
     select: "#{{ form.team.auto_id }}"
 });

--- a/django/thunderstore/repository/views/repository.py
+++ b/django/thunderstore/repository/views/repository.py
@@ -26,6 +26,7 @@ from thunderstore.community.models import (
     PackageListing,
     PackageListingSection,
 )
+from thunderstore.frontend.api.experimental.serializers.views import CommunitySerializer
 from thunderstore.frontend.url_reverse import get_community_url_reverse_args
 from thunderstore.repository.mixins import CommunityMixin
 from thunderstore.repository.models import (
@@ -580,6 +581,14 @@ class PackageVersionDetailView(CommunityMixin, DetailView):
 @method_decorator(ensure_csrf_cookie, name="dispatch")
 class PackageCreateView(CommunityMixin, TemplateView):
     template_name = "repository/package_create.html"
+
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        serializer = CommunitySerializer(self.community)
+        context["upload_page_props"] = {
+            "currentCommunity": serializer.data,
+        }
+        return context
 
     def dispatch(self, *args, **kwargs):
         if not self.request.user.is_authenticated:


### PR DESCRIPTION
Improve the way the upload pages handle community context and make them less tightly bound to the domain based community selection, or any specific communities at all.

This is not a final iteration of these changes, but it should suffice to make them usable in production.

Refs TS-1497