### PR TITLE
Admin: Add shortcuts to package admin views

### DIFF
--- a/builder/src/components/PackageManagement/Panel.tsx
+++ b/builder/src/components/PackageManagement/Panel.tsx
@@ -10,18 +10,16 @@ export const PackageManagementPanel: React.FC<ContextProps> = (props) => {
     return (
         <CsrfTokenProvider token={props.csrfToken}>
             <ManagementContextProvider initial={props} closeModal={closeModal}>
-                <div className="d-flex justify-content-end">
-                    {isVisible && <PackageManagementModal />}
-                    <button
-                        type="button"
-                        className="btn btn-primary"
-                        aria-label="Manage Package"
-                        onClick={() => setIsVisible(true)}
-                    >
-                        <span className="fa fa-cog" />
-                        &nbsp;Manage Package
-                    </button>
-                </div>
+                {isVisible && <PackageManagementModal />}
+                <button
+                    type="button"
+                    className="btn btn-primary"
+                    aria-label="Manage Package"
+                    onClick={() => setIsVisible(true)}
+                >
+                    <span className="fa fa-cog" />
+                    &nbsp;&nbsp;Manage Package
+                </button>
             </ManagementContextProvider>
         </CsrfTokenProvider>
     );

--- a/django/thunderstore/community/templates/community/packagelisting_detail.html
+++ b/django/thunderstore/community/templates/community/packagelisting_detail.html
@@ -23,7 +23,15 @@
 
 {% block content %}
 {% if show_management_panel %}
-<div id="package-management-panel"></div>
+<div class="d-flex justify-content-end gap-1">
+    <div id="package-management-panel"></div>
+    {% if show_listing_admin_link %}
+    <a href="{% url "admin:community_packagelisting_change" object.pk %}" type="button" class="btn btn-primary"><span class="fas fa-external-link-alt"></span>&nbsp;&nbsp;Listing admin</a>
+    {% endif %}
+    {% if show_package_admin_link %}
+    <a href="{% url "admin:repository_package_change" object.package.pk %}" type="button" class="btn btn-primary"><span class="fas fa-external-link-alt"></span>&nbsp;&nbsp;Package admin</a>
+    {% endif %}
+</div>
 <script type="text/javascript">
 window.ts.PackageManagementPanel(
     document.getElementById("package-management-panel"),

--- a/django/thunderstore/repository/views/repository.py
+++ b/django/thunderstore/repository/views/repository.py
@@ -26,6 +26,7 @@ from thunderstore.community.models import (
     PackageListing,
     PackageListingSection,
 )
+from thunderstore.core.types import UserType
 from thunderstore.frontend.api.experimental.serializers.views import CommunitySerializer
 from thunderstore.frontend.url_reverse import get_community_url_reverse_args
 from thunderstore.repository.mixins import CommunityMixin
@@ -440,6 +441,16 @@ def get_package_listing_or_404(
     return package_listing
 
 
+def can_view_listing_admin(user: UserType, obj: PackageListing):
+    # TODO: Object level permissions once implemented
+    return user.is_staff and user.has_perm("community.view_packagelisting")
+
+
+def can_view_package_admin(user: UserType, obj: Package):
+    # TODO: Object level permissions once implemented
+    return user.is_staff and user.has_perm("repository.view_package")
+
+
 @method_decorator(ensure_csrf_cookie, name="dispatch")
 class PackageDetailView(CommunityMixin, PackageTabsMixin, DetailView):
     model = PackageListing
@@ -484,6 +495,12 @@ class PackageDetailView(CommunityMixin, PackageTabsMixin, DetailView):
 
         context["dependants_string"] = dependants_string
         context["show_management_panel"] = self.can_manage
+        context["show_listing_admin_link"] = can_view_listing_admin(
+            self.request.user, package_listing
+        )
+        context["show_package_admin_link"] = can_view_package_admin(
+            self.request.user, package_listing.package
+        )
 
         def format_category(cat: PackageCategory):
             return {"name": cat.name, "slug": cat.slug}


### PR DESCRIPTION
Add links to the relevant admin pages on the package detail page if the current user has permissions to view them.

Preview:
![image](https://github.com/thunderstore-io/Thunderstore/assets/8225825/9d52fad7-1df9-4e37-9ad2-ca26c752f23c)
