### PR TITLE
Cyberstorm API: treat PackageCategory ids as strings

### DIFF
--- a/django/thunderstore/api/cyberstorm/serializers/community.py
+++ b/django/thunderstore/api/cyberstorm/serializers/community.py
@@ -20,7 +20,7 @@ class CyberstormCommunitySerializer(serializers.Serializer):
 
 
 class CyberstormPackageCategorySerializer(serializers.Serializer):
-    id = serializers.IntegerField()  # noqa: A003
+    id = serializers.CharField()  # noqa: A003
     name = serializers.CharField()
     slug = serializers.SlugField()
 

--- a/django/thunderstore/api/cyberstorm/tests/test_community_filters.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_community_filters.py
@@ -10,8 +10,8 @@ def test_community_filters_api_view__returns_package_categories(
     api_client: APIClient,
     community: Community,
 ):
-    PackageCategoryFactory(community=community, name="Mods", slug="mods")
-    PackageCategoryFactory(community=community, name="Modpacks", slug="modpacks")
+    c1 = PackageCategoryFactory(community=community)
+    c2 = PackageCategoryFactory(community=community)
 
     response = api_client.get(
         f"/api/cyberstorm/community/{community.identifier}/filters/",
@@ -19,9 +19,11 @@ def test_community_filters_api_view__returns_package_categories(
     result = response.json()
 
     assert len(result["package_categories"]) == 2
-    slugs = [c["slug"] for c in result["package_categories"]]
-    assert "mods" in slugs
-    assert "modpacks" in slugs
+    category_ids = [c["id"] for c in result["package_categories"]]
+    assert isinstance(category_ids[0], str)
+    assert isinstance(category_ids[1], str)
+    assert str(c1.id) in category_ids
+    assert str(c2.id) in category_ids
 
 
 @pytest.mark.django_db

--- a/django/thunderstore/api/cyberstorm/tests/test_packages.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_packages.py
@@ -125,7 +125,7 @@ def test_base_view__when_including_category__filters_out_not_matched(
     PackageListingFactory(community_=community, categories=[])
     included = PackageListingFactory(community_=community, categories=[cat])
 
-    request = APIRequestFactory().get("/", {"included_categories": [cat.id]})
+    request = APIRequestFactory().get("/", {"included_categories": [str(cat.id)]})
     response = BasePackageListAPIView().dispatch(
         request,
         community_id=community.identifier,
@@ -144,7 +144,7 @@ def test_base_view__when_excluding_category__filters_out_matched(
     included = PackageListingFactory(community_=community, categories=[])
     PackageListingFactory(community_=community, categories=[cat])
 
-    request = APIRequestFactory().get("/", {"excluded_categories": [cat.id]})
+    request = APIRequestFactory().get("/", {"excluded_categories": [str(cat.id)]})
     response = BasePackageListAPIView().dispatch(
         request,
         community_id=community.identifier,
@@ -501,7 +501,7 @@ def test_base_view__when_multiple_pages_of_results__page_urls_retain_paramaters(
         "/",
         data={
             "deprecated": True,
-            "included_categories": [cat.id],
+            "included_categories": [str(cat.id)],
             "ordering": "most-downloaded",
             "page": 2,
             "q": "test",

--- a/django/thunderstore/api/cyberstorm/views/packages.py
+++ b/django/thunderstore/api/cyberstorm/views/packages.py
@@ -33,11 +33,11 @@ class PackageListRequestSerializer(serializers.Serializer):
 
     deprecated = serializers.BooleanField(default=False)
     excluded_categories = serializers.ListField(
-        child=serializers.IntegerField(),
+        child=serializers.CharField(),
         default=[],
     )
     included_categories = serializers.ListField(
-        child=serializers.IntegerField(),
+        child=serializers.CharField(),
         default=[],
     )
     nsfw = serializers.BooleanField(default=False)
@@ -337,7 +337,7 @@ def filter_nsfw(
 
 
 def filter_in_categories(
-    category_ids: List[int],
+    category_ids: List[str],
     queryset: QuerySet[Package],
 ) -> QuerySet[Package]:
     """
@@ -355,7 +355,7 @@ def filter_in_categories(
 
 
 def filter_not_in_categories(
-    category_ids: List[int],
+    category_ids: List[str],
     queryset: QuerySet[Package],
 ) -> QuerySet[Package]:
     """


### PR DESCRIPTION
Ids should be provided as strings when the client requests a list of
community's package categories to be used as filters for package
listings. Received ids should be treated as strings when client
requests a filtered package listing.

Refs TS-1899
