### PR TITLE
Filter out deactivated teams from views

### DIFF
--- a/django/thunderstore/account/forms.py
+++ b/django/thunderstore/account/forms.py
@@ -13,7 +13,7 @@ class CreateServiceAccountForm(forms.Form):
         super().__init__(*args, **kwargs)
         self.user = user
         self.fields["team"] = forms.ModelChoiceField(
-            queryset=Team.objects.filter(members__user=user),
+            queryset=Team.objects.filter(members__user=user, is_active=True),
         )
 
     def clean_team(self) -> Team:

--- a/django/thunderstore/repository/api/experimental/serializers/main.py
+++ b/django/thunderstore/repository/api/experimental/serializers/main.py
@@ -131,7 +131,7 @@ class PackageUploadAuthorNameField(serializers.SlugRelatedField):
 
     def get_queryset(self):
         return Team.objects.exclude(
-            ~Q(members__user=self.context["request"].user),
+            ~Q(members__user=self.context["request"].user) | Q(is_active=False)
         )
 
 

--- a/django/thunderstore/repository/context_processors.py
+++ b/django/thunderstore/repository/context_processors.py
@@ -2,7 +2,7 @@ def team(request):
     if not (hasattr(request, "user") and request.user.is_authenticated):
         return {}
     name = request.user.username
-    membership = request.user.teams.first()
+    membership = request.user.teams.filter(team__is_active=True).first()
     if membership:
         name = membership.team.name
     return {"team": name}

--- a/django/thunderstore/repository/package_upload.py
+++ b/django/thunderstore/repository/package_upload.py
@@ -70,6 +70,7 @@ class PackageUploadForm(forms.ModelForm):
         # TODO: Query only teams where the user has upload permission
         self.fields["team"].queryset = Team.objects.filter(
             members__user=self.user,
+            is_active=True,
         )
         # TODO: Move this to the frontent code somehow
         self.fields["team"].widget.attrs["class"] = "slimselect-lg"

--- a/django/thunderstore/repository/views/team_settings.py
+++ b/django/thunderstore/repository/views/team_settings.py
@@ -37,13 +37,15 @@ class SettingsTeamListView(RequireAuthenticationMixin, TemplateView):
         context = super().get_context_data(*args, **kwargs)
         context["page_title"] = "Teams"
         context["team_memberships"] = TeamMember.objects.filter(
-            user=self.request.user
+            user=self.request.user,
+            team__is_active=True,
         ).select_related("team")
         return context
 
 
 class TeamDetailView(DetailView):
     model = Team
+    queryset = Team.objects.filter(is_active=True)
     slug_field = "name"
     slug_url_kwarg = "name"
     context_object_name = "team"
@@ -89,7 +91,8 @@ class SettingsTeamDetailView(TeamDetailView, UserFormKwargs, FormView):
         kwargs = super().get_form_kwargs()
         if "demote" in self.request.POST or "promote" in self.request.POST:
             instance = TeamMember.objects.filter(
-                pk=self.request.POST.get("membership")
+                pk=self.request.POST.get("membership"),
+                team__is_active=True,
             ).first()
             if "membership" not in self.request.POST:
                 raise SuspiciousOperation("Invalid action; membership not found")

--- a/django/thunderstore/social/api/experimental/views/current_user.py
+++ b/django/thunderstore/social/api/experimental/views/current_user.py
@@ -18,7 +18,9 @@ class CurrentUserExperimentalApiView(APIView):
             rated_packages = request.user.package_ratings.select_related(
                 "package"
             ).values_list("package__uuid4", flat=True)
-            teams = request.user.teams.values_list("team__name")
+            teams = request.user.teams.filter(team__is_active=True).values_list(
+                "team__name"
+            )
             teams = [team[0] for team in teams]
         return Response(
             {


### PR DESCRIPTION
Deactivated teams are unusable, yet they're still being shown to the users as if they were. This commit changes the views to exclude deactivated views from views where they would normally be visible in.

In practice, this allows for teams to be archived without removing their members at the time of archival. This could be useful if a team needs to later be restored and it would otherwise be unclear who is the owner of the team.

It would be better to have a dedicated field for archival status, but that's beyond the scope of this PR.

Refs TS-1622