### PR TITLE
Make all DRF endpoints require Auth by default

### DIFF
--- a/django/thunderstore/api/cyberstorm/views/community_detail.py
+++ b/django/thunderstore/api/cyberstorm/views/community_detail.py
@@ -1,4 +1,5 @@
 from rest_framework.generics import RetrieveAPIView
+from rest_framework.permissions import AllowAny
 
 from thunderstore.api.cyberstorm.serializers import CyberstormCommunitySerializer
 from thunderstore.api.utils import conditional_swagger_auto_schema
@@ -8,7 +9,7 @@ from thunderstore.community.models import Community
 class CommunityDetailAPIView(RetrieveAPIView):
     lookup_url_kwarg = "community_id"
     lookup_field = "identifier"
-    permission_classes = []
+    permission_classes = [AllowAny]
 
     # Unlisted communities are included, as direct links to them should work.
     queryset = Community.objects.all()

--- a/django/thunderstore/api/cyberstorm/views/community_filters.py
+++ b/django/thunderstore/api/cyberstorm/views/community_filters.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from rest_framework.generics import get_object_or_404
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -22,6 +23,7 @@ class CommunityFiltersAPIView(APIView):
     they can be used as filters.
     """
 
+    permission_classes = [AllowAny]
     queryset = Community.objects.prefetch_related("package_categories")
     serializer_class = CommunityFiltersAPIViewSerializer
 

--- a/django/thunderstore/api/cyberstorm/views/community_list.py
+++ b/django/thunderstore/api/cyberstorm/views/community_list.py
@@ -1,6 +1,7 @@
 from rest_framework.filters import SearchFilter
 from rest_framework.generics import ListAPIView
 from rest_framework.pagination import PageNumberPagination
+from rest_framework.permissions import AllowAny
 
 from thunderstore.api.cyberstorm.serializers import CyberstormCommunitySerializer
 from thunderstore.api.ordering import StrictOrderingFilter
@@ -13,7 +14,7 @@ class CommunityPaginator(PageNumberPagination):
 
 
 class CommunityListAPIView(ListAPIView):
-    permission_classes = []
+    permission_classes = [AllowAny]
     serializer_class = CyberstormCommunitySerializer
     pagination_class = CommunityPaginator
     queryset = Community.objects.listed()

--- a/django/thunderstore/api/cyberstorm/views/markdown.py
+++ b/django/thunderstore/api/cyberstorm/views/markdown.py
@@ -3,6 +3,7 @@ from typing import Optional
 from django.http import Http404
 from rest_framework import serializers
 from rest_framework.generics import RetrieveAPIView, get_object_or_404
+from rest_framework.permissions import AllowAny
 
 from thunderstore.api.utils import CyberstormAutoSchemaMixin
 from thunderstore.markdown.templatetags.markdownify import render_markdown
@@ -20,6 +21,7 @@ class PackageVersionReadmeAPIView(CyberstormAutoSchemaMixin, RetrieveAPIView):
     If no version number is provided, the latest version is used.
     """
 
+    permission_classes = [AllowAny]
     serializer_class = CyberstormMarkdownResponseSerializer
 
     def get_object(self):
@@ -39,6 +41,7 @@ class PackageVersionChangelogAPIView(CyberstormAutoSchemaMixin, RetrieveAPIView)
     If no version number is provided, the latest version is used.
     """
 
+    permission_classes = [AllowAny]
     serializer_class = CyberstormMarkdownResponseSerializer
 
     def get_object(self):

--- a/django/thunderstore/api/cyberstorm/views/package_detail.py
+++ b/django/thunderstore/api/cyberstorm/views/package_detail.py
@@ -1,6 +1,7 @@
 from django.db.models import CharField, Count, OuterRef, QuerySet, Subquery, Sum, Value
 from rest_framework import serializers
 from rest_framework.generics import RetrieveAPIView, get_object_or_404
+from rest_framework.permissions import AllowAny
 
 from thunderstore.api.cyberstorm.serializers import (
     CyberstormPackageCategorySerializer,
@@ -77,6 +78,7 @@ class ResponseSerializer(serializers.Serializer):
 
 
 class PackageDetailAPIView(CyberstormAutoSchemaMixin, RetrieveAPIView):
+    permission_classes = [AllowAny]
     serializer_class = ResponseSerializer
 
     def get_object(self):

--- a/django/thunderstore/api/cyberstorm/views/package_versions.py
+++ b/django/thunderstore/api/cyberstorm/views/package_versions.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from rest_framework.generics import ListAPIView, get_object_or_404
+from rest_framework.permissions import AllowAny
 
 from thunderstore.api.utils import CyberstormAutoSchemaMixin
 from thunderstore.repository.models import Package
@@ -18,6 +19,7 @@ class PackageVersionsAPIView(CyberstormAutoSchemaMixin, ListAPIView):
     Return a list of available versions of the package.
     """
 
+    permission_classes = [AllowAny]
     serializer_class = CyberstormPackageVersionSerializer
 
     def get_queryset(self):

--- a/django/thunderstore/api/cyberstorm/views/packages.py
+++ b/django/thunderstore/api/cyberstorm/views/packages.py
@@ -10,6 +10,7 @@ from django.utils.decorators import method_decorator
 from rest_framework import serializers
 from rest_framework.generics import ListAPIView, get_object_or_404
 from rest_framework.pagination import PageNumberPagination
+from rest_framework.permissions import AllowAny
 
 from thunderstore.api.cyberstorm.serializers import CyberstormPackagePreviewSerializer
 from thunderstore.api.utils import conditional_swagger_auto_schema
@@ -92,6 +93,7 @@ class BasePackageListAPIView(ListAPIView):
     methods, whereas the rest are overwritten methods from ListAPIView.
     """
 
+    permission_classes = [AllowAny]
     pagination_class = PackageListPaginator
     serializer_class = CyberstormPackagePreviewSerializer
     viewname: str = ""  # Define in subclass

--- a/django/thunderstore/api/cyberstorm/views/team.py
+++ b/django/thunderstore/api/cyberstorm/views/team.py
@@ -3,7 +3,7 @@ from django.db.models import Q, QuerySet
 from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.generics import ListAPIView, RetrieveAPIView, get_object_or_404
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -26,6 +26,7 @@ User = get_user_model()
 
 
 class TeamDetailAPIView(CyberstormAutoSchemaMixin, RetrieveAPIView):
+    permission_classes = [AllowAny]
     serializer_class = CyberstormTeamSerializer
     queryset = Team.objects.exclude(is_active=False)
     lookup_field = "name__iexact"
@@ -76,6 +77,8 @@ class CyberstormTeamAddMemberResponseSerialiazer(serializers.Serializer):
 
 
 class AddTeamMemberAPIView(APIView):
+    permission_classes = [AllowAny]
+
     @conditional_swagger_auto_schema(
         request_body=CyberstormTeamAddMemberRequestSerialiazer,
         responses={200: CyberstormTeamAddMemberResponseSerialiazer},

--- a/django/thunderstore/community/api/experimental/views.py
+++ b/django/thunderstore/community/api/experimental/views.py
@@ -5,6 +5,7 @@ from rest_framework import status
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.generics import GenericAPIView, ListAPIView, get_object_or_404
 from rest_framework.pagination import CursorPagination
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -60,6 +61,7 @@ class CustomListAPIView(ListAPIView):
 
 
 class CommunitiesExperimentalApiView(CustomListAPIView):
+    permission_classes = [AllowAny]
     pagination_class = CustomCursorPagination
     queryset = Community.objects.listed()
     serializer_class = CommunitySerializer
@@ -70,6 +72,7 @@ class CommunitiesExperimentalApiView(CustomListAPIView):
 
 
 class PackageCategoriesExperimentalApiView(CustomListAPIView):
+    permission_classes = [AllowAny]
     pagination_class = CustomCursorPagination
     serializer_class = PackageCategorySerializer
 
@@ -84,6 +87,7 @@ class PackageCategoriesExperimentalApiView(CustomListAPIView):
 
 
 class CurrentCommunityExperimentalApiView(APIView):
+    permission_classes = [AllowAny]
     serializer_class = CommunitySerializer
 
     @swagger_auto_schema(
@@ -98,6 +102,7 @@ class CurrentCommunityExperimentalApiView(APIView):
 
 
 class PackageListingUpdateApiView(GenericAPIView):
+    permission_classes = [AllowAny]
     queryset = PackageListing.objects.active().select_related(
         "community",
         "package",

--- a/django/thunderstore/core/settings.py
+++ b/django/thunderstore/core/settings.py
@@ -523,6 +523,9 @@ REST_FRAMEWORK = {
         "thunderstore.account.authentication.UserSessionTokenAuthentication",
     ],
     "EXCEPTION_HANDLER": "thunderstore.core.exception_handler.exception_handler",
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.IsAuthenticated",
+    ],
 }
 
 # Thumbnails

--- a/django/thunderstore/frontend/api/experimental/views/community_package_list.py
+++ b/django/thunderstore/frontend/api/experimental/views/community_package_list.py
@@ -7,6 +7,7 @@ from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
 from rest_framework.exceptions import ParseError
 from rest_framework.generics import get_object_or_404
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -27,7 +28,7 @@ class CommunityPackageListApiView(APIView):
     Return paginated list of community's packages.
     """
 
-    permission_classes = []
+    permission_classes = [AllowAny]
 
     @swagger_auto_schema(
         responses={200: CommunityPackageListSerializer()},

--- a/django/thunderstore/frontend/api/experimental/views/frontpage.py
+++ b/django/thunderstore/frontend/api/experimental/views/frontpage.py
@@ -1,6 +1,7 @@
 from django.db.models import QuerySet
 from django.http import HttpRequest, HttpResponse
 from drf_yasg.utils import swagger_auto_schema
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -15,7 +16,7 @@ class FrontPageApiView(APIView):
     Return information required to render the site's front page.
     """
 
-    permission_classes = []
+    permission_classes = [AllowAny]
 
     @swagger_auto_schema(
         responses={200: FrontPageContentSerializer()},

--- a/django/thunderstore/frontend/api/experimental/views/markdown.py
+++ b/django/thunderstore/frontend/api/experimental/views/markdown.py
@@ -1,5 +1,6 @@
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -12,7 +13,7 @@ from thunderstore.markdown.templatetags.markdownify import render_markdown
 
 class RenderMarkdownApiView(APIView):
     serializer_class = RenderMarkdownResponseSerializer
-    permission_classes = []
+    permission_classes = [AllowAny]
 
     @swagger_auto_schema(
         request_body=RenderMarkdownParamsSerializer,

--- a/django/thunderstore/frontend/api/experimental/views/package_details.py
+++ b/django/thunderstore/frontend/api/experimental/views/package_details.py
@@ -3,6 +3,7 @@ from django.http import Http404, HttpRequest, HttpResponse
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
 from rest_framework.generics import get_object_or_404
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -21,7 +22,7 @@ class PackageDetailApiView(APIView):
     Return details about a single Package.
     """
 
-    permission_classes = []
+    permission_classes = [AllowAny]
 
     @swagger_auto_schema(
         responses={200: PackageDetailViewContentSerializer()},

--- a/django/thunderstore/modpacks/api/experimental/views/legacyprofile.py
+++ b/django/thunderstore/modpacks/api/experimental/views/legacyprofile.py
@@ -6,6 +6,7 @@ from rest_framework import serializers, status
 from rest_framework.exceptions import ValidationError
 from rest_framework.generics import get_object_or_404
 from rest_framework.parsers import FileUploadParser
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.throttling import UserRateThrottle
 from rest_framework.views import APIView
@@ -30,7 +31,7 @@ class LegacyProfileCreateThrottle(UserRateThrottle):
 
 
 class LegacyProfileCreateApiView(APIView):
-    permission_classes = []
+    permission_classes = [AllowAny]
     parser_classes = [LegacyProfileFileUploadParser]
     throttle_classes = [LegacyProfileCreateThrottle]
 
@@ -54,7 +55,7 @@ class LegacyProfileCreateApiView(APIView):
 
 
 class LegacyProfileRetrieveApiView(APIView):
-    permission_classes = []
+    permission_classes = [AllowAny]
 
     @swagger_auto_schema(
         responses={200: Schema(title="content", type=TYPE_FILE)},

--- a/django/thunderstore/repository/api/experimental/views/package.py
+++ b/django/thunderstore/repository/api/experimental/views/package.py
@@ -3,6 +3,7 @@ from drf_yasg.utils import swagger_auto_schema
 from rest_framework.exceptions import ValidationError
 from rest_framework.generics import ListAPIView, RetrieveAPIView, get_object_or_404
 from rest_framework.pagination import CursorPagination
+from rest_framework.permissions import AllowAny
 
 from thunderstore.cache.cache import ManualCacheCommunityMixin
 from thunderstore.cache.enums import CacheBustCondition
@@ -49,6 +50,7 @@ class PackageListApiView(ManualCacheCommunityMixin, ListAPIView):
     Lists all available packages
     """
 
+    permission_classes = [AllowAny]
     cache_until = CacheBustCondition.any_package_updated
     serializer_class = PackageSerializerExperimental
     pagination_class = CustomCursorPagination
@@ -69,6 +71,7 @@ class PackageDetailApiView(ManualCacheCommunityMixin, RetrieveAPIView):
     Get a single package
     """
 
+    permission_classes = [AllowAny]
     cache_until = CacheBustCondition.any_package_updated
     serializer_class = PackageSerializerExperimental
 

--- a/django/thunderstore/repository/api/experimental/views/package_index.py
+++ b/django/thunderstore/repository/api/experimental/views/package_index.py
@@ -7,6 +7,7 @@ from django.shortcuts import redirect
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import serializers
 from rest_framework.exceptions import APIException
+from rest_framework.permissions import AllowAny
 from rest_framework.renderers import JSONRenderer
 from rest_framework.views import APIView
 from sentry_sdk import capture_exception
@@ -80,6 +81,8 @@ class PackageIndexApiView(APIView):
     Lists all known package versions across all communities in a stream of
     newline delimited JSON.
     """
+
+    permission_classes = [AllowAny]
 
     @swagger_auto_schema(
         tags=["experimental"],

--- a/django/thunderstore/repository/api/experimental/views/package_version.py
+++ b/django/thunderstore/repository/api/experimental/views/package_version.py
@@ -1,6 +1,7 @@
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework.exceptions import ValidationError
 from rest_framework.generics import RetrieveAPIView, get_object_or_404
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
 from thunderstore.cache.cache import ManualCacheCommunityMixin
@@ -59,6 +60,7 @@ class PackageVersionDetailApiView(PackageVersionDetailMixin):
     Get a single package version
     """
 
+    permission_classes = [AllowAny]
     serializer_class = PackageVersionSerializerExperimental
 
     @swagger_auto_schema(
@@ -74,6 +76,7 @@ class PackageVersionChangelogApiView(PackageVersionDetailMixin):
     Get a package verion's changelog
     """
 
+    permission_classes = [AllowAny]
     serializer_class = MarkdownResponseSerializer
 
     @swagger_auto_schema(
@@ -94,6 +97,7 @@ class PackageVersionReadmeApiView(PackageVersionDetailMixin):
     Get a package verion's readme
     """
 
+    permission_classes = [AllowAny]
     serializer_class = MarkdownResponseSerializer
 
     @swagger_auto_schema(

--- a/django/thunderstore/repository/api/experimental/views/wiki.py
+++ b/django/thunderstore/repository/api/experimental/views/wiki.py
@@ -9,6 +9,7 @@ from drf_yasg.utils import swagger_auto_schema
 from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.generics import GenericAPIView, RetrieveAPIView, get_object_or_404
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
 from thunderstore.repository.models import Package, PackageWiki
@@ -23,6 +24,7 @@ from thunderstore.wiki.models import Wiki, WikiPage
 
 
 class PackageWikiApiView(RetrieveAPIView):
+    permission_classes = [AllowAny]
     queryset = Wiki.objects.all().prefetch_related("pages")
     serializer_class = WikiSerializer
 
@@ -136,6 +138,7 @@ class PackageWikiListResponse(serializers.Serializer):
 
 
 class PackageWikiListAPIView(GenericAPIView):
+    permission_classes = [AllowAny]
     queryset = (
         PackageWiki.objects.all()
         .annotate(namespace=F("package__owner__name"), name=F("package__name"))

--- a/django/thunderstore/repository/api/v1/views.py
+++ b/django/thunderstore/repository/api/v1/views.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework.exceptions import NotFound, PermissionDenied
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
 from thunderstore.core.jwt_helpers import JWTApiView
@@ -17,6 +18,8 @@ class DeprecateModApiView(JWTApiView):
     * Requires JWT authentication.
     * Only users with special permissions may use this action
     """
+
+    permission_classes = [AllowAny]
 
     def get_package(self, package_name):
         if package_name is None:

--- a/django/thunderstore/repository/api/v1/viewsets.py
+++ b/django/thunderstore/repository/api/v1/viewsets.py
@@ -10,7 +10,7 @@ from rest_framework import viewsets
 from rest_framework.authentication import BasicAuthentication, SessionAuthentication
 from rest_framework.decorators import action
 from rest_framework.generics import get_object_or_404
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 
@@ -74,6 +74,7 @@ class PackageViewSet(
     CommunityMixin,
     viewsets.ReadOnlyModelViewSet,
 ):
+    permission_classes = [AllowAny]
     cache_database_fallback = False
     serializer_class = PACKAGE_SERIALIZER
     lookup_field = "package__uuid4"

--- a/django/thunderstore/schema_server/api/experimental/views/channel.py
+++ b/django/thunderstore/schema_server/api/experimental/views/channel.py
@@ -9,6 +9,7 @@ from rest_framework import serializers, status
 from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
 from rest_framework.generics import get_object_or_404
 from rest_framework.parsers import FileUploadParser
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -28,7 +29,7 @@ class SchemaFileUploadParser(FileUploadParser):
 
 
 class SchemaChannelApiView(APIView):
-    permission_classes = []
+    permission_classes = [AllowAny]
     parser_classes = [SchemaFileUploadParser]
     throttle_classes = []
 
@@ -65,7 +66,7 @@ class SchemaChannelApiView(APIView):
 
 
 class SchemaChannelLatestApiView(APIView):
-    permission_classes = []
+    permission_classes = [AllowAny]
 
     @swagger_auto_schema(
         responses={200: Schema(title="content", type=TYPE_FILE)},

--- a/django/thunderstore/social/api/experimental/views/current_user.py
+++ b/django/thunderstore/social/api/experimental/views/current_user.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 from drf_yasg.utils import swagger_auto_schema
 from pydantic import BaseModel
 from rest_framework import serializers
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -19,6 +20,8 @@ class CurrentUserExperimentalApiView(APIView):
     """
     Gets information about the current user, such as rated packages and permissions
     """
+
+    permission_classes = [AllowAny]
 
     @swagger_auto_schema(tags=["experimental"])
     def get(self, request, format=None):

--- a/django/thunderstore/social/api/experimental/views/overwolf.py
+++ b/django/thunderstore/social/api/experimental/views/overwolf.py
@@ -9,7 +9,7 @@ from drf_yasg.utils import swagger_auto_schema  # type: ignore
 from pydantic import BaseModel
 from rest_framework import serializers
 from rest_framework.exceptions import AuthenticationFailed
-from rest_framework.permissions import BasePermission
+from rest_framework.permissions import AllowAny, BasePermission
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -54,7 +54,7 @@ class OverwolfLoginApiView(APIView):
     login process triggered from a browser.
     """
 
-    permission_classes: Sequence[Type[BasePermission]] = []
+    permission_classes: Sequence[Type[BasePermission]] = [AllowAny]
 
     @swagger_auto_schema(
         operation_id="experimental.auth.overwolf.login",

--- a/django/thunderstore/social/api/experimental/views/validate_session.py
+++ b/django/thunderstore/social/api/experimental/views/validate_session.py
@@ -1,5 +1,6 @@
 from django.http import HttpResponse
 from drf_yasg.utils import swagger_auto_schema  # type: ignore
+from rest_framework.permissions import AllowAny
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.status import HTTP_401_UNAUTHORIZED
@@ -10,6 +11,8 @@ class ValidateSessionApiView(APIView):
     """
     Check that valid session key is provided in Authorization header.
     """
+
+    permission_classes = [AllowAny]
 
     @swagger_auto_schema(
         operation_id="experimental.auth.validate",

--- a/django/thunderstore/social/api/v1/views/current_user.py
+++ b/django/thunderstore/social/api/v1/views/current_user.py
@@ -1,5 +1,6 @@
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework.authentication import BasicAuthentication, SessionAuthentication
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -10,6 +11,7 @@ class CurrentUserInfoView(APIView):
     """
 
     authentication_classes = [SessionAuthentication, BasicAuthentication]
+    permission_classes = [AllowAny]
 
     @swagger_auto_schema(tags=["v1"])
     def get(self, request, format=None, community_identifier=None):

--- a/django/thunderstore/wiki/api/experimental/views.py
+++ b/django/thunderstore/wiki/api/experimental/views.py
@@ -1,11 +1,13 @@
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework.generics import RetrieveAPIView
+from rest_framework.permissions import AllowAny
 
 from thunderstore.wiki.api.experimental.serializers import WikiPageSerializer
 from thunderstore.wiki.models import WikiPage
 
 
 class WikiPageApiView(RetrieveAPIView):
+    permission_classes = [AllowAny]
     queryset = WikiPage.objects.all()
     serializer_class = WikiPageSerializer
 


### PR DESCRIPTION
Make all DRF endpoints require Auth by default

Add AllowAny to endpoints that should be available without Auth