### PR TITLE
Increase max dependency count to 1000

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/isort
-    rev: "5.6.4"
+    rev: "5.12.0"
     hooks:
       - id: isort
         exclude: "^(loadtest)"

--- a/django/thunderstore/repository/package_manifest.py
+++ b/django/thunderstore/repository/package_manifest.py
@@ -34,7 +34,7 @@ class ManifestV1Serializer(serializers.Serializer):
     )
     dependencies = serializers.ListField(
         child=DependencyField(),
-        max_length=250,
+        max_length=1000,
         allow_empty=True,
     )
 

--- a/django/thunderstore/repository/tests/test_package_manifest.py
+++ b/django/thunderstore/repository/tests/test_package_manifest.py
@@ -146,7 +146,7 @@ def test_manifest_v1_serializer_unresolved_dependency(
 @pytest.mark.django_db
 def test_manifest_v1_serializer_too_many_dependencies(user, manifest_v1_data):
     team = Team.get_or_create_for_user(user)
-    reference_strings = [f"user-package-{i}.{i}.{i}" for i in range(251)]
+    reference_strings = [f"user-package-{i}.{i}.{i}" for i in range(1001)]
     manifest_v1_data["dependencies"] = reference_strings
     serializer = ManifestV1Serializer(
         user=user,
@@ -162,7 +162,7 @@ def test_manifest_v1_serializer_too_many_dependencies(user, manifest_v1_data):
     ]
     assert serializer.is_valid() is False
     assert len(serializer.errors["dependencies"]) == 1
-    assert "Ensure this field has no more than 250 elements." in str(
+    assert "Ensure this field has no more than 1000 elements." in str(
         serializer.errors["dependencies"][0]
     )
 


### PR DESCRIPTION
Increase the maximum amount of dependencies for a package to 1000. The number is arbitrary as before, but the 250 limit was crossed with a real use case.

No refs