### PR TITLE
Improve package list sorting priority

### DIFF
--- a/django/thunderstore/repository/views/repository.py
+++ b/django/thunderstore/repository/views/repository.py
@@ -183,6 +183,7 @@ class PackageListSearchView(CommunityMixin, ListView):
                 "-package__is_pinned",
                 "package__is_deprecated",
                 "-total_downloads",
+                "-package__date_updated",
             )
         if active_ordering == "top-rated":
             return queryset.annotate(
@@ -191,6 +192,7 @@ class PackageListSearchView(CommunityMixin, ListView):
                 "-package__is_pinned",
                 "package__is_deprecated",
                 "-total_rating",
+                "-package__date_updated",
             )
         return queryset.order_by(
             "-package__is_pinned",


### PR DESCRIPTION
Add upload date as the last sorting criteria for "Most Downloaded" and "Top Rated" sorting options. This fixes an issue where packages with equal amounts of ratings or downloads would get arbitrarily sorted in search results, sometimes leading to a subset of the results never being visible on any page (if a sufficiently large group of same-priority sorting packages exists).

Thanks for keks307 on the Inscryption Modding discord for noticing this.

No refs