### PR TITLE
Admin: Add 'community' to PackageListAdmin raw_id_fields

### DIFF
--- a/django/thunderstore/community/admin/package_listing.py
+++ b/django/thunderstore/community/admin/package_listing.py
@@ -34,7 +34,7 @@ class PackageListingAdmin(admin.ModelAdmin):
         reject_listing,
     )
     filter_horizontal = ("categories",)
-    raw_id_fields = ("package",)
+    raw_id_fields = ("package", "community")
     list_filter = (
         "has_nsfw_content",
         "community",


### PR DESCRIPTION
A dropdown at >100 communities is no longer practical, so swap it to a raw ID field which has a proper selection dialog.