### PR TITLE
Extend CyberstormAutoSchemaMixin to post functions

### DIFF
--- a/django/thunderstore/api/utils.py
+++ b/django/thunderstore/api/utils.py
@@ -22,3 +22,7 @@ class CyberstormAutoSchemaMixin:  # pragma: no cover
     @conditional_swagger_auto_schema(tags=["cyberstorm"])
     def get(self, *args, **kwargs):
         return super().get(*args, **kwargs)
+
+    @conditional_swagger_auto_schema(tags=["cyberstorm"])
+    def post(self, *args, **kwargs):
+        return super().get(*args, **kwargs)


### PR DESCRIPTION
Make the CyberstormAutoSchemaMixin a bit easier to use by extending post