### PR TITLE
Admin: Override the default user admin pages

### DIFF
--- a/django/thunderstore/account/admin/__init__.py
+++ b/django/thunderstore/account/admin/__init__.py
@@ -1,3 +1,4 @@
 from .service_account import *
 from .token import *
+from .user import *
 from .user_flag import *

--- a/django/thunderstore/account/admin/tests/test_user_admin.py
+++ b/django/thunderstore/account/admin/tests/test_user_admin.py
@@ -1,0 +1,63 @@
+import pytest
+from django.test import Client
+from social_django.models import UserSocialAuth
+
+from thunderstore.core import settings
+from thunderstore.core.types import UserType
+
+
+@pytest.mark.django_db
+def test_admin_user_list(
+    admin_client: Client,
+    user: UserType,
+) -> None:
+    resp = admin_client.get(
+        path="/djangoadmin/auth/user/",
+        HTTP_HOST=settings.PRIMARY_HOST,
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.django_db
+def test_admin_user_is_service_account_ordering(
+    admin_client: Client,
+    user: UserType,
+) -> None:
+    resp = admin_client.get(
+        path="/djangoadmin/auth/user/?o=6.1",
+        HTTP_HOST=settings.PRIMARY_HOST,
+    )
+    assert resp.status_code == 200
+    resp = admin_client.get(
+        path="/djangoadmin/auth/user/?o=-6.1",
+        HTTP_HOST=settings.PRIMARY_HOST,
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.django_db
+def test_admin_user_search_by_social_auth_uid(
+    admin_client: Client,
+    user: UserType,
+) -> None:
+    UserSocialAuth.objects.create(user=user, provider="testprovider", uid="hunter2")
+    resp = admin_client.get(
+        path="/djangoadmin/auth/user/?q=hunter2",
+        HTTP_HOST=settings.PRIMARY_HOST,
+    )
+    assert resp.status_code == 200
+    resp_text = resp.content.decode()
+    assert user.username in resp_text
+    assert user.email in resp_text
+
+
+@pytest.mark.django_db
+def test_admin_user_detail(
+    admin_client: Client,
+    user: UserType,
+) -> None:
+    resp = admin_client.get(
+        path=f"/djangoadmin/auth/user/{user.pk}/change/",
+        HTTP_HOST=settings.PRIMARY_HOST,
+    )
+    assert resp.status_code == 200

--- a/django/thunderstore/account/admin/user.py
+++ b/django/thunderstore/account/admin/user.py
@@ -1,0 +1,108 @@
+from django.contrib import admin
+from django.contrib.admin import SimpleListFilter
+from django.contrib.auth import get_user_model
+from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
+from django.db.models import Exists, OuterRef, Q, QuerySet
+from django.http import HttpRequest
+from social_django.models import UserSocialAuth
+
+from thunderstore.account.models import ServiceAccount, UserSettings
+from thunderstore.community.models import CommunityMembership
+from thunderstore.repository.models import TeamMember
+
+User = get_user_model()
+
+
+class ServiceAccountFilter(SimpleListFilter):
+    title = "service account status"
+    parameter_name = "is_service_account"
+
+    def lookups(self, request: HttpRequest, model_admin):
+        return [
+            ("1", "Yes"),
+            ("0", "No"),
+        ]
+
+    def queryset(self, request: HttpRequest, queryset):
+        if self.value() == "0":
+            return queryset.exclude(~Q(service_account=None))
+        elif self.value() == "1":
+            return queryset.exclude(service_account=None)
+
+
+class ReadOnlyInline:
+    extra = 0
+
+    def has_change_permission(self, request: HttpRequest, obj=None) -> bool:
+        return False
+
+    def has_add_permission(self, request: HttpRequest, obj=None) -> bool:
+        return False
+
+    def has_delete_permission(self, request: HttpRequest, obj=None) -> bool:
+        return False
+
+
+class UserSettingsInline(ReadOnlyInline, admin.StackedInline):
+    model = UserSettings
+
+
+class TeamMembershipInline(ReadOnlyInline, admin.TabularInline):
+    verbose_name = "team membership"
+    verbose_name_plural = "team memberships"
+    model = TeamMember
+
+
+class CommunityMembershipInline(ReadOnlyInline, admin.TabularInline):
+    verbose_name = "community membership"
+    verbose_name_plural = "community memberships"
+    model = CommunityMembership
+
+
+class SocialAuthInline(ReadOnlyInline, admin.TabularInline):
+    model = UserSocialAuth
+    fields = ["provider", "uid"]
+
+
+class UserAdmin(DjangoUserAdmin):
+    inlines = (
+        *DjangoUserAdmin.inlines,
+        UserSettingsInline,
+        TeamMembershipInline,
+        CommunityMembershipInline,
+        SocialAuthInline,
+    )
+    search_fields = (
+        *DjangoUserAdmin.search_fields,
+        "social_auth__uid",
+    )
+    list_filter = (
+        *DjangoUserAdmin.list_filter,
+        ServiceAccountFilter,
+    )
+    list_display = (
+        *DjangoUserAdmin.list_display,
+        "is_service_account",
+    )
+    date_hierarchy = "date_joined"
+
+    def get_queryset(self, request: HttpRequest) -> QuerySet:
+        return (
+            super()
+            .get_queryset(request)
+            .annotate(
+                is_service_account=Exists(
+                    ServiceAccount.objects.filter(user=OuterRef("pk"))
+                )
+            )
+        )
+
+    def is_service_account(self, obj):
+        return obj.is_service_account
+
+    is_service_account.boolean = True
+    is_service_account.admin_order_field = "is_service_account"
+
+
+admin.site.unregister(User)
+admin.site.register(User, UserAdmin)

--- a/django/thunderstore/account/migrations/0004_add_usersettings.py
+++ b/django/thunderstore/account/migrations/0004_add_usersettings.py
@@ -36,5 +36,9 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
+            options={
+                "verbose_name": "user settings",
+                "verbose_name_plural": "user settings",
+            },
         ),
     ]

--- a/django/thunderstore/account/models/user_settings.py
+++ b/django/thunderstore/account/models/user_settings.py
@@ -22,3 +22,7 @@ class UserSettings(models.Model):
     def get_for_user(cls, user: User) -> Optional["UserSettings"]:
         settings = cls.objects.filter(user=user).first()
         return settings if settings else cls.objects.create(user=user)
+
+    class Meta:
+        verbose_name = "user settings"
+        verbose_name_plural = "user settings"


### PR DESCRIPTION
Override the default user admin pages and include Thunderstore-specific extra information on them.

Specifically:

- Add service account status column to list view
- Add service account status filter to list view
- Include social auth user IDs in the search fields
- Add date hierarchy based on join date to list view
- Add team memberships inline
- Add community memberships inline
- Add social auths inline
- Add user settings inline