### PR TITLE
Cyberstorm API: add package details endpoint

### DIFF
--- a/django/thunderstore/api/cyberstorm/tests/test_package_details.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_package_details.py
@@ -1,0 +1,198 @@
+from datetime import datetime
+
+import pytest
+from rest_framework.test import APIClient
+
+from thunderstore.api.cyberstorm.views.package_detail import (
+    get_custom_package_detail_listing,
+)
+from thunderstore.community.factories import (
+    CommunityFactory,
+    PackageCategoryFactory,
+    PackageListingFactory,
+)
+from thunderstore.repository.factories import (
+    PackageRatingFactory,
+    PackageVersionFactory,
+    TeamMemberFactory,
+)
+
+
+@pytest.mark.django_db
+def test_get_custom_package_detail_listing__returns_objects_matching_args() -> None:
+    expected = PackageListingFactory()
+    PackageListingFactory(package_=expected.package)  # Different Community
+    PackageListingFactory(
+        community=expected.community,
+        package_kwargs={"name": expected.package.name},
+    )  # Different Namespace
+    PackageListingFactory(
+        community=expected.community,
+        package_kwargs={"namespace": expected.package.namespace},
+    )  # Different Package name
+
+    actual = get_custom_package_detail_listing(
+        expected.community.identifier,
+        expected.package.namespace.name,
+        expected.package.name,
+    )
+
+    assert actual.community.identifier == expected.community.identifier
+    assert actual.package.namespace.name == expected.package.namespace.name
+    assert actual.package.name == expected.package.name
+
+
+@pytest.mark.django_db
+def test_get_custom_package_detail_listing__treats_package_name_as_case_insensitive() -> None:
+    expected = PackageListingFactory()
+
+    requested_as_uppercase = get_custom_package_detail_listing(
+        expected.community.identifier,
+        expected.package.namespace.name,
+        expected.package.name.upper(),
+    )
+    requested_as_lowercase = get_custom_package_detail_listing(
+        expected.community.identifier,
+        expected.package.namespace.name,
+        expected.package.name.lower(),
+    )
+
+    assert requested_as_uppercase.package.name == expected.package.name
+    assert requested_as_lowercase.package.name == expected.package.name
+
+
+@pytest.mark.django_db
+def test_get_custom_package_detail_listing__annotates_downloads_and_ratings() -> None:
+    listing = PackageListingFactory(package_version_kwargs={"downloads": 100})
+    PackageVersionFactory(
+        package=listing.package,
+        version_number="1.0.1",
+        downloads=20,
+    )
+    PackageVersionFactory(
+        package=listing.package,
+        version_number="1.0.2",
+        downloads=3,
+    )
+
+    [PackageRatingFactory(package=listing.package) for _ in range(3)]
+
+    actual = get_custom_package_detail_listing(
+        listing.community.identifier,
+        listing.package.namespace.name,
+        listing.package.name.upper(),
+    )
+
+    assert actual.download_count == 123
+    assert actual.rating_count == 3
+
+
+@pytest.mark.django_db
+def test_get_custom_package_detail_listing__augments_listing_with_dependant_count() -> None:
+    listing = PackageListingFactory()
+    dependant_count = 5
+
+    for _ in range(dependant_count):
+        dependant = PackageVersionFactory()
+        dependant.dependencies.add(listing.package.latest)
+
+    actual = get_custom_package_detail_listing(
+        listing.community.identifier,
+        listing.package.namespace.name,
+        listing.package.name.upper(),
+    )
+
+    assert actual.dependant_count == dependant_count
+
+
+@pytest.mark.django_db
+def test_get_custom_package_detail_listing__augments_listing_with_dependencies_from_same_community() -> None:
+    dependant = PackageListingFactory()
+    dependency1 = PackageListingFactory(community=dependant.community)
+    dependency2 = PackageListingFactory()
+    dependency3 = PackageListingFactory(community=dependant.community)
+    dependant.package.latest.dependencies.set(
+        [
+            dependency1.package.latest,
+            dependency2.package.latest,
+            dependency3.package.latest,
+        ],
+    )
+
+    actual = get_custom_package_detail_listing(
+        dependant.community.identifier,
+        dependant.package.namespace.name,
+        dependant.package.name.upper(),
+    )
+
+    assert actual.dependencies.count() == 2
+    assert dependency1.package.latest in actual.dependencies
+    assert dependency2.package.latest not in actual.dependencies
+    assert dependency3.package.latest in actual.dependencies
+
+
+@pytest.mark.django_db
+def test_package_detail_view__returns_info(api_client: APIClient) -> None:
+    community = CommunityFactory()
+    category = PackageCategoryFactory(community=community)
+    listing = PackageListingFactory(
+        community=community,
+        categories=[category],
+        package_kwargs={"is_pinned": True},
+        package_version_kwargs={
+            "changelog": " ",
+            "downloads": 99,
+            "website_url": "https://thunderstore.io/",
+        },
+    )
+    latest = listing.package.latest
+    dependant = PackageVersionFactory()
+    dependant.dependencies.set([latest])
+    dependency = PackageListingFactory(community=community)
+    latest.dependencies.set([dependency.package.latest])
+    [PackageRatingFactory(package=listing.package) for _ in range(8)]
+    owner = TeamMemberFactory(team=listing.package.owner, role="owner")
+    member = TeamMemberFactory(team=listing.package.owner, role="member")
+
+    response = api_client.get(
+        f"/api/cyberstorm/package/{community.identifier}/{listing.package.namespace}/{listing.package.name}/",
+    )
+    actual = response.json()
+
+    assert len(actual["categories"]) == 1
+    assert actual["categories"][0]["id"] == str(category.id)
+    assert actual["community_identifier"] == community.identifier
+    assert actual["community_name"] == community.name
+    assert actual["datetime_created"] == _date_to_z(latest.date_created)
+    assert actual["dependant_count"] == 1
+    assert len(actual["dependencies"]) == 1
+    assert actual["dependencies"][0]["community_identifier"] == community.identifier
+    assert actual["dependencies"][0]["namespace"] == dependency.package.namespace.name
+    assert actual["dependencies"][0]["name"] == dependency.package.name
+    assert actual["description"] == latest.description
+    assert actual["download_count"] == 99
+    assert actual["download_url"] == latest.full_download_url
+    assert actual["full_version_name"] == latest.full_version_name
+    assert actual["has_changelog"] == bool(latest.changelog.strip())
+    assert actual["icon_url"] == latest.icon.url
+    assert actual["install_url"] == latest.install_url
+    assert actual["is_deprecated"] == listing.package.is_deprecated
+    assert actual["is_nsfw"] == listing.has_nsfw_content
+    assert actual["is_pinned"] == listing.package.is_pinned
+    assert actual["last_updated"] == _date_to_z(listing.package.date_updated)
+    assert actual["latest_version_number"] == latest.version_number
+    assert actual["name"] == listing.package.name
+    assert actual["namespace"] == listing.package.namespace.name
+    assert actual["rating_count"] == 8
+    assert actual["size"] == latest.file_size
+    assert actual["team"]["name"] == listing.package.owner.name
+    assert len(actual["team"]["members"]) == 2
+    assert actual["team"]["members"][0]["identifier"] == owner.user.id
+    assert actual["team"]["members"][0]["role"] == "owner"
+    assert actual["team"]["members"][1]["identifier"] == member.user.id
+    assert actual["team"]["members"][1]["role"] == "member"
+    assert actual["website_url"] == latest.website_url
+
+
+def _date_to_z(value: datetime) -> str:
+    return value.strftime("%Y-%m-%dT%H:%M:%S.%fZ")

--- a/django/thunderstore/api/cyberstorm/views/__init__.py
+++ b/django/thunderstore/api/cyberstorm/views/__init__.py
@@ -1,6 +1,7 @@
 from .community_detail import CommunityDetailAPIView
 from .community_filters import CommunityFiltersAPIView
 from .community_list import CommunityListAPIView
+from .package_detail import PackageDetailAPIView
 from .packages import (
     CommunityPackageListAPIView,
     NamespacePackageListAPIView,
@@ -15,6 +16,7 @@ __all__ = [
     "CommunityPackageListAPIView",
     "NamespacePackageListAPIView",
     "PackageDependantsListAPIView",
+    "PackageDetailAPIView",
     "TeamDetailAPIView",
     "TeamMembersAPIView",
     "TeamServiceAccountsAPIView",

--- a/django/thunderstore/api/cyberstorm/views/package_detail.py
+++ b/django/thunderstore/api/cyberstorm/views/package_detail.py
@@ -1,0 +1,152 @@
+from django.db.models import CharField, Count, OuterRef, QuerySet, Subquery, Sum, Value
+from rest_framework import serializers
+from rest_framework.generics import RetrieveAPIView, get_object_or_404
+
+from thunderstore.api.cyberstorm.serializers import (
+    CyberstormPackageCategorySerializer,
+    CyberstormTeamMemberSerializer,
+)
+from thunderstore.api.utils import CyberstormAutoSchemaMixin
+from thunderstore.community.models.package_listing import PackageListing
+from thunderstore.repository.models.package import get_package_dependants
+from thunderstore.repository.models.package_version import PackageVersion
+
+
+class DependencySerializer(serializers.Serializer):
+    """
+    Dependencies of a given PackageVersion, listed in a given Community.
+
+    community_identifier and namespace are not present by default and
+    need to be annotated to the object.
+    """
+
+    community_identifier = serializers.CharField()
+    description = serializers.CharField()
+    icon_url = serializers.CharField(source="icon.url")
+    name = serializers.CharField()
+    namespace = serializers.CharField(source="package.namespace.name")
+    version_number = serializers.CharField()
+
+
+class TeamSerializer(serializers.Serializer):
+    """
+    Minimal information to present the team on package detail view.
+    """
+
+    name = serializers.CharField()
+    members = CyberstormTeamMemberSerializer(many=True)
+
+
+class ResponseSerializer(serializers.Serializer):
+    """
+    Data shown on package detail view.
+
+    Expects an annotated and customized CustomListing object.
+    """
+
+    categories = CyberstormPackageCategorySerializer(many=True)
+    community_identifier = serializers.CharField(source="community.identifier")
+    community_name = serializers.CharField(source="community.name")
+    datetime_created = serializers.DateTimeField(source="package.latest.date_created")
+    dependant_count = serializers.IntegerField(min_value=0)
+    dependencies = DependencySerializer(many=True)
+    description = serializers.CharField(source="package.latest.description")
+    download_count = serializers.IntegerField(min_value=0)
+    download_url = serializers.CharField(source="package.latest.full_download_url")
+    full_version_name = serializers.CharField(source="package.latest")
+    has_changelog = serializers.SerializerMethodField()
+    icon_url = serializers.CharField(source="package.latest.icon.url")
+    install_url = serializers.CharField(source="package.latest.install_url")
+    is_deprecated = serializers.BooleanField(source="package.is_deprecated")
+    is_nsfw = serializers.BooleanField(source="has_nsfw_content")
+    is_pinned = serializers.BooleanField(source="package.is_pinned")
+    last_updated = serializers.DateTimeField(source="package.date_updated")
+    latest_version_number = serializers.CharField(
+        source="package.latest.version_number",
+    )
+    name = serializers.CharField(source="package.name")
+    namespace = serializers.CharField(source="package.namespace.name")
+    rating_count = serializers.IntegerField(min_value=0)
+    size = serializers.IntegerField(min_value=0, source="package.latest.file_size")
+    team = TeamSerializer(source="package.owner")
+    website_url = serializers.CharField(source="package.latest.website_url")
+
+    def get_has_changelog(self, listing: PackageListing) -> bool:
+        changelog = listing.package.latest.changelog
+        return False if changelog is None else bool(changelog.strip())
+
+
+class PackageDetailAPIView(CyberstormAutoSchemaMixin, RetrieveAPIView):
+    serializer_class = ResponseSerializer
+
+    def get_object(self):
+        return get_custom_package_detail_listing(
+            self.kwargs["community_id"],
+            self.kwargs["namespace_id"],
+            self.kwargs["package_name"],
+        )
+
+
+class CustomListing(PackageListing):
+    class Meta:
+        abstract = True
+
+    dependant_count: int
+    dependencies: QuerySet[PackageVersion]
+    download_count: int
+    rating_count: int
+
+
+def get_custom_package_detail_listing(
+    community_id: str,
+    namespace_id: str,
+    package_name: str,
+) -> CustomListing:
+    listing_ref = PackageListing.objects.filter(pk=OuterRef("pk"))
+
+    qs = (
+        PackageListing.objects.active()
+        .filter_by_community_approval_rule()
+        .select_related(
+            "community",
+            "package__latest",
+            "package__namespace",
+            "package__owner",
+        )
+        .prefetch_related(
+            "categories",
+            "package__owner__members",
+        )
+        .annotate(
+            download_count=Subquery(
+                listing_ref.annotate(
+                    downloads=Sum("package__versions__downloads"),
+                ).values("downloads"),
+            ),
+            rating_count=Subquery(
+                listing_ref.annotate(
+                    ratings=Count("package__package_ratings"),
+                ).values("ratings"),
+            ),
+        )
+    )
+
+    listing = get_object_or_404(
+        qs,
+        community__identifier=community_id,
+        package__namespace__name=namespace_id,
+        package__name__iexact=package_name,
+    )
+
+    listing.dependant_count = get_package_dependants(listing.package.pk).count()
+    listing.dependencies = (
+        listing.package.latest.dependencies.active()
+        .listed_in(community_id)
+        .annotate(
+            community_identifier=Value(community_id, CharField()),
+        )
+        .select_related("package", "package__namespace")
+        .order_by("package__namespace__name", "package__name")
+    )
+
+    return listing

--- a/django/thunderstore/api/urls.py
+++ b/django/thunderstore/api/urls.py
@@ -7,6 +7,7 @@ from thunderstore.api.cyberstorm.views import (
     CommunityPackageListAPIView,
     NamespacePackageListAPIView,
     PackageDependantsListAPIView,
+    PackageDetailAPIView,
     TeamDetailAPIView,
     TeamMembersAPIView,
     TeamServiceAccountsAPIView,
@@ -37,6 +38,11 @@ cyberstorm_urls = [
         "package/<str:community_id>/<str:namespace_id>/",
         NamespacePackageListAPIView.as_view(),
         name="cyberstorm.package.community.namespace",
+    ),
+    path(
+        "package/<str:community_id>/<str:namespace_id>/<str:package_name>/",
+        PackageDetailAPIView.as_view(),
+        name="cyberstorm.package.community.namespace.package-details",
     ),
     path(
         "package/<str:community_id>/<str:namespace_id>/<str:package_name>/dependants/",


### PR DESCRIPTION
Endpoint for fetching the information required to display a package
view. Markdown content is not included since it will be read from a
separate endpoint that processes the raw data to markup in a safe
manner. Also content under different tabs is omitted since they will
be loaded separately when needed.

When the implementation was nearly complete, it occured to us that
we'll actually need a similar endpoint for each versions, whereas the
current implementation assumes the latest version is always requested.
Rather than make this a blocker now, it was decided to move on with the
current implementation and refactor it in the future as needed.

Refs TS-1980