### PR TITLE
Increase the community dropdown size to 4 columns

### DIFF
--- a/builder/src/scss/navbar.scss
+++ b/builder/src/scss/navbar.scss
@@ -6,7 +6,11 @@
         padding: 1.5rem 1.75rem;
 
         .grid {
-            column-count: 3;
+            column-count: 4;
+
+            @media (max-width: 1500px) {
+                column-count: 3;
+            }
 
             @media (max-width: 1160px) {
                 column-count: 2;

--- a/django/thunderstore/frontend/templates/base.html
+++ b/django/thunderstore/frontend/templates/base.html
@@ -53,7 +53,7 @@
                             <div class="section">
                                 <h6 class="title">Popular communities</h6>
                                 <div class="grid" role="list">
-                                    {% for community in selectable_communities|slice:":6"|dictsort:"name" %}
+                                    {% for community in selectable_communities|slice:":8"|dictsort:"name" %}
                                         <a class="grid-item" href="{{ community.full_url }}" role="listitem">{{ community.name }}</a>
                                     {% endfor %}
                                 </div>
@@ -62,7 +62,7 @@
                                 <div class="section">
                                     <h6 class="title">Other communities</h6>
                                     <div class="grid" role="list">
-                                        {% for community in selectable_communities|slice:"6:"|dictsort:"name" %}
+                                        {% for community in selectable_communities|slice:"8:"|dictsort:"name" %}
                                             <a class="grid-item" href="{{ community.full_url }}" role="listitem">{{ community.name }}</a>
                                         {% endfor %}
                                     </div>


### PR DESCRIPTION
Increase the community selection dropdown to 4 columns as it no longer fits new communities.

Hopefully we'll get the community list page ready before this becomes a problem again.