### PR TITLE
Admin: Fix invalid link redirects

### DIFF
--- a/django/thunderstore/community/admin/package_listing.py
+++ b/django/thunderstore/community/admin/package_listing.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from django.contrib import admin
 from django.db import transaction
 from django.db.models import QuerySet
@@ -77,3 +79,10 @@ class PackageListingAdmin(admin.ModelAdmin):
             return self.readonly_fields
         else:
             return []
+
+    def get_view_on_site_url(
+        self, obj: Optional[PackageListing] = None
+    ) -> Optional[str]:
+        if obj:
+            return obj.get_full_url()
+        return super().get_view_on_site_url(obj)

--- a/django/thunderstore/repository/models/package.py
+++ b/django/thunderstore/repository/models/package.py
@@ -237,7 +237,7 @@ class Package(models.Model):
         # TODO: Point this to the main page of a package once that exists as a concept
         from thunderstore.community.models import PackageListing
 
-        listing = PackageListing.objects.active().first()
+        listing = PackageListing.objects.active().filter(package=self).first()
         return listing.get_full_url() if listing else None
 
     def get_page_url(self, community_identifier: str) -> str:


### PR DESCRIPTION
Fix the "View on site" links for both Package and PackageListing models, as both were linking to the wrong URL