### PR TITLE
Add a task queue for long running tasks

### DIFF
--- a/django/thunderstore/core/settings.py
+++ b/django/thunderstore/core/settings.py
@@ -363,6 +363,7 @@ class CeleryQueues:
     Default = "celery"
     BackgroundCache = "background.cache"
     BackgroundTask = "background.task"
+    BackgroundLongRunning = "background.long_running"
 
 
 CELERY_BROKER_URL = env.str("CELERY_BROKER_URL")

--- a/django/thunderstore/repository/tasks/caches.py
+++ b/django/thunderstore/repository/tasks/caches.py
@@ -17,7 +17,9 @@ def update_api_caches():
 
 @shared_task(
     name="thunderstore.repository.tasks.update_experimental_package_index",
-    queue=CeleryQueues.BackgroundTask,
+    queue=CeleryQueues.BackgroundLongRunning,
+    soft_time_limit=60 * 60 * 23,
+    time_limit=60 * 60 * 24,
 )
 def update_experimental_package_index():
     update_api_experimental_package_index()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ x-django-service: &django-service
       BUILD_INSTALL_EXTRAS: ${BUILD_INSTALL_EXTRAS}
   environment:
     CELERY_BROKER_URL: "pyamqp://django:django@rabbitmq/django"
-    CELERY_QUEUES: "celery,background.cache,background.task"
+    CELERY_QUEUES: "celery,background.cache,background.task,background.long_running"
     DATABASE_URL: "psql://django:django@dbpool/django"
     REDIS_URL: "redis://redis:6379/0"
     PROTOCOL: "http://"


### PR DESCRIPTION
Add a dedicated task queue for long running tasks and increase the timeout of the API index building task