### PR TITLE
Disable package metrics from the experimental API

### DIFF
--- a/django/thunderstore/repository/api/experimental/serializers/main.py
+++ b/django/thunderstore/repository/api/experimental/serializers/main.py
@@ -96,10 +96,10 @@ class PackageSerializerExperimental(serializers.ModelSerializer):
         return make_full_url(self.context["request"], instance.get_absolute_url())
 
     def get_total_downloads(self, instance):
-        return instance._total_downloads
+        return -1
 
     def get_rating_score(self, instance):
-        return instance._rating_score
+        return -1
 
     class Meta:
         model = Package


### PR DESCRIPTION
Disable download & rating metrics from the experimental API, as it was returning invalid data.

The disabling is done by setting the returned values to -1, which keeps the endpoint backwards-compatible while also clearly indicating that the value is not usable.