### PR TITLE
Cyberstorm API: add CommunityFilters endpoint

### DIFF
--- a/django/thunderstore/api/cyberstorm/serializers/__init__.py
+++ b/django/thunderstore/api/cyberstorm/serializers/__init__.py
@@ -1,4 +1,8 @@
-from .community import CyberstormCommunitySerializer
+from .community import (
+    CyberstormCommunitySerializer,
+    CyberstormPackageCategorySerializer,
+    CyberstormPackageListingSectionSerializer,
+)
 from .team import (
     CyberstormServiceAccountSerializer,
     CyberstormTeamMemberSerializer,
@@ -7,6 +11,8 @@ from .team import (
 
 __all__ = [
     "CyberstormCommunitySerializer",
+    "CyberstormPackageCategorySerializer",
+    "CyberstormPackageListingSectionSerializer",
     "CyberstormServiceAccountSerializer",
     "CyberstormTeamMemberSerializer",
     "CyberstormTeamSerializer",

--- a/django/thunderstore/api/cyberstorm/serializers/community.py
+++ b/django/thunderstore/api/cyberstorm/serializers/community.py
@@ -1,13 +1,5 @@
 from rest_framework import serializers
 
-from thunderstore.community.api.experimental.serializers import (
-    PackageCategoryExperimentalSerializer,
-)
-from thunderstore.community.models import PackageCategory
-from thunderstore.repository.api.experimental.serializers import (
-    CommunityFilteredModelChoiceField,
-)
-
 
 class CyberstormCommunitySerializer(serializers.Serializer):
     name = serializers.CharField()
@@ -19,7 +11,6 @@ class CyberstormCommunitySerializer(serializers.Serializer):
     icon_url = serializers.CharField(required=False)
     total_download_count = serializers.SerializerMethodField()
     total_package_count = serializers.SerializerMethodField()
-    package_categories = PackageCategoryExperimentalSerializer(many=True)
 
     def get_total_download_count(self, obj) -> int:
         return obj.aggregated.download_count

--- a/django/thunderstore/api/cyberstorm/serializers/community.py
+++ b/django/thunderstore/api/cyberstorm/serializers/community.py
@@ -17,3 +17,14 @@ class CyberstormCommunitySerializer(serializers.Serializer):
 
     def get_total_package_count(self, obj) -> int:
         return obj.aggregated.package_count
+
+
+class CyberstormPackageCategorySerializer(serializers.Serializer):
+    name = serializers.CharField()
+    slug = serializers.SlugField()
+
+
+class CyberstormPackageListingSectionSerializer(serializers.Serializer):
+    name = serializers.CharField()
+    slug = serializers.SlugField()
+    priority = serializers.IntegerField()

--- a/django/thunderstore/api/cyberstorm/tests/test_community_detail.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_community_detail.py
@@ -2,11 +2,7 @@ import pytest
 from rest_framework.test import APIClient
 
 from thunderstore.community.factories import PackageListingFactory
-from thunderstore.community.models import (
-    CommunityAggregatedFields,
-    CommunitySite,
-    PackageCategory,
-)
+from thunderstore.community.models import CommunityAggregatedFields, CommunitySite
 
 
 @pytest.mark.django_db
@@ -14,23 +10,12 @@ def test_api_cyberstorm_community_detail_success(
     client: APIClient,
     community_site: CommunitySite,
 ):
-    categories = [
-        PackageCategory.objects.create(
-            name=i,
-            slug=i,
-            community=community_site.community,
-        )
-        for i in range(3)
-    ]
-
     PackageListingFactory(
         community_=community_site.community,
-        categories=[categories[0]],
         package_version_kwargs={"downloads": 0},
     )
     PackageListingFactory(
         community_=community_site.community,
-        categories=[categories[0], categories[1]],
         package_version_kwargs={"downloads": 23},
     )
     PackageListingFactory(
@@ -57,15 +42,6 @@ def test_api_cyberstorm_community_detail_success(
     assert c.background_image_url == response_data["background_image_url"]
     assert c.description == response_data["description"]
     assert c.discord_url == response_data["discord_url"]
-
-    # Include all community's categories even if they're currently not
-    # in use, so people see they exists.
-    assert type(response_data["package_categories"]) == list
-    assert len(response_data["package_categories"]) == 3
-    slugs = [c["slug"] for c in response_data["package_categories"]]
-    assert "0" in slugs
-    assert "1" in slugs
-    assert "2" in slugs
 
 
 @pytest.mark.django_db

--- a/django/thunderstore/api/cyberstorm/tests/test_community_filters.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_community_filters.py
@@ -1,0 +1,60 @@
+import pytest
+from rest_framework.test import APIClient
+
+from thunderstore.community.factories import PackageCategoryFactory
+from thunderstore.community.models import Community, PackageListingSection
+
+
+@pytest.mark.django_db
+def test_community_filters_api_view__returns_package_categories(
+    api_client: APIClient,
+    community: Community,
+):
+    PackageCategoryFactory(community=community, name="Mods", slug="mods")
+    PackageCategoryFactory(community=community, name="Modpacks", slug="modpacks")
+
+    response = api_client.get(
+        f"/api/cyberstorm/community/{community.identifier}/filters/",
+    )
+    result = response.json()
+
+    assert len(result["package_categories"]) == 2
+    slugs = [c["slug"] for c in result["package_categories"]]
+    assert "mods" in slugs
+    assert "modpacks" in slugs
+
+
+@pytest.mark.django_db
+def test_community_filters_api_view__returns_package_listing_sections(
+    api_client: APIClient,
+    community: Community,
+):
+    section1 = PackageListingSection.objects.create(
+        community=community,
+        name="Mods",
+        slug="mods",
+        priority=3,
+    )
+    PackageListingSection.objects.create(
+        community=community,
+        name="Modpacks",
+        slug="modpacks",
+        priority=2,
+        is_listed=False,
+    )
+    section3 = PackageListingSection.objects.create(
+        community=community,
+        name="DLC",
+        slug="dlc",
+        priority=1,
+    )
+
+    response = api_client.get(
+        f"/api/cyberstorm/community/{community.identifier}/filters/",
+    )
+    result = response.json()
+
+    # Filter out unlisted, order by priority.
+    assert len(result["sections"]) == 2
+    assert result["sections"][0]["slug"] == section3.slug
+    assert result["sections"][1]["slug"] == section1.slug

--- a/django/thunderstore/api/cyberstorm/views/__init__.py
+++ b/django/thunderstore/api/cyberstorm/views/__init__.py
@@ -1,9 +1,11 @@
 from .community_detail import CommunityDetailAPIView
+from .community_filters import CommunityFiltersAPIView
 from .community_list import CommunityListAPIView
 from .team import TeamDetailAPIView, TeamMembersAPIView, TeamServiceAccountsAPIView
 
 __all__ = [
     "CommunityDetailAPIView",
+    "CommunityFiltersAPIView",
     "CommunityListAPIView",
     "TeamDetailAPIView",
     "TeamMembersAPIView",

--- a/django/thunderstore/api/cyberstorm/views/community_filters.py
+++ b/django/thunderstore/api/cyberstorm/views/community_filters.py
@@ -1,0 +1,41 @@
+from rest_framework import serializers
+from rest_framework.generics import get_object_or_404
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from thunderstore.api.cyberstorm.serializers import (
+    CyberstormPackageCategorySerializer,
+    CyberstormPackageListingSectionSerializer,
+)
+from thunderstore.api.utils import conditional_swagger_auto_schema
+from thunderstore.community.models import Community
+
+
+class CommunityFiltersAPIViewSerializer(serializers.Serializer):
+    package_categories = CyberstormPackageCategorySerializer(many=True)
+    sections = CyberstormPackageListingSectionSerializer(many=True)
+
+
+class CommunityFiltersAPIView(APIView):
+    """
+    Return info about PackageCategories and PackageListingSections so
+    they can be used as filters.
+    """
+
+    queryset = Community.objects.prefetch_related("package_categories")
+    serializer_class = CommunityFiltersAPIViewSerializer
+
+    @conditional_swagger_auto_schema(
+        tags=["cyberstorm"],
+        responses={200: serializer_class()},
+    )
+    def get(self, request, community_id: str, format=None):
+        community = get_object_or_404(self.queryset, identifier=community_id)
+        filters = {
+            "package_categories": community.package_categories.all(),
+            "sections": community.package_listing_sections.listed().order_by(
+                "priority",
+            ),
+        }
+
+        return Response(self.serializer_class(filters).data)

--- a/django/thunderstore/api/urls.py
+++ b/django/thunderstore/api/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from thunderstore.api.cyberstorm.views import (
     CommunityDetailAPIView,
+    CommunityFiltersAPIView,
     CommunityListAPIView,
     TeamDetailAPIView,
     TeamMembersAPIView,
@@ -18,6 +19,11 @@ cyberstorm_urls = [
         "community/<str:community_id>/",
         CommunityDetailAPIView.as_view(),
         name="cyberstorm.community.detail",
+    ),
+    path(
+        "community/<str:community_id>/filters/",
+        CommunityFiltersAPIView.as_view(),
+        name="cyberstorm.community.filters",
     ),
     path(
         "team/<str:team_id>/",


### PR DESCRIPTION
Cyperstorm API: remove package categories from CommunityDetail endpoint

Package categories and sections will be provided by a separate endpoint
in the future.

Refs TS-1885

Cyberstorm API: add CommunityFilters endpoint

The endpoint returns the community specific information that can be
used to filters packages, namely the available categories and sections.

Refs TS-1885