### PR TITLE
Make file_tree read only in PackageVersionInline

### DIFF
--- a/django/thunderstore/repository/admin/package.py
+++ b/django/thunderstore/repository/admin/package.py
@@ -21,6 +21,7 @@ class PackageVersionInline(admin.StackedInline):
         "icon",
         "version_number",
         "website_url",
+        "file_tree",
     )
     exclude = ("readme", "changelog", "dependencies", "name")
     extra = 0


### PR DESCRIPTION
Make the recently introduced file_tree field in the PackageVersion model read only in its inline on the PackageAdmin page.