### PR TITLE
Cyberstorm API: add package dependant list endpoint

### DIFF
--- a/django/thunderstore/api/cyberstorm/views/__init__.py
+++ b/django/thunderstore/api/cyberstorm/views/__init__.py
@@ -1,7 +1,11 @@
 from .community_detail import CommunityDetailAPIView
 from .community_filters import CommunityFiltersAPIView
 from .community_list import CommunityListAPIView
-from .packages import CommunityPackageListAPIView, NamespacePackageListAPIView
+from .packages import (
+    CommunityPackageListAPIView,
+    NamespacePackageListAPIView,
+    PackageDependantsListAPIView,
+)
 from .team import TeamDetailAPIView, TeamMembersAPIView, TeamServiceAccountsAPIView
 
 __all__ = [
@@ -10,6 +14,7 @@ __all__ = [
     "CommunityListAPIView",
     "CommunityPackageListAPIView",
     "NamespacePackageListAPIView",
+    "PackageDependantsListAPIView",
     "TeamDetailAPIView",
     "TeamMembersAPIView",
     "TeamServiceAccountsAPIView",

--- a/django/thunderstore/api/urls.py
+++ b/django/thunderstore/api/urls.py
@@ -6,6 +6,7 @@ from thunderstore.api.cyberstorm.views import (
     CommunityListAPIView,
     CommunityPackageListAPIView,
     NamespacePackageListAPIView,
+    PackageDependantsListAPIView,
     TeamDetailAPIView,
     TeamMembersAPIView,
     TeamServiceAccountsAPIView,
@@ -36,6 +37,11 @@ cyberstorm_urls = [
         "package/<str:community_id>/<str:namespace_id>/",
         NamespacePackageListAPIView.as_view(),
         name="cyberstorm.package.community.namespace",
+    ),
+    path(
+        "package/<str:community_id>/<str:namespace_id>/<str:package_name>/dependants/",
+        PackageDependantsListAPIView.as_view(),
+        name="cyberstorm.package.community.namespace.package-dependants",
     ),
     path(
         "team/<str:team_id>/",


### PR DESCRIPTION
Endpoint for fetching listed packages that depend on a given package.
To be included in the results the packages must also be listed in the
requested community.

Refs TS-1975