### PR TITLE
Remove autofill from upload community field

### DIFF
--- a/django/thunderstore/repository/templates/repository/package_create_old.html
+++ b/django/thunderstore/repository/templates/repository/package_create_old.html
@@ -54,7 +54,7 @@
                         {# Manual rendering due to different set being displayed than validated #}
                         <select class="slimselect-lg" name="communities" id="{{ form.communities.auto_id }}" multiple>
                             {% for opt in selectable_communities %}
-                            <option value="{{ opt.identifier }}" {% if opt == community %}selected{% endif %}>{{ opt.name }}</option>
+                            <option value="{{ opt.identifier }}">{{ opt.name }}</option>
                             {% endfor %}
                         </select>
                     </div>


### PR DESCRIPTION
Stop autofilling the current community in the package upload form as accidental uploads to the wrong community have been increasingly more frequent recently.

To help finding the correct community, the community dropdown is now sorted alphabetically and the current community is always sorted to the top.