### PR TITLE
Add GUNICORN_WORKER_CONNECTIONS config option

### DIFF
--- a/django/docker_entrypoint.py
+++ b/django/docker_entrypoint.py
@@ -76,6 +76,9 @@ AUTORELOAD = register_variable(str, "AUTORELOAD", False)
 GUNICORN_WORKER_CLASS = register_variable(str, "GUNICORN_WORKER_CLASS", "gevent")
 GUNICORN_WORKER_COUNT = register_variable(int, "GUNICORN_WORKER_COUNT", 3)
 GUNICORN_WORKER_TIMEOUT = register_variable(int, "GUNICORN_WORKER_TIMEOUT", 30)
+GUNICORN_WORKER_CONNECTIONS = register_variable(
+    int, "GUNICORN_WORKER_CONNECTIONS", 1000
+)
 GUNICORN_LOG_LEVEL = register_variable(str, "GUNICORN_LOG_LEVEL", "info")
 GUNICORN_MAX_REQUESTS = register_variable(int, "GUNICORN_MAX_REQUESTS", 10000)
 GUNICORN_MAX_REQUESTS_JITTER = register_variable(
@@ -121,6 +124,8 @@ def run_gunicorn() -> None:
         GUNICORN_MAX_REQUESTS,
         "--max-requests-jitter",
         GUNICORN_MAX_REQUESTS_JITTER,
+        "--worker-connections",
+        GUNICORN_WORKER_CONNECTIONS,
         "-w",
         GUNICORN_WORKER_COUNT,
         "-t",


### PR DESCRIPTION
Add support for configuring max simultaneous connection count per gunicorn worker with the GUNICORN_WORKER_CONNECTIONS environment variable.