### PR TITLE
Reduce package index building query usage

### DIFF
--- a/django/thunderstore/repository/api/experimental/tests/test_package_index.py
+++ b/django/thunderstore/repository/api/experimental/tests/test_package_index.py
@@ -2,7 +2,9 @@ import json
 
 import pytest
 import requests
+from django.db import connection
 from django.db.models import F
+from django.test.utils import CaptureQueriesContext
 from rest_framework.test import APIClient
 
 from thunderstore.repository.api.experimental.views.package_index import (
@@ -35,3 +37,12 @@ def test_api_experimental_package_index(api_client: APIClient):
     assert len(results) == len(expected)
     for entry in expected:
         assert entry in results
+
+
+@pytest.mark.django_db
+def test_update_api_experimental_package_index_query_count():
+    [PackageVersionFactory() for _ in range(10)]
+    assert PackageVersion.objects.count() == 10
+    with CaptureQueriesContext(connection) as context:
+        update_api_experimental_package_index()
+    assert len(context) < 8

--- a/django/thunderstore/repository/api/experimental/views/package_index.py
+++ b/django/thunderstore/repository/api/experimental/views/package_index.py
@@ -42,8 +42,10 @@ class PackageIndexEntry(serializers.Serializer):
 
 
 def serialize_package_index() -> bytes:
-    versions: PackageVersionQuerySet = PackageVersion.objects.active().annotate(
-        namespace=F("package__namespace")
+    versions: PackageVersionQuerySet = (
+        PackageVersion.objects.active()
+        .annotate(namespace=F("package__namespace"))
+        .prefetch_related("dependencies", "dependencies__package")
     )
     renderer = JSONRenderer()
     result = BytesIO()


### PR DESCRIPTION
Reduce the amount of queries executed when building the new package index by prefetching related objects. In exchange, this increases the memory consumption.