### PR TITLE
Improve package review tool & status messages

### DIFF
--- a/builder/src/api/api.ts
+++ b/builder/src/api/api.ts
@@ -84,14 +84,23 @@ class ExperimentalApiImpl extends ThunderstoreApi {
         return (await response.json()) as UpdatePackageListingResponse;
     };
 
-    approvePackageListing = async (props: { packageListingId: string }) => {
-        await this.post(ApiUrls.approvePackageListing(props.packageListingId));
+    approvePackageListing = async (props: {
+        packageListingId: string;
+        data: {
+            internal_notes: string;
+        };
+    }) => {
+        await this.post(
+            ApiUrls.approvePackageListing(props.packageListingId),
+            props.data
+        );
     };
 
     rejectPackageListing = async (props: {
         packageListingId: string;
         data: {
             rejection_reason: string;
+            internal_notes: string;
         };
     }) => {
         await this.post(

--- a/builder/src/components/PackageReview/Context.tsx
+++ b/builder/src/components/PackageReview/Context.tsx
@@ -5,6 +5,7 @@ export type ContextProps = {
     reviewStatus: ReviewStatus;
     rejectionReason: string;
     packageListingId: string;
+    internalNotes: string;
 };
 
 export interface IReviewContext {

--- a/builder/src/components/PackageReview/Modal.tsx
+++ b/builder/src/components/PackageReview/Modal.tsx
@@ -54,6 +54,14 @@ const Body: React.FC<BodyProps> = (props) => {
                         style={{ minHeight: "100px" }}
                     />
                 </div>
+                <div className="mt-3">
+                    <h6>Internal notes</h6>
+                    <textarea
+                        {...props.form.control.register("internalNotes")}
+                        className={"code-input"}
+                        style={{ minHeight: "100px" }}
+                    />
+                </div>
             </form>
             {props.form.error && (
                 <div className={"alert alert-danger mt-2 mb-0"}>
@@ -102,10 +110,7 @@ const Footer: React.FC<FooterProps> = (props) => {
 };
 export const PackageReviewModal: React.FC = () => {
     const context = useReviewContext();
-    const form = usePackageReviewForm(
-        context.props.packageListingId,
-        context.props.rejectionReason
-    );
+    const form = usePackageReviewForm(context.props);
     useOnEscape(context.closeModal);
 
     const style = {

--- a/django/thunderstore/community/api/experimental/tests/test_api_approval_status.py
+++ b/django/thunderstore/community/api/experimental/tests/test_api_approval_status.py
@@ -31,15 +31,18 @@ def test_api_experimental_package_listing_approve_success(
     active_package_listing: PackageListing,
     moderator: UserType,
 ):
+    notes = "Internal note"
     api_client.force_authenticate(user=moderator)
     response = api_client.post(
         f"/api/experimental/package-listing/{active_package_listing.pk}/approve/",
+        data=json.dumps({"internal_notes": notes}),
         content_type="application/json",
     )
 
     assert response.status_code == 200
     active_package_listing.refresh_from_db()
     assert active_package_listing.review_status == PackageListingReviewStatus.approved
+    assert active_package_listing.notes == notes
 
 
 @pytest.mark.django_db
@@ -72,10 +75,16 @@ def test_api_experimental_package_listing_reject_success(
     moderator: UserType,
 ):
     reason = "Bad upload"
+    notes = "Internal note"
     api_client.force_authenticate(user=moderator)
     response = api_client.post(
         f"/api/experimental/package-listing/{active_package_listing.pk}/reject/",
-        data=json.dumps({"rejection_reason": reason}),
+        data=json.dumps(
+            {
+                "rejection_reason": reason,
+                "internal_notes": notes,
+            }
+        ),
         content_type="application/json",
     )
 
@@ -83,6 +92,7 @@ def test_api_experimental_package_listing_reject_success(
     active_package_listing.refresh_from_db()
     assert active_package_listing.review_status == PackageListingReviewStatus.rejected
     assert active_package_listing.rejection_reason == reason
+    assert active_package_listing.notes == notes
 
 
 @pytest.mark.django_db

--- a/django/thunderstore/community/templates/community/packagelisting_detail.html
+++ b/django/thunderstore/community/templates/community/packagelisting_detail.html
@@ -48,6 +48,7 @@ window.ts.PackageManagementPanel(
 );
 </script>
 {% endif %}
+
 {% cache_until "any_package_updated" "mod-detail-header" 300 object.package.pk community_identifier %}
 
 <nav class="mt-3" aria-label="breadcrumb">
@@ -65,14 +66,18 @@ window.ts.PackageManagementPanel(
     </div>
 {% endif %}
 
-{% if object.is_rejected %}
+{% endcache %}
+
+{% if show_review_status and object.is_rejected %}
 <div class="card text-white bg-danger mt-2">
     <div class="card-body">
         <h4 class="card-title">
             Package rejected
         </h4>
         <p class="card-text">
-            This package has been rejected by site or community moderators
+            This package has been rejected by site or community moderators.
+            If you think this is a mistake, please reach out to the moderators in
+            <a href="https://discord.thunderstore.io/">our Discord server</a>
         </p>
         {% if object.rejection_reason %}
         <p class="card-text">
@@ -83,7 +88,7 @@ window.ts.PackageManagementPanel(
 </div>
 {% endif %}
 
-{% if object.is_waiting_for_approval %}
+{% if show_review_status and object.is_waiting_for_approval %}
 <div class="card text-white bg-warning mt-2">
     <div class="card-body">
         <h4 class="card-title">
@@ -96,8 +101,18 @@ window.ts.PackageManagementPanel(
 </div>
 {% endif %}
 
+{% if show_internal_notes and object.notes %}
+    <div class="card text-white bg-info mt-2">
+        <div class="card-body">
+            <h4 class="card-title">
+                Internal notes
+            </h4>
+            <p class="card-text">{{ object.notes }}</p>
+        </div>
+    </div>
+{% endif %}
+
 <div class="card bg-light mt-2">
-    {% endcache %}
     {% include "community/includes/package_tabs.html" with tabs=tabs %}
     {% cache_until "any_package_updated" "mod-detail-content" 300 object.package.pk community_identifier %}
     <div class="card-header">

--- a/django/thunderstore/repository/views/repository.py
+++ b/django/thunderstore/repository/views/repository.py
@@ -520,6 +520,7 @@ class PackageDetailView(CommunityMixin, PackageTabsMixin, DetailView):
         return {
             "reviewStatus": self.object.review_status,
             "rejectionReason": self.object.rejection_reason,
+            "internalNotes": self.object.notes,
             "packageListingId": self.object.pk,
         }
 

--- a/django/thunderstore/repository/views/repository.py
+++ b/django/thunderstore/repository/views/repository.py
@@ -480,7 +480,7 @@ class PackageDetailView(CommunityMixin, PackageTabsMixin, DetailView):
             raise Http404("Package is waiting for approval or has been rejected")
         return listing
 
-    @property
+    @cached_property
     def can_manage(self):
         return any(
             (
@@ -494,7 +494,7 @@ class PackageDetailView(CommunityMixin, PackageTabsMixin, DetailView):
     def can_manage_deprecation(self):
         return self.object.package.can_user_manage_deprecation(self.request.user)
 
-    @property
+    @cached_property
     def can_manage_categories(self) -> bool:
         return check_validity(
             lambda: self.object.ensure_update_categories_permission(self.request.user)
@@ -514,8 +514,12 @@ class PackageDetailView(CommunityMixin, PackageTabsMixin, DetailView):
     def can_unlist(self):
         return self.request.user.is_superuser
 
+    @cached_property
+    def can_moderate(self) -> bool:
+        return self.object.community.can_user_manage_packages(self.request.user)
+
     def get_review_panel(self):
-        if not self.object.community.can_user_manage_packages(self.request.user):
+        if not self.can_moderate:
             return None
         return {
             "reviewStatus": self.object.review_status,
@@ -547,6 +551,8 @@ class PackageDetailView(CommunityMixin, PackageTabsMixin, DetailView):
         context["show_package_admin_link"] = can_view_package_admin(
             self.request.user, package_listing.package
         )
+        context["show_review_status"] = self.can_manage
+        context["show_internal_notes"] = self.can_moderate
 
         def format_category(cat: PackageCategory):
             return {"name": cat.name, "slug": cat.slug}


### PR DESCRIPTION
Add a link to the Thunderstore Discord on the package rejection message as a means of contacting moderators for clarification on rejections.

Additionally include a moderator-only panel for internal notes and make it possible to include them when approving or rejecting packages.