### PR TITLE
Update dependants link wording

### DIFF
--- a/django/thunderstore/repository/views/repository.py
+++ b/django/thunderstore/repository/views/repository.py
@@ -496,9 +496,13 @@ class PackageDetailView(CommunityMixin, PackageTabsMixin, DetailView):
         dependant_count = len(package_listing.package.dependants_list)
 
         if dependant_count == 1:
-            dependants_string = f"{dependant_count} other mod depends on this mod"
+            dependants_string = (
+                f"{dependant_count} other package depends on this package"
+            )
         else:
-            dependants_string = f"{dependant_count} other mods depend on this mod"
+            dependants_string = (
+                f"{dependant_count} other packages depend on this package"
+            )
 
         context["dependants_string"] = dependants_string
         context["show_management_panel"] = self.can_manage


### PR DESCRIPTION
Change the wording used in the dependants link to refer to packages instead of mods.

This change is done based on a recent discussion in the Lethal Company community, where it became apparent that using 'Mods' was setting up users with false expectations, as all kinds of packages are included in the number (such as modpacks).

While this doesn't solve the use case of "I want to see how many other mod developers integrate with my mod" (which seemed to be the main use case), it should at least be a minor improvement over the previous wording.