### PR TITLE
Update website footer

### DIFF
--- a/django/thunderstore/frontend/templates/base.html
+++ b/django/thunderstore/frontend/templates/base.html
@@ -172,7 +172,7 @@
                 </div>
             </div>
             <div class="container footer_links">
-                <p>Thunderstore 2022</p>
+                <p>Thunderstore 2023</p>
                 <div>
                     <a class="nav-link" href="https://discord.gg/UWpWhjZken"><span class="fab fa-discord"></span></a>
                 </div>

--- a/django/thunderstore/frontend/tests/data/scripts.html
+++ b/django/thunderstore/frontend/tests/data/scripts.html
@@ -301,7 +301,7 @@ window.ts.PackageManagementPanel(
                 </div>
             </div>
             <div class="container footer_links">
-                <p>Thunderstore 2022</p>
+                <p>Thunderstore 2023</p>
                 <div>
                     <a class="nav-link" href="https://discord.gg/UWpWhjZken"><span class="fab fa-discord"></span></a>
                 </div>


### PR DESCRIPTION
Update the website footer year number to 2023. Not making it automatic given that the current frontend should be gone before 2024.

Refs TS-1421