### PR TITLE
Implement PackageVersionManager as QuerySet and add listed_in filter

### DIFF
--- a/django/thunderstore/repository/models/package_version.py
+++ b/django/thunderstore/repository/models/package_version.py
@@ -52,6 +52,11 @@ class PackageVersionQuerySet(models.QuerySet):
             for entry in page:
                 yield entry
 
+    def listed_in(self, community_identifier: str):
+        return self.exclude(
+            ~Q(package__community_listings__community__identifier=community_identifier),
+        )
+
 
 class PackageVersion(models.Model):
     objects: "Manager[PackageVersion]" = PackageVersionQuerySet.as_manager()

--- a/django/thunderstore/repository/models/package_version.py
+++ b/django/thunderstore/repository/models/package_version.py
@@ -126,7 +126,7 @@ class PackageVersion(models.Model):
     def validate(self):
         if not re.match(PACKAGE_NAME_REGEX, self.name):
             raise ValidationError(
-                "Package names can only contain a-z A-Z 0-9 _ characters"
+                "Package names can only contain a-z A-Z 0-9 _ characters",
             )
 
     def save(self, *args, **kwargs):
@@ -139,7 +139,8 @@ class PackageVersion(models.Model):
         ]
         constraints = [
             models.UniqueConstraint(
-                fields=("package", "version_number"), name="unique_version_per_package"
+                fields=("package", "version_number"),
+                name="unique_version_per_package",
             ),
             models.CheckConstraint(
                 check=PackageFormats.as_query_filter(
@@ -211,20 +212,12 @@ class PackageVersion(models.Model):
 
     @cached_property
     def full_download_url(self) -> str:
-        return "%(protocol)s%(hostname)s%(path)s" % {
-            "protocol": settings.PROTOCOL,
-            "hostname": settings.PRIMARY_HOST,
-            "path": self._download_url,
-        }
+        return f"{settings.PROTOCOL}{settings.PRIMARY_HOST}{self._download_url}"
 
     @property
     def install_url(self):
-        return "ror2mm://v1/install/%(hostname)s/%(owner)s/%(name)s/%(version)s/" % {
-            "hostname": settings.PRIMARY_HOST,
-            "owner": self.package.owner.name,
-            "name": self.package.name,
-            "version": self.version_number,
-        }
+        path = f"{self.package.owner.name}/{self.package.name}/{self.version_number}"
+        return f"ror2mm://v1/install/{settings.PRIMARY_HOST}/{path}/"
 
     @staticmethod
     def post_save(sender, instance, created, **kwargs):

--- a/django/thunderstore/repository/tests/test_package_version.py
+++ b/django/thunderstore/repository/tests/test_package_version.py
@@ -51,7 +51,7 @@ def test_package_version_get_page_url(
     active_package_listing: PackageListing,
 ) -> None:
     owner_url = active_package_listing.package.latest.get_page_url(
-        active_package_listing.community.identifier
+        active_package_listing.community.identifier,
     )
     assert (
         owner_url
@@ -62,7 +62,8 @@ def test_package_version_get_page_url(
 @pytest.mark.django_db
 @pytest.mark.parametrize("protocol", ("http://", "https://"))
 @pytest.mark.parametrize(
-    "primary_host", ("primary.example.org", "secondary.example.org")
+    "primary_host",
+    ("primary.example.org", "secondary.example.org"),
 )
 def test_package_version_full_download_url(
     active_package_listing: PackageListing,
@@ -91,7 +92,8 @@ def test_package_version_format_spec_constraint(
         package_version.save()
     else:
         with pytest.raises(
-            IntegrityError, match='violates check constraint "valid_package_format"'
+            IntegrityError,
+            match='violates check constraint "valid_package_format"',
         ):
             package_version.save()
 

--- a/django/thunderstore/repository/tests/test_package_version.py
+++ b/django/thunderstore/repository/tests/test_package_version.py
@@ -3,6 +3,7 @@ from typing import Any, Literal, Union
 import pytest
 from django.db import IntegrityError
 
+from thunderstore.community.factories import PackageListingFactory
 from thunderstore.community.models.package_listing import PackageListing
 from thunderstore.repository.factories import PackageVersionFactory
 from thunderstore.repository.models import PackageVersion
@@ -19,13 +20,30 @@ def test_get_total_used_disk_space():
 
 
 @pytest.mark.django_db
-def test_package_version_manager_active():
+def test_package_version_queryset_active():
     p1 = PackageVersionFactory(is_active=True)
     p2 = PackageVersionFactory(is_active=False)
 
     active_versions = PackageVersion.objects.active()
     assert p1 in active_versions
     assert p2 not in active_versions
+
+
+@pytest.mark.django_db
+def test_package_version_queryset_listed_in():
+    l1 = PackageListingFactory()
+    l2 = PackageListingFactory()
+    l3 = PackageListingFactory()
+
+    versions1 = PackageVersion.objects.listed_in(l1.community.identifier)
+    versions2 = PackageVersion.objects.listed_in(l2.community.identifier)
+
+    assert l1.package.latest in versions1
+    assert l1.package.latest not in versions2
+    assert l2.package.latest not in versions1
+    assert l2.package.latest in versions2
+    assert l3.package.latest not in versions1
+    assert l3.package.latest not in versions2
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Implement PackageVersionManager as QuerySet and add listed_in filter

Define Manager as a QuerySet to make the methods chainable by default.
Add a new method for filtering PackageVersions by the Community where
the related package is listed.

Refs TS-1980
