### PR TITLE
Admin: Improve PackageListing creation performance

### DIFF
--- a/django/thunderstore/community/admin/package_listing.py
+++ b/django/thunderstore/community/admin/package_listing.py
@@ -3,7 +3,7 @@ from django.db import transaction
 from django.db.models import QuerySet
 
 from ..consts import PackageListingReviewStatus
-from ..forms import PackageListingForm
+from ..forms import PackageListingAdminForm
 from ..models.package_listing import PackageListing
 
 
@@ -29,6 +29,7 @@ approve_listing.short_description = "Approve"
 
 @admin.register(PackageListing)
 class PackageListingAdmin(admin.ModelAdmin):
+    form = PackageListingAdminForm
     actions = (
         approve_listing,
         reject_listing,
@@ -70,7 +71,6 @@ class PackageListingAdmin(admin.ModelAdmin):
         "datetime_created",
         "datetime_updated",
     )
-    form = PackageListingForm
 
     def get_readonly_fields(self, request, obj=None):
         if obj:

--- a/django/thunderstore/community/forms/package_listing.py
+++ b/django/thunderstore/community/forms/package_listing.py
@@ -29,3 +29,16 @@ class PackageListingForm(forms.ModelForm):
             raise ValidationError(
                 "All PackageListing categories must match the community of the PackageListing"
             )
+
+
+class PackageListingAdminForm(PackageListingForm):
+    """
+    Same as PackageListingForm but without allowing any category selection
+    before first save, as the admin view will populate the category selection
+    with all categories in the DB otherwise.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not self.instance.pk:
+            self.fields["categories"].queryset = PackageCategory.objects.none()

--- a/django/thunderstore/community/tests/test_forms_package_listing.py
+++ b/django/thunderstore/community/tests/test_forms_package_listing.py
@@ -1,7 +1,7 @@
 import pytest
 from django.forms import model_to_dict
 
-from thunderstore.community.forms import PackageListingForm
+from thunderstore.community.forms import PackageListingAdminForm, PackageListingForm
 from thunderstore.community.models import Community, PackageCategory, PackageListing
 from thunderstore.repository.models import Package
 
@@ -105,3 +105,11 @@ def test_package_listing_form_create_categories_different_community(
     )
     assert form.is_valid() is False
     assert form.errors == {"__all__": [expected_error]}
+
+
+@pytest.mark.django_db
+def test_package_listing_form_admin_variant(active_package_listing: PackageListing):
+    form1 = PackageListingAdminForm(instance=active_package_listing)
+    assert form1.fields["categories"].queryset.query.is_empty() is False
+    form2 = PackageListingAdminForm()
+    assert form2.fields["categories"].queryset.query.is_empty() is True


### PR DESCRIPTION
The PackageListing creation admin form was getting slowed down due to listing every category in the form before a community was selected.

Fix this by disallowing selection of categories before the object is saved once and a community is set, as setting a community will narrow down the applicable categories to a manageable level.