### PR TITLE
Make audit event user optional for system logs

### DIFF
--- a/django/thunderstore/webhooks/audit.py
+++ b/django/thunderstore/webhooks/audit.py
@@ -18,7 +18,7 @@ class AuditEventField(BaseModel):
 
 class AuditEvent(BaseModel):
     timestamp: datetime
-    user_id: int
+    user_id: Optional[int]
     community_id: Optional[int]
     action: AuditAction
     message: Optional[str]

--- a/django/thunderstore/webhooks/models/audit.py
+++ b/django/thunderstore/webhooks/models/audit.py
@@ -48,12 +48,15 @@ class AuditWebhook(TimestampMixin):
 
     @staticmethod
     def render_event(event: AuditEvent) -> DiscordPayload:
-        agent = User.objects.prefetch_related("social_auth").get(pk=event.user_id)
-        agent_discord_mention = None
-        for entry in agent.social_auth.all():
-            if entry.provider == "discord":
-                agent_discord_mention = f"<@{entry.uid}>"
-                break
+        agent_username = "System"
+
+        if event.user_id:
+            agent = User.objects.prefetch_related("social_auth").get(pk=event.user_id)
+            agent_username = agent.username
+            for entry in agent.social_auth.all():
+                if entry.provider == "discord":
+                    agent_username = f"<@{entry.uid}>"
+                    break
 
         return DiscordPayload(
             embeds=[
@@ -66,7 +69,7 @@ class AuditWebhook(TimestampMixin):
                     fields=[
                         DiscordEmbedField(
                             name="Triggered by",
-                            value=agent_discord_mention or agent.username,
+                            value=agent_username,
                         )
                     ]
                     + event.fields,


### PR DESCRIPTION
Make the user field in audit events optional for logs produced by system
events.