### PR TITLE
Fix the team creation view

### DIFF
--- a/django/thunderstore/frontend/views.py
+++ b/django/thunderstore/frontend/views.py
@@ -44,7 +44,7 @@ class ManifestV1ValidatorView(TemplateView):
     template_name = "frontend/manifest_v1_validator.html"
 
 
-class SettingsViewMixin(TemplateView):
+class SettingsViewMixin:
     def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:
         context = super().get_context_data(**kwargs)
         context["setting_links"] = plugin_registry.get_settings_links()

--- a/django/thunderstore/repository/tests/test_views.py
+++ b/django/thunderstore/repository/tests/test_views.py
@@ -437,6 +437,25 @@ def test_service_account_creation(client, community_site, team, team_owner):
 
 
 @pytest.mark.django_db
+def test_team_creation_view(client, community_site, team_owner):
+    client.force_login(team_owner.user)
+
+    response = client.get(
+        reverse("settings.teams.create"),
+        HTTP_HOST=community_site.site.domain,
+    )
+    assert response.status_code == 200
+    assert b"Enter the name of the team you wish to create." in response.content
+
+    response = client.post(
+        reverse("settings.teams.create"),
+        {"name": "TeamName"},
+        HTTP_HOST=community_site.site.domain,
+    )
+    assert response.status_code == 302
+
+
+@pytest.mark.django_db
 def test_team_settings_donation_link_view(
     client: APIClient,
     community_site: CommunitySite,


### PR DESCRIPTION
Add automated tests for the team creation view and fix a bug that was recently introduced on it. The bug was caused due to mixin inheritance working differently from what was expected.