### PR TITLE
Admin: Improve Webhook creation performance

### DIFF
--- a/django/thunderstore/webhooks/admin.py
+++ b/django/thunderstore/webhooks/admin.py
@@ -1,10 +1,13 @@
 from django.contrib import admin
 
+from thunderstore.webhooks.forms.webhook import WebhookForm
 from thunderstore.webhooks.models import Webhook
 
 
 @admin.register(Webhook)
 class PackageAdmin(admin.ModelAdmin):
+    form = WebhookForm
+
     readonly_fields = (
         "date_created",
         "uuid4",

--- a/django/thunderstore/webhooks/forms/__init__.py
+++ b/django/thunderstore/webhooks/forms/__init__.py
@@ -1,0 +1,1 @@
+from .webhook import *

--- a/django/thunderstore/webhooks/forms/webhook.py
+++ b/django/thunderstore/webhooks/forms/webhook.py
@@ -1,0 +1,54 @@
+from typing import List
+
+from django import forms
+from django.core.exceptions import ValidationError
+
+from thunderstore.community.models import PackageCategory
+
+from ..models import Webhook
+
+
+class WebhookForm(forms.ModelForm):
+    class Meta:
+        model = Webhook
+        exclude = []
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance.pk:
+            category_qs = PackageCategory.objects.filter(
+                community=self.instance.community,
+            )
+            self.fields["exclude_categories"].queryset = category_qs
+            self.fields["require_categories"].queryset = category_qs
+
+    def clean(self):
+        community = self.cleaned_data.get(
+            "community", getattr(self.instance, "community", None)
+        )
+
+        def validate_cats(cats: List[str]):
+            invalid_categories = PackageCategory.objects.exclude(
+                community=community
+            ).filter(pk__in=cats)
+            if invalid_categories.count() > 0:
+                raise ValidationError(
+                    "All categories must match the community of the Webhook"
+                )
+
+        validate_cats(self.cleaned_data.get("exclude_categories", []))
+        validate_cats(self.cleaned_data.get("require_categories", []))
+
+
+class WebhookAdminForm(WebhookForm):
+    """
+    Same as WebhookForm but without allowing any category selection before first
+    save, as the admin view will populate the category selection with all
+    categories in the DB otherwise.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not self.instance.pk:
+            self.fields["exclude_categories"].queryset = PackageCategory.objects.none()
+            self.fields["require_categories"].queryset = PackageCategory.objects.none()

--- a/django/thunderstore/webhooks/tests/test_forms_webhook.py
+++ b/django/thunderstore/webhooks/tests/test_forms_webhook.py
@@ -1,0 +1,114 @@
+from typing import Dict
+
+import pytest
+from django.db.models.sql.where import NothingNode
+from django.forms import model_to_dict
+
+from thunderstore.community.models import Community, PackageCategory
+from thunderstore.webhooks.forms import WebhookAdminForm, WebhookForm
+from thunderstore.webhooks.models import Webhook, WebhookType
+
+
+def _create_category(community: Community) -> PackageCategory:
+    return PackageCategory.objects.create(
+        community=community,
+        name="Test category",
+        slug="test-category",
+    )
+
+
+def _form_from_instance(webhook: Webhook, data: Dict[str, any]) -> WebhookForm:
+    return WebhookForm(
+        instance=webhook,
+        data={
+            **(model_to_dict(webhook)),
+            **data,
+        },
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("field_name", ("require_categories", "exclude_categories"))
+def test_webhook_form_modify_categories_same_community(
+    release_webhook: Webhook,
+    field_name: str,
+) -> None:
+    category = _create_category(release_webhook.community)
+    form = _form_from_instance(release_webhook, {field_name: [category.pk]})
+    assert form.is_valid() is True
+    webhook = form.save()
+    assert webhook == release_webhook
+    assert category in getattr(webhook, field_name).all()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("field_name", ("require_categories", "exclude_categories"))
+def test_webhook_form_modify_categories_different_community(
+    release_webhook: Webhook,
+    field_name: str,
+) -> None:
+    category = _create_category(Community.objects.create(name="Test"))
+    form = _form_from_instance(release_webhook, {field_name: [category.pk]})
+    assert form.is_valid() is False
+    assert form.errors == {
+        field_name: [
+            "Select a valid choice. "
+            f"{category.pk} "
+            "is not one of the available choices."
+        ]
+    }
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("field_name", ("require_categories", "exclude_categories"))
+def test_webhook_form_create_categories_same_community(
+    community: Community,
+    field_name: str,
+) -> None:
+    category = _create_category(community)
+    form = WebhookForm(
+        data={
+            "name": "test",
+            "webhook_url": "https://example.com/",
+            "webhook_type": WebhookType.mod_release,
+            "is_active": True,
+            "community": community,
+            field_name: [category.pk],
+        }
+    )
+    assert form.is_valid() is True
+    webhook = form.save()
+    assert category in getattr(webhook, field_name).all()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("field_name", ("require_categories", "exclude_categories"))
+def test_webhook_form_create_categories_different_community(
+    community: Community,
+    field_name: str,
+) -> None:
+    category = _create_category(Community.objects.create(name="Test"))
+    form = WebhookForm(
+        data={
+            "name": "test",
+            "webhook_url": "https://example.com/",
+            "webhook_type": WebhookType.mod_release,
+            "is_active": True,
+            "community": community,
+            field_name: [category.pk],
+        }
+    )
+
+    expected_error = "All categories must match the community of the Webhook"
+    assert form.is_valid() is False
+    assert form.errors == {"__all__": [expected_error]}
+
+
+@pytest.mark.django_db
+def test_webhook_form_admin_variant(release_webhook: Webhook):
+    form1 = WebhookAdminForm(instance=release_webhook)
+    assert form1.fields["exclude_categories"].queryset.query.is_empty() is False
+    assert form1.fields["require_categories"].queryset.query.is_empty() is False
+    form2 = WebhookAdminForm()
+    assert form2.fields["exclude_categories"].queryset.query.is_empty() is True
+    assert form2.fields["require_categories"].queryset.query.is_empty() is True


### PR DESCRIPTION
Improve the webhook creation process performance by only allowing category selection after the webhook has been saved once, which allows for them to be filtered based on the community selected for the webhook.