### PR TITLE
Make community_list endpoint support required functionality

### DIFF
--- a/django/thunderstore/api/cyberstorm/serializers/community.py
+++ b/django/thunderstore/api/cyberstorm/serializers/community.py
@@ -4,8 +4,10 @@ from rest_framework import serializers
 class CyberstormCommunitySerializer(serializers.Serializer):
     name = serializers.CharField()
     identifier = serializers.CharField()
+    description = serializers.CharField(required=False)
+    discord_url = serializers.CharField(required=False)
+    datetime_created = serializers.DateTimeField()
+    background_image_url = serializers.CharField(required=False)
+    icon_url = serializers.CharField(required=False)
     total_download_count = serializers.IntegerField()
     total_package_count = serializers.IntegerField()
-    background_image_url = serializers.CharField(required=False)
-    description = serializers.CharField()
-    discord_url = serializers.CharField(required=False)

--- a/django/thunderstore/api/cyberstorm/views/community_list.py
+++ b/django/thunderstore/api/cyberstorm/views/community_list.py
@@ -1,3 +1,4 @@
+from rest_framework.filters import SearchFilter
 from rest_framework.generics import ListAPIView
 from rest_framework.pagination import PageNumberPagination
 
@@ -7,7 +8,7 @@ from thunderstore.community.models import Community
 
 
 class CommunityPaginator(PageNumberPagination):
-    page_size = 100
+    page_size = 150
 
 
 class CommunityListAPIView(ListAPIView):
@@ -15,6 +16,7 @@ class CommunityListAPIView(ListAPIView):
     serializer_class = CyberstormCommunitySerializer
     pagination_class = CommunityPaginator
     queryset = Community.objects.listed()
-    filter_backends = [StrictOrderingFilter]
-    ordering_fields = ["identifier"]
+    filter_backends = [SearchFilter, StrictOrderingFilter]
+    search_fields = ["description", "name"]
+    ordering_fields = ["datetime_created", "identifier", "name"]
     ordering = ["identifier"]


### PR DESCRIPTION
Moving from placeholder implementation to the real deal on the client side has revealed some shortcomings in the functionality and the returned data of this endpoint.

- Add support for varying page size via page_size query param
- Add support for filtering based on name and description fields via search query param
- Add support for ordering by name and datetime_created fields
- Add datetime_created and icon_url to serializer
- Fields that can return null due to having Null=True in model definition are marked as optional in the serializer
- Add naive implementations for Community's total_package_count and total_downloads_count properties
- Add less naive implementation for icon_url property

Refs TS-1815