### PR TITLE
Stop implicit removal of categories

### DIFF
--- a/django/thunderstore/repository/models/package.py
+++ b/django/thunderstore/repository/models/package.py
@@ -131,7 +131,7 @@ class Package(models.Model):
         listing = self.get_or_create_package_listing(community)
         listing.has_nsfw_content = has_nsfw_content
         if categories:
-            listing.categories.set(categories)
+            listing.categories.add(*categories)
         listing.save(update_fields=("has_nsfw_content",))
 
     @cached_property


### PR DESCRIPTION
Adjust the upload processing behavior to not implicitly remove existing categories from packages when a new version is uploaded. Many users re-select some categories when updating their package without realizing that any category _not_ selected gets removed.

This commit changes the behavior so that category removals will never happen when mods are updated, which should reduce the amount of accidental category removals.

Categories can still be removed via the package management panel.