### PR TITLE
Update dynamic HTML to use community context

### DIFF
--- a/django/thunderstore/frontend/templatetags/dynamic_html.py
+++ b/django/thunderstore/frontend/templatetags/dynamic_html.py
@@ -18,7 +18,8 @@ def get_dynamic_html_content(community, placement):
 
 @register.simple_tag(takes_context=True)
 def dynamic_html(context, placement):
-    if not hasattr(context["request"], "community"):
-        return ""
-    community = context["request"].community
+    community = context.get("community", None)
+    request = context["request"]
+    if not community and hasattr(request, "community"):
+        community = request.community
     return mark_safe(get_dynamic_html_content(community, placement))


### PR DESCRIPTION
Update the dynamic HTML template tag to read community from the template context first and only fall back to the request if not found from context.

Also remove the requirement for having a community available in the
context, as some placements can be global.

Refs TS-1511