### PR TITLE
Cyberstorm API: return categories and sections for a team

### DIFF
--- a/django/thunderstore/api/cyberstorm/serializers/community.py
+++ b/django/thunderstore/api/cyberstorm/serializers/community.py
@@ -1,11 +1,7 @@
 from rest_framework import serializers
 
-from thunderstore.community.api.experimental.serializers import (
-    PackageCategoryExperimentalSerializer,
-)
-from thunderstore.community.models import PackageCategory
-from thunderstore.repository.api.experimental.serializers import (
-    CommunityFilteredModelChoiceField,
+from thunderstore.api.cyberstorm.serializers.shared import (
+    CyberstormPackageCategorySerializer,
 )
 
 
@@ -19,7 +15,7 @@ class CyberstormCommunitySerializer(serializers.Serializer):
     icon_url = serializers.CharField(required=False)
     total_download_count = serializers.SerializerMethodField()
     total_package_count = serializers.SerializerMethodField()
-    package_categories = PackageCategoryExperimentalSerializer(many=True)
+    package_categories = CyberstormPackageCategorySerializer(many=True)
 
     def get_total_download_count(self, obj) -> int:
         return obj.aggregated.download_count

--- a/django/thunderstore/api/cyberstorm/serializers/shared.py
+++ b/django/thunderstore/api/cyberstorm/serializers/shared.py
@@ -8,3 +8,9 @@ from rest_framework import serializers
 class CyberstormPackageCategorySerializer(serializers.Serializer):
     name = serializers.CharField()
     slug = serializers.SlugField()
+
+
+class CyberstormPackageListingSectionSerializer(serializers.Serializer):
+    name = serializers.CharField()
+    slug = serializers.SlugField()
+    priority = serializers.IntegerField()

--- a/django/thunderstore/api/cyberstorm/serializers/shared.py
+++ b/django/thunderstore/api/cyberstorm/serializers/shared.py
@@ -1,0 +1,10 @@
+"""
+Do not import/export these through __init__.py to avoid circular imports
+in other serializer files.
+"""
+from rest_framework import serializers
+
+
+class CyberstormPackageCategorySerializer(serializers.Serializer):
+    name = serializers.CharField()
+    slug = serializers.SlugField()

--- a/django/thunderstore/api/cyberstorm/serializers/team.py
+++ b/django/thunderstore/api/cyberstorm/serializers/team.py
@@ -2,6 +2,11 @@ from typing import Optional
 
 from rest_framework import serializers
 
+from thunderstore.api.cyberstorm.serializers.shared import (
+    CyberstormPackageCategorySerializer,
+    CyberstormPackageListingSectionSerializer,
+)
+from thunderstore.community.models import PackageCategory, PackageListingSection
 from thunderstore.social.utils import get_avatar_url
 
 
@@ -9,11 +14,42 @@ class CyberstormTeamSerializer(serializers.Serializer):
     """
     This is for team's public profile and readably by anyone. Don't add
     any sensitive information here.
+
+    package_categories and sections will be populated only if a
+    `community` query parameter is used with the request.
     """
 
     identifier = serializers.IntegerField(source="id")
     name = serializers.CharField()
     donation_link = serializers.CharField(required=False)
+    package_categories = serializers.SerializerMethodField()
+    sections = serializers.SerializerMethodField()
+
+    def get_package_categories(self, obj):
+        community_id = self.context["request"].GET.get("community")
+
+        if community_id:
+            categories = PackageCategory.objects.filter(
+                community__identifier=community_id,
+            )
+        else:
+            categories = PackageCategory.objects.none()
+
+        return CyberstormPackageCategorySerializer(categories, many=True).data
+
+    def get_sections(self, obj):
+        community_id = self.context["request"].GET.get("community")
+
+        if community_id:
+            sections = (
+                PackageListingSection.objects.listed()
+                .filter(community__identifier=community_id)
+                .order_by("priority")
+            )
+        else:
+            sections = PackageListingSection.objects.none()
+
+        return CyberstormPackageListingSectionSerializer(sections, many=True).data
 
 
 class CyberstormTeamMemberSerializer(serializers.Serializer):


### PR DESCRIPTION
Cyberstorm API: add CyberstormPackageCategorySerializer

It felt a bit dirty to import such a simple serializer from another
app, especially since that serializer is marked experimental.

Refs TS-1860

Cyberstorm API: return team's categories and sections

If community is defined, return a list of community's PackageCategories
and PackageListingSections too. This is done via optional query
parameter so both views that have access to community (e.g. team's
package listing view) and don't have it (e.g. team's profile settings
view) can use the same endpoint.

Refs TS-1856