### PR TITLE
Add filter_by_community_approval_rule for PackageListing QuerySet

### DIFF
--- a/django/thunderstore/community/models/package_listing.py
+++ b/django/thunderstore/community/models/package_listing.py
@@ -28,6 +28,12 @@ class PackageListingQueryset(models.QuerySet):
     def approved(self):
         return self.exclude(~Q(review_status=PackageListingReviewStatus.approved))
 
+    def filter_by_community_approval_rule(self):
+        return self.exclude(review_status=PackageListingReviewStatus.rejected).exclude(
+            Q(community__require_package_listing_approval=True)
+            & ~Q(review_status=PackageListingReviewStatus.approved),
+        )
+
 
 # TODO: Add a db constraint that ensures a package listing and it's categories
 #       belong to the same community. This might require actually specifying

--- a/django/thunderstore/repository/cache.py
+++ b/django/thunderstore/repository/cache.py
@@ -1,6 +1,5 @@
 from django.db.models import QuerySet
 
-from thunderstore.community.consts import PackageListingReviewStatus
 from thunderstore.community.models import PackageListing, Q
 
 
@@ -21,7 +20,9 @@ def order_package_listing_queryset(
     queryset: QuerySet[PackageListing],
 ) -> QuerySet[PackageListing]:
     return queryset.order_by(
-        "-package__is_pinned", "package__is_deprecated", "-package__date_updated"
+        "-package__is_pinned",
+        "package__is_deprecated",
+        "-package__date_updated",
     )
 
 
@@ -29,11 +30,7 @@ def get_package_listing_queryset(community_identifier: str) -> QuerySet[PackageL
     return order_package_listing_queryset(
         prefetch_package_listing_queryset(
             PackageListing.objects.active()
-            .exclude(~Q(community__identifier=community_identifier))
-            .exclude(review_status=PackageListingReviewStatus.rejected)
-            .exclude(
-                Q(community__require_package_listing_approval=True)
-                & ~Q(review_status=PackageListingReviewStatus.approved)
-            )
-        )
+            .filter_by_community_approval_rule()
+            .exclude(~Q(community__identifier=community_identifier)),
+        ),
     )


### PR DESCRIPTION
Add filter_by_community_approval_rule for PackageListing QuerySet

Filter the QuerySet by approval status, taking into account whether the
Community has approval process activated.

Refs TS-1980
