### PR TITLE
Add feature flag for the new CS API

### DIFF
--- a/django/pytest.ini
+++ b/django/pytest.ini
@@ -13,3 +13,4 @@ env =
     AUTH_EXCLUSIVE_HOST=auth.testsite.test
     SESSION_COOKIE_DOMAIN=testsite.test
     AWS_S3_CUSTOM_DOMAIN=minio:9000/thunderstore
+    IS_CYBERSTORM_ENABLED=True

--- a/django/thunderstore/core/api_urls.py
+++ b/django/thunderstore/core/api_urls.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.urls import include, path
 
 from thunderstore.api.urls import cyberstorm_urls
@@ -57,8 +58,12 @@ api_urls = [
         "experimental/",
         include((api_experimental_urls, "experimental"), namespace="experimental"),
     ),
-    path(
-        "cyberstorm/",
-        include((cyberstorm_urls, "cyberstorm"), namespace="cyberstorm"),
-    ),
 ]
+
+if settings.IS_CYBERSTORM_ENABLED:
+    api_urls.append(
+        path(
+            "cyberstorm/",
+            include((cyberstorm_urls, "cyberstorm"), namespace="cyberstorm"),
+        )
+    )

--- a/django/thunderstore/core/settings.py
+++ b/django/thunderstore/core/settings.py
@@ -126,6 +126,7 @@ env = environ.Env(
         str,
         "https://gcdn.thunderstore.io/static/dev/schema/ecosystem-schema.0.0.2.json",
     ),
+    IS_CYBERSTORM_ENABLED=(bool, False),
 )
 
 ALWAYS_RAISE_EXCEPTIONS = env.bool("ALWAYS_RAISE_EXCEPTIONS")
@@ -767,5 +768,9 @@ OAUTH_SHARED_SECRET = env.str("OAUTH_SHARED_SECRET")
 
 # Mod manager client id
 OVERWOLF_CLIENT_ID = env.str("OVERWOLF_CLIENT_ID")
+
+# Cyberstorm APIs enabled?
+IS_CYBERSTORM_ENABLED = env.bool("IS_CYBERSTORM_ENABLED")
+
 
 globals().update(plugin_registry.get_django_settings(globals()))


### PR DESCRIPTION
As the upcoming CS API hasn't been reviewed yet for production use, add a feature flag that can be used to toggle it on or off depending on the environment.

Tests will be run with them enabled.