### PR TITLE
Cyberstorm API: return unique ids for category and section filters

### DIFF
--- a/django/thunderstore/api/cyberstorm/serializers/community.py
+++ b/django/thunderstore/api/cyberstorm/serializers/community.py
@@ -20,11 +20,13 @@ class CyberstormCommunitySerializer(serializers.Serializer):
 
 
 class CyberstormPackageCategorySerializer(serializers.Serializer):
+    id = serializers.IntegerField()  # noqa: A003
     name = serializers.CharField()
     slug = serializers.SlugField()
 
 
 class CyberstormPackageListingSectionSerializer(serializers.Serializer):
+    uuid = serializers.UUIDField()
     name = serializers.CharField()
     slug = serializers.SlugField()
     priority = serializers.IntegerField()

--- a/django/thunderstore/api/cyberstorm/tests/test_community_filters.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_community_filters.py
@@ -56,5 +56,7 @@ def test_community_filters_api_view__returns_package_listing_sections(
 
     # Filter out unlisted, order by priority.
     assert len(result["sections"]) == 2
+    assert result["sections"][0]["uuid"] == str(section3.uuid)
     assert result["sections"][0]["slug"] == section3.slug
+    assert result["sections"][1]["uuid"] == str(section1.uuid)
     assert result["sections"][1]["slug"] == section1.slug


### PR DESCRIPTION
Slugs of PackageCategory and PackageListingSections are unique only in
a scope of each Community. Send the globally unique ids to client so
they can be used when the client sends a package list filtering request
back to backend.

Refs TS-1890