### PR TITLE
Update dev env usermedia signing URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ x-django-service: &django-service
     AWS_S3_SECURE_URLS: "False"
 
     USERMEDIA_S3_ENDPOINT_URL: "http://minio:9000/"
-    USERMEDIA_S3_SIGNING_ENDPOINT_URL: "http://localhost:9000/"
+    USERMEDIA_S3_SIGNING_ENDPOINT_URL: "http://thunderstore.localhost:9000/"
     USERMEDIA_S3_ACCESS_KEY_ID: "thunderstore"
     USERMEDIA_S3_SECRET_ACCESS_KEY: "thunderstore"
     USERMEDIA_S3_REGION_NAME: ""


### PR DESCRIPTION
Update the endpoint used for pre-signed s3 upload URLs by the development environment.

This update is necessary to enable proper integration testing with some of the frontend code that's in development. See https://github.com/thunderstore-io/thunderstore-ui/commit/bb2fc1ce857a512672496b9272acd0b010250101#diff-3c4dbbc0689a6ed61e26d415987d64eb05067e938423b6e3aa997b0e96bb49d5R79-R84 for more details