### PR TITLE
Fix odd issue with test state consistency

### DIFF
--- a/django/thunderstore/core/tests/test_storage.py
+++ b/django/thunderstore/core/tests/test_storage.py
@@ -37,7 +37,7 @@ def test_get_storage_class_or_stub(mocker) -> None:
 )
 @pytest.mark.django_db
 def test_mirrored_storage(dummy_image: Image) -> None:
-    pv = PackageVersionFactory(icon=None)
+    pv = PackageVersionFactory(icon=None, name="MirrorStorageTest")
     icon_path = get_version_png_filepath(pv, "")
 
     assert hasattr(default_storage, "mirrors")


### PR DESCRIPTION
Evidently some configurations of test run splitting will lead to a problem where a test starts off expecting a file to not exist in an S3 bucket, but it does. This problem does not occur if all tests are run.

This does not solve the root cause, but it does address the issue for the specific test which was failing.