### PR TITLE
Add note about team name usage as namespace

### DIFF
--- a/builder/src/upload.tsx
+++ b/builder/src/upload.tsx
@@ -349,7 +349,8 @@ const SubmissionForm: React.FC<SubmissionFormProps> = observer((props) => {
                                 }}
                             >
                                 <p className="mt-1 mb-2">
-                                    No teams available?{" "}
+                                    The team name will become the prefix of the
+                                    package ID. No teams available?{" "}
                                     <a href="/settings/teams/" className="ml-1">
                                         Create one here!
                                     </a>

--- a/django/thunderstore/repository/templates/repository/package_create_old.html
+++ b/django/thunderstore/repository/templates/repository/package_create_old.html
@@ -39,6 +39,7 @@
                     <div class="w-100">
                         {{ form.team }}
                         <p class="mt-1 mb-2">
+                            The team name will become the prefix of the package ID.
                             No teams available? <a href="{% url "settings.teams.create" %}" class="ml-1">Create one here!</a>
                         </p>
                     </div>


### PR DESCRIPTION
Add a note about how the team a package is uploaded to becomes a part of the package ID.

This is something that has (understandably) caused confusion to new users and led to requests to remove packages uploaded under team names that weren't intended to be included in the package ID.