### PR TITLE
Configure blob storage to use the mirrored storage

### DIFF
--- a/django/thunderstore/core/settings.py
+++ b/django/thunderstore/core/settings.py
@@ -665,7 +665,7 @@ if all(
     PACKAGE_FILE_STORAGE = "thunderstore.core.storage.MirroredS3Storage"
     MODPACK_FILE_STORAGE = "thunderstore.core.storage.MirroredS3Storage"
     SCHEMA_FILE_STORAGE = "thunderstore.core.storage.MirroredS3Storage"
-    BLOB_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+    BLOB_FILE_STORAGE = "thunderstore.core.storage.MirroredS3Storage"
 
 # Storage Defaults
 DEFAULT_FILE_STORAGE = get_storage_class_or_stub(DEFAULT_FILE_STORAGE)


### PR DESCRIPTION
Configure the blob storage to also use the mirrored storage backend as it was mistakenly not using it yet