### PR TITLE
Actually use API serializers

### DIFF
--- a/django/thunderstore/social/api/experimental/views/complete_login.py
+++ b/django/thunderstore/social/api/experimental/views/complete_login.py
@@ -66,11 +66,13 @@ class CompleteLoginApiView(APIView):
         login(request, user, "django.contrib.auth.backends.ModelBackend")
 
         return Response(
-            {
-                "email": user.email,
-                "session_id": request.session.session_key,
-                "username": user.username,
-            }
+            ResponseBody(
+                {
+                    "email": user.email,
+                    "session_id": request.session.session_key,
+                    "username": user.username,
+                }
+            ).data
         )
 
 

--- a/django/thunderstore/social/api/experimental/views/overwolf.py
+++ b/django/thunderstore/social/api/experimental/views/overwolf.py
@@ -77,10 +77,12 @@ class OverwolfLoginApiView(APIView):
             request.session.create()
 
         return Response(
-            {
-                "session_id": request.session.session_key,
-                "profile": get_user_profile(user),
-            }
+            OwLoginResponseBody(
+                {
+                    "session_id": request.session.session_key,
+                    "profile": get_user_profile(user),
+                }
+            ).data
         )
 
 


### PR DESCRIPTION
A few API views declared a serializer they supposedly used for the docs without actually using said serializer to format the data. This commit actually passes the data through the declared serialiers, which is generally what you'd expect when working on a DRF API.