### PR TITLE
Admin: Improve get_absolute_url of the Package model

### DIFF
--- a/django/thunderstore/repository/admin/package.py
+++ b/django/thunderstore/repository/admin/package.py
@@ -103,6 +103,11 @@ class PackageAdmin(admin.ModelAdmin):
     def has_add_permission(self, request: HttpRequest) -> bool:
         return False
 
+    def get_view_on_site_url(self, obj: Optional[Package] = None) -> Optional[str]:
+        if obj:
+            return obj.get_view_on_site_url()
+        return super().get_view_on_site_url(obj)
+
     def has_delete_permission(
         self, request: HttpRequest, obj: Optional[Package] = None
     ) -> bool:

--- a/django/thunderstore/repository/admin/tests/test_package.py
+++ b/django/thunderstore/repository/admin/tests/test_package.py
@@ -2,6 +2,7 @@ import pytest
 from django.conf import settings
 from django.test import Client
 
+from thunderstore.community.models import PackageListing
 from thunderstore.repository.admin.package import (
     PackageAdmin,
     deprecate_package,
@@ -39,6 +40,18 @@ def test_admin_package_detail(
         HTTP_HOST=settings.PRIMARY_HOST,
     )
     assert resp.status_code == 200
+
+
+@pytest.mark.django_db
+def test_admin_package_view_on_site_url(
+    active_package_listing: PackageListing,
+):
+    modeladmin = PackageAdmin(Package, None)
+    assert modeladmin.get_view_on_site_url(None) is None
+    assert (
+        modeladmin.get_view_on_site_url(active_package_listing.package)
+        == active_package_listing.get_full_url()
+    )
 
 
 @pytest.mark.django_db

--- a/django/thunderstore/repository/models/package.py
+++ b/django/thunderstore/repository/models/package.py
@@ -224,11 +224,21 @@ class Package(models.Model):
     def changelog(self):
         return self.latest.changelog
 
-    def get_absolute_url(self):
+    def get_absolute_url(self) -> str:
         return reverse(
             "old_urls:packages.detail",
             kwargs={"owner": self.owner.name, "name": self.name},
         )
+
+    def get_view_on_site_url(self) -> Optional[str]:
+        # This function is currently only used in Django admin, so it doens't
+        # matter too much which community it links to. That said, this should
+        # be updated once the concept of a "main page" for a mod exists.
+        # TODO: Point this to the main page of a package once that exists as a concept
+        from thunderstore.community.models import PackageListing
+
+        listing = PackageListing.objects.active().first()
+        return listing.get_full_url() if listing else None
 
     def get_page_url(self, community_identifier: str) -> str:
         return reverse(


### PR DESCRIPTION
Improve the chances of the get_absolute_url function for the Package model to return an actual valid & functional URL. The function is only used on Django admin currently, and will generate broken links if the pacckage exists in a different community than the one bound to the active domain.

This change makes it so the first active package listing's page URL is returned instead.