### PR TITLE
Add support for avatars when using Discord as an OAuth provider

### DIFF
--- a/django/thunderstore/api/cyberstorm/serializers/team.py
+++ b/django/thunderstore/api/cyberstorm/serializers/team.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from rest_framework import serializers
 
-from thunderstore.social.utils import get_avatar_url
+from thunderstore.social.utils import get_user_avatar_url
 
 
 class CyberstormTeamSerializer(serializers.Serializer):
@@ -23,7 +23,7 @@ class CyberstormTeamMemberSerializer(serializers.Serializer):
     role = serializers.CharField()
 
     def get_avatar(self, obj) -> Optional[str]:
-        return get_avatar_url(obj.user)
+        return get_user_avatar_url(obj.user)
 
 
 class CyberstormServiceAccountSerializer(serializers.Serializer):

--- a/django/thunderstore/social/api/experimental/views/current_user.py
+++ b/django/thunderstore/social/api/experimental/views/current_user.py
@@ -12,6 +12,7 @@ from rest_framework.views import APIView
 from thunderstore.account.models.user_flag import UserFlag
 from thunderstore.core.types import UserType
 from thunderstore.repository.models import TeamMember
+from thunderstore.social.utils import get_connection_avatar_url
 
 
 class CurrentUserExperimentalApiView(APIView):
@@ -146,12 +147,6 @@ OAUTH_USERNAME_FIELDS = {
 }
 
 
-OAUTH_AVATAR_FIELDS = {
-    "github": "avatar_url",
-    "overwolf": "avatar",
-}
-
-
 def get_social_auth_connections(user: UserType) -> List[SocialAuthConnection]:
     """
     Return information regarding user's registered OAuth logins.
@@ -161,9 +156,7 @@ def get_social_auth_connections(user: UserType) -> List[SocialAuthConnection]:
         {
             "provider": sa.provider,
             "username": sa.extra_data.get(OAUTH_USERNAME_FIELDS.get(sa.provider)),
-            "avatar": sa.extra_data.get(OAUTH_AVATAR_FIELDS[sa.provider])
-            if sa.provider in OAUTH_AVATAR_FIELDS
-            else None,
+            "avatar": get_connection_avatar_url(sa),
         }
         for sa in user.social_auth.all()
     ]

--- a/django/thunderstore/social/tests/test_utils.py
+++ b/django/thunderstore/social/tests/test_utils.py
@@ -2,73 +2,124 @@ import pytest
 from social_django.models import UserSocialAuth  # type: ignore
 
 from thunderstore.core.types import UserType
-from thunderstore.social.utils import get_avatar_url
+from thunderstore.social.utils import get_connection_avatar_url, get_user_avatar_url
 
 
 @pytest.mark.django_db
-def test_get_avatar_url__for_user_without_connetions__returns_none(
+def test_get_user_avatar_url__for_user_without_connetions__returns_none(
     user: UserType,
 ) -> None:
-    avatar = get_avatar_url(user)
+    user_avatar = get_user_avatar_url(user)
 
-    assert avatar is None
-
-
-@pytest.mark.django_db
-def test_get_avatar_url__for_discord_user__returns_avatar(user: UserType) -> None:
-    connection = UserSocialAuth.objects.create(
-        user=user,
-        provider="discord",
-        uid="user",
-    )
-
-    avatar = get_avatar_url(user)
-
-    assert avatar is None
-
-    connection.extra_data = {"id": "user_id", "avatar": "avatar_id"}
-    connection.save()
-
-    avatar = get_avatar_url(user)
-
-    assert avatar.endswith("avatars/user_id/avatar_id.png")
+    assert user_avatar is None
 
 
 @pytest.mark.django_db
-def test_get_avatar_url__for_github_user__returns_avatar(user: UserType) -> None:
+def test_get_user_avatar_url__for_user_with_one_connetion__returns_avatar(
+    user: UserType,
+) -> None:
     connection = UserSocialAuth.objects.create(
         user=user,
         provider="github",
         uid="user",
+        extra_data={"avatar_url": "url"},
     )
 
-    avatar = get_avatar_url(user)
+    user_avatar = get_user_avatar_url(user)
+    connection_avatar = get_connection_avatar_url(connection)
 
-    assert avatar is None
-
-    connection.extra_data = {"avatar_url": "url"}
-    connection.save()
-
-    avatar = get_avatar_url(user)
-
-    assert avatar == "url"
+    assert user_avatar is not None
+    assert user_avatar != ""
+    assert user_avatar == connection_avatar
 
 
 @pytest.mark.django_db
-def test_get_avatar_url__for_overwolf_user__returns_avatar(user: UserType) -> None:
+def test_get_user_avatar_url__for_user_with_many_connetions__returns_avatar(
+    user: UserType,
+) -> None:
+    UserSocialAuth.objects.create(
+        user=user,
+        provider="discord",
+        uid="user",
+        extra_data={"id": "user_id", "avatar": "avatar_id"},
+    )
+    UserSocialAuth.objects.create(
+        user=user,
+        provider="github",
+        uid="user",
+        extra_data={"avatar_url": "url"},
+    )
+    UserSocialAuth.objects.create(
+        user=user,
+        provider="overwolf",
+        uid="user",
+        extra_data={"avatar": "url"},
+    )
+
+    user_avatar = get_user_avatar_url(user)
+
+    assert user_avatar is not None
+    assert user_avatar != ""
+
+
+@pytest.mark.django_db
+def test_get_connection_avatar_url__for_unknown_provider__returns_none(
+    user: UserType,
+) -> None:
+    connection = UserSocialAuth.objects.create(
+        user=user,
+        provider="thunderstore",
+        uid="user",
+        extra_data={"avatar": "url"},
+    )
+
+    connection_avatar = get_connection_avatar_url(connection)
+
+    assert connection_avatar is None
+
+
+@pytest.mark.django_db
+def test_get_connection_avatar_url__for_discord__returns_avatar(user: UserType) -> None:
+    connection = UserSocialAuth.objects.create(
+        user=user,
+        provider="discord",
+        uid="user",
+        extra_data={"id": "user_id", "avatar": "avatar_id"},
+    )
+
+    connection_avatar = get_connection_avatar_url(connection)
+
+    assert type(connection_avatar) == str
+    assert connection_avatar.endswith("avatars/user_id/avatar_id.png")
+
+
+@pytest.mark.django_db
+def test_get_connection_avatar_url__for_github_user__returns_avatar(
+    user: UserType,
+) -> None:
+    connection = UserSocialAuth.objects.create(
+        user=user,
+        provider="github",
+        uid="user",
+        extra_data={"avatar_url": "url"},
+    )
+
+    connection_avatar = get_connection_avatar_url(connection)
+
+    assert connection_avatar == "url"
+
+
+@pytest.mark.django_db
+def test_get_connection_avatar_url__for_overwolf_user__returns_avatar(
+    user: UserType,
+) -> None:
     connection = UserSocialAuth.objects.create(
         user=user,
         provider="overwolf",
         uid="user",
+        extra_data={"avatar": "url"},
     )
 
-    avatar = get_avatar_url(user)
+    connection_avatar = get_connection_avatar_url(connection)
 
-    assert avatar is None
-
-    connection.extra_data = {"avatar": "url"}
-    connection.save()
-
-    avatar = get_avatar_url(user)
-
-    assert avatar == "url"
+    assert connection_avatar == "url"

--- a/django/thunderstore/social/tests/test_utils.py
+++ b/django/thunderstore/social/tests/test_utils.py
@@ -15,18 +15,23 @@ def test_get_avatar_url__for_user_without_connetions__returns_none(
 
 
 @pytest.mark.django_db
-def test_get_avatar_url__for_discord_user__returns_none(user: UserType) -> None:
-    UserSocialAuth.objects.create(
+def test_get_avatar_url__for_discord_user__returns_avatar(user: UserType) -> None:
+    connection = UserSocialAuth.objects.create(
         user=user,
         provider="discord",
         uid="user",
-        extra_data={"avatar": "url", "avatar_url": "url"},
     )
 
     avatar = get_avatar_url(user)
 
-    # Discord doesn't return avatar URLs.
     assert avatar is None
+
+    connection.extra_data = {"id": "user_id", "avatar": "avatar_id"}
+    connection.save()
+
+    avatar = get_avatar_url(user)
+
+    assert avatar.endswith("avatars/user_id/avatar_id.png")
 
 
 @pytest.mark.django_db

--- a/django/thunderstore/social/utils.py
+++ b/django/thunderstore/social/utils.py
@@ -1,28 +1,44 @@
 from typing import Optional
 
+from social_django.models import UserSocialAuth  # type: ignore
+
 from thunderstore.core.types import UserType
 
 
-def get_avatar_url(user: UserType) -> Optional[str]:
+def get_connection_avatar_url(connection: UserSocialAuth) -> Optional[str]:
     """
+    Return URL associated with a given OAuth provider.
+    """
+    if connection.provider == "discord":
+        user_id = connection.extra_data.get("id")
+        avatar_id = connection.extra_data.get("avatar")
+
+        if user_id and avatar_id:
+            return f"https://cdn.discordapp.com/avatars/{user_id}/{avatar_id}.png"
+
+    elif connection.provider == "github" and connection.extra_data.get(
+        "avatar_url",
+    ):
+        return connection.extra_data.get("avatar_url")
+
+    elif connection.provider == "overwolf" and connection.extra_data.get(
+        "avatar",
+    ):
+        return connection.extra_data.get("avatar")
+
+    return None
+
+
+def get_user_avatar_url(user: UserType) -> Optional[str]:
+    """
+    Return URL of one of the avatars user might have via OAuth providers.
+
     TODO: TS-1883.
     """
     for connection in user.social_auth.all():
-        if connection.provider == "discord":
-            user_id = connection.extra_data.get("id")
-            avatar_id = connection.extra_data.get("avatar")
+        avatar_url = get_connection_avatar_url(connection)
 
-            if user_id and avatar_id:
-                return f"https://cdn.discordapp.com/avatars/{user_id}/{avatar_id}.png"
-
-        elif connection.provider == "github" and connection.extra_data.get(
-            "avatar_url",
-        ):
-            return connection.extra_data.get("avatar_url")
-
-        elif connection.provider == "overwolf" and connection.extra_data.get(
-            "avatar",
-        ):
-            return connection.extra_data.get("avatar")
+        if avatar_url:
+            return avatar_url
 
     return None

--- a/django/thunderstore/social/utils.py
+++ b/django/thunderstore/social/utils.py
@@ -8,12 +8,19 @@ def get_avatar_url(user: UserType) -> Optional[str]:
     TODO: TS-1883.
     """
     for connection in user.social_auth.all():
-        if connection.provider == "github" and connection.extra_data.get(
+        if connection.provider == "discord":
+            user_id = connection.extra_data.get("id")
+            avatar_id = connection.extra_data.get("avatar")
+
+            if user_id and avatar_id:
+                return f"https://cdn.discordapp.com/avatars/{user_id}/{avatar_id}.png"
+
+        elif connection.provider == "github" and connection.extra_data.get(
             "avatar_url",
         ):
             return connection.extra_data.get("avatar_url")
 
-        if connection.provider == "overwolf" and connection.extra_data.get(
+        elif connection.provider == "overwolf" and connection.extra_data.get(
             "avatar",
         ):
             return connection.extra_data.get("avatar")


### PR DESCRIPTION
Add support for avatars when using Discord as an OAuth provider

Unlike other providers, Discord doesn't provide an URL for the user
avatar straight up. Instead, we need to parse it from other data they
do provide.

Refs TS-1884

DRY up avatar fetching code

- Split the util function for reading the avatar into two: one that
  accepts the User object and nondeterministically returns any one of
  their avatars, and another that accepts SocialAuth object and returns
  the avatar associated with that OAuth provider
- Use the latter when resolving the avatars of the currently
  authenticated user

Refs TS-1884