### PR TITLE
Set Community.aggregated_fields as readonly

### DIFF
--- a/django/thunderstore/community/admin/community.py
+++ b/django/thunderstore/community/admin/community.py
@@ -46,6 +46,7 @@ class CommunityAdmin(admin.ModelAdmin):
         "icon_height",
         "datetime_created",
         "datetime_updated",
+        "aggregated_fields",
     )
     inlines = (CommunityMembershipInline,)
 


### PR DESCRIPTION
Set the recently introduced aggregated_fields as read-only on the Community model admin page.