### PR TITLE
Remove bad job filter from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,6 @@ jobs:
   deploy:
     name: Trigger deploy
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
     steps:
       - name: Call deployment workflow
         run: |


### PR DESCRIPTION
Remove a filter condition from the deploy job which prevented it from ever being run.