### PR TITLE
Cyberstorm API: add endpoint for package's README and CHANGELOG

### DIFF
--- a/django/thunderstore/api/cyberstorm/tests/test_markdown.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_markdown.py
@@ -1,0 +1,94 @@
+from typing import Optional
+
+import pytest
+from django.http import Http404
+from rest_framework.test import APIClient
+
+from thunderstore.api.cyberstorm.views.markdown import get_package_version
+from thunderstore.repository.factories import PackageVersionFactory
+from thunderstore.repository.models import Package
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("requested_version", (None, "1.0.0", "1.0.1", "1.2.3"))
+def test_get_package_version__returns_requested_version_or_latest_by_default(
+    package: Package,
+    requested_version: Optional[str],
+) -> None:
+    PackageVersionFactory(package=package, version_number="1.0.0")
+    PackageVersionFactory(package=package, version_number="1.2.3")
+    PackageVersionFactory(package=package, version_number="1.0.1")
+
+    actual = get_package_version(
+        package.namespace.name,
+        package.name,
+        requested_version,
+    )
+
+    if requested_version:
+        assert actual.version_number == requested_version
+    else:
+        assert actual.version_number == "1.2.3"  # latest
+
+
+@pytest.mark.django_db
+def test_get_package_version__raises_for_inactive_package(
+    package: Package,
+) -> None:
+    PackageVersionFactory(package=package)
+    package.is_active = False
+    package.save()
+
+    with pytest.raises(Http404):
+        get_package_version(package.namespace.name, package.name, None)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("requested_version", (None, "1.0.0"))
+def test_get_package_version__raises_for_inactive_package_version(
+    package: Package,
+    requested_version: Optional[str],
+) -> None:
+    PackageVersionFactory(package=package, is_active=False)
+
+    with pytest.raises(Http404):
+        get_package_version(
+            package.namespace.name,
+            package.name,
+            requested_version,
+        )
+
+
+@pytest.mark.django_db
+def test_readme_api_view__prerenders_markup(api_client: APIClient) -> None:
+    v = PackageVersionFactory(readme="# Very **strong** header")
+
+    response = api_client.get(
+        f"/api/cyberstorm/readme/{v.package.namespace}/{v.package.name}/",
+    )
+    actual = response.json()
+
+    assert actual["html"] == "<h1>Very <strong>strong</strong> header</h1>\n"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("markdown", "markup"),
+    (
+        (None, ""),
+        ("Oh hai!", "<p>Oh hai!</p>\n"),
+    ),
+)
+def test_changelog_api_view__prerenders_markup(
+    api_client: APIClient,
+    markdown: Optional[str],
+    markup: str,
+) -> None:
+    v = PackageVersionFactory(changelog=markdown)
+
+    response = api_client.get(
+        f"/api/cyberstorm/changelog/{v.package.namespace}/{v.package.name}/",
+    )
+    actual = response.json()
+
+    assert actual["html"] == markup

--- a/django/thunderstore/api/cyberstorm/views/__init__.py
+++ b/django/thunderstore/api/cyberstorm/views/__init__.py
@@ -1,6 +1,7 @@
 from .community_detail import CommunityDetailAPIView
 from .community_filters import CommunityFiltersAPIView
 from .community_list import CommunityListAPIView
+from .markdown import PackageVersionChangelogAPIView, PackageVersionReadmeAPIView
 from .package_detail import PackageDetailAPIView
 from .packages import (
     CommunityPackageListAPIView,
@@ -17,6 +18,8 @@ __all__ = [
     "NamespacePackageListAPIView",
     "PackageDependantsListAPIView",
     "PackageDetailAPIView",
+    "PackageVersionChangelogAPIView",
+    "PackageVersionReadmeAPIView",
     "TeamDetailAPIView",
     "TeamMembersAPIView",
     "TeamServiceAccountsAPIView",

--- a/django/thunderstore/api/cyberstorm/views/markdown.py
+++ b/django/thunderstore/api/cyberstorm/views/markdown.py
@@ -1,0 +1,77 @@
+from typing import Optional
+
+from django.http import Http404
+from rest_framework import serializers
+from rest_framework.generics import RetrieveAPIView, get_object_or_404
+
+from thunderstore.api.utils import CyberstormAutoSchemaMixin
+from thunderstore.markdown.templatetags.markdownify import render_markdown
+from thunderstore.repository.models import Package, PackageVersion
+
+
+class CyberstormMarkdownResponseSerializer(serializers.Serializer):
+    html = serializers.CharField()
+
+
+class PackageVersionReadmeAPIView(CyberstormAutoSchemaMixin, RetrieveAPIView):
+    """
+    Return README.md prerendered as HTML.
+
+    If no version number is provided, the latest version is used.
+    """
+
+    serializer_class = CyberstormMarkdownResponseSerializer
+
+    def get_object(self):
+        package_version = get_package_version(
+            self.kwargs["namespace_id"],
+            self.kwargs["package_name"],
+            self.kwargs.get("version_number"),
+        )
+
+        return {"html": render_markdown(package_version.readme)}
+
+
+class PackageVersionChangelogAPIView(CyberstormAutoSchemaMixin, RetrieveAPIView):
+    """
+    Return CHANGELOG.md prerendered as HTML.
+
+    If no version number is provided, the latest version is used.
+    """
+
+    serializer_class = CyberstormMarkdownResponseSerializer
+
+    def get_object(self):
+        package_version = get_package_version(
+            self.kwargs["namespace_id"],
+            self.kwargs["package_name"],
+            self.kwargs.get("version_number"),
+        )
+
+        if package_version.changelog:
+            return {"html": render_markdown(package_version.changelog)}
+
+        return {"html": ""}
+
+
+def get_package_version(
+    namespace_id: str,
+    package_name: str,
+    version_number: Optional[str],
+) -> PackageVersion:
+    package = get_object_or_404(
+        Package.objects.active(),
+        namespace__name=namespace_id,
+        name__iexact=package_name,
+    )
+
+    if version_number:
+        return get_object_or_404(
+            package.versions.active(),
+            version_number=version_number,
+        )
+
+    if package.latest.is_active:
+        return package.latest
+
+    raise Http404

--- a/django/thunderstore/api/urls.py
+++ b/django/thunderstore/api/urls.py
@@ -8,6 +8,8 @@ from thunderstore.api.cyberstorm.views import (
     NamespacePackageListAPIView,
     PackageDependantsListAPIView,
     PackageDetailAPIView,
+    PackageVersionChangelogAPIView,
+    PackageVersionReadmeAPIView,
     TeamDetailAPIView,
     TeamMembersAPIView,
     TeamServiceAccountsAPIView,
@@ -63,5 +65,28 @@ cyberstorm_urls = [
         "team/<str:team_id>/service-accounts/",
         TeamServiceAccountsAPIView.as_view(),
         name="cyberstorm.team.service-accounts",
+    ),
+    # TODO: rethink URL prefixes. Now "package" is in use for community
+    # scoped things, so have to use something else for actually package
+    # (version) scoped things.
+    path(
+        "changelog/<str:namespace_id>/<str:package_name>/",
+        PackageVersionChangelogAPIView.as_view(),
+        name="cyberstorm.package-version.changelog-latest",
+    ),
+    path(
+        "changelog/<str:namespace_id>/<str:package_name>/<str:version_number>/",
+        PackageVersionChangelogAPIView.as_view(),
+        name="cyberstorm.package-version.changelog",
+    ),
+    path(
+        "readme/<str:namespace_id>/<str:package_name>/",
+        PackageVersionReadmeAPIView.as_view(),
+        name="cyberstorm.package-version.readme-latest",
+    ),
+    path(
+        "readme/<str:namespace_id>/<str:package_name>/<str:version_number>/",
+        PackageVersionReadmeAPIView.as_view(),
+        name="cyberstorm.package-version.readme",
     ),
 ]


### PR DESCRIPTION
The endpoints return the markdown prerendered to HTML.

Refs TS-2000