### PR TITLE
Enforce proper website_url formatting in manifests

### DIFF
--- a/django/thunderstore/repository/package_manifest.py
+++ b/django/thunderstore/repository/package_manifest.py
@@ -1,3 +1,4 @@
+from django.core.validators import URLValidator
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
@@ -27,6 +28,7 @@ class ManifestV1Serializer(serializers.Serializer):
     website_url = StrictCharField(
         max_length=PackageVersion._meta.get_field("website_url").max_length,
         allow_blank=True,
+        validators=[URLValidator(schemes=["http", "https", "mailto", "ipfs"])],
     )
     description = StrictCharField(
         max_length=PackageVersion._meta.get_field("description").max_length,

--- a/django/thunderstore/repository/tests/test_package_manifest.py
+++ b/django/thunderstore/repository/tests/test_package_manifest.py
@@ -242,15 +242,32 @@ def test_manifest_v1_serializer_version_number_validation(
 @pytest.mark.parametrize(
     "url, error",
     [
-        ["asdiasdhuasd", ""],
+        ["asdiasdhuasd", "Enter a valid URL."],
         ["https://google.com/", ""],
         ["", ""],
-        ["a", ""],
-        ["some not valid website URL", ""],
+        ["a", "Enter a valid URL."],
+        ["some not valid website URL", "Enter a valid URL."],
+        ["http://google.com/", ""],
+        ["https://google.com/", ""],
+        ["mailto://google.com/", ""],
+        ["ipfs://google.com/", ""],
         [None, "This field may not be null."],
-        ["a" * PackageVersion._meta.get_field("website_url").max_length, ""],
+        [
+            "a" * PackageVersion._meta.get_field("website_url").max_length,
+            "Enter a valid URL.",
+        ],
         [
             "a" * PackageVersion._meta.get_field("website_url").max_length + "b",
+            "Enter a valid URL.",
+        ],
+        [
+            "https://example.org/"
+            + ("a" * (PackageVersion._meta.get_field("website_url").max_length - 20)),
+            "",
+        ],
+        [
+            "https://example.org/"
+            + ("a" * (PackageVersion._meta.get_field("website_url").max_length - 19)),
             "Ensure this field has no more than 1024 characters.",
         ],
     ],


### PR DESCRIPTION
Make sure the package manifest.json website_url field is a properly formatted URL and uses a known valid URL scheme. This should prevent issues caused by incorrectly formatted links for downstream consumers, although some older packages might of course contain incorrectly formatted links.

Refs #840