### PR TITLE
Cyberstorm: show deprecated package dependencies

### DIFF
--- a/django/thunderstore/api/cyberstorm/views/package_listing.py
+++ b/django/thunderstore/api/cyberstorm/views/package_listing.py
@@ -34,6 +34,7 @@ class DependencySerializer(serializers.Serializer):
     community_identifier = serializers.CharField()
     description = serializers.CharField()
     icon_url = serializers.CharField(source="icon.url")
+    is_active = serializers.BooleanField(source="is_effectively_active")
     name = serializers.CharField()
     namespace = serializers.CharField(source="package.namespace.name")
     version_number = serializers.CharField()
@@ -165,8 +166,7 @@ def get_custom_package_listing(
     )
 
     dependencies = (
-        listing.package.latest.dependencies.active()
-        .listed_in(community_id)
+        listing.package.latest.dependencies.listed_in(community_id)
         .annotate(
             community_identifier=Value(community_id, CharField()),
         )

--- a/django/thunderstore/repository/models/package_version.py
+++ b/django/thunderstore/repository/models/package_version.py
@@ -193,6 +193,10 @@ class PackageVersion(models.Model):
         return self.package.is_deprecated
 
     @cached_property
+    def is_effectively_active(self):
+        return self.is_active and self.package.is_active
+
+    @cached_property
     def full_version_name(self):
         return f"{self.package.full_package_name}-{self.version_number}"
 

--- a/django/thunderstore/repository/tests/test_package_version.py
+++ b/django/thunderstore/repository/tests/test_package_version.py
@@ -5,7 +5,7 @@ from django.db import IntegrityError
 
 from thunderstore.community.factories import PackageListingFactory
 from thunderstore.community.models.package_listing import PackageListing
-from thunderstore.repository.factories import PackageVersionFactory
+from thunderstore.repository.factories import PackageFactory, PackageVersionFactory
 from thunderstore.repository.models import PackageVersion
 from thunderstore.repository.package_formats import PackageFormats
 
@@ -109,3 +109,23 @@ def test_package_version_chunked_enumerate() -> None:
         package_ids.remove(entry.pk)
 
     assert len(package_ids) == 0
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("package_is_active", "version_is_active"),
+    (
+        (False, False),
+        (True, False),
+        (False, True),
+        (True, True),
+    ),
+)
+def test_package_version_is_effectively_active(
+    package_is_active: bool,
+    version_is_active: bool,
+) -> None:
+    package = PackageFactory(is_active=package_is_active)
+    version = PackageVersionFactory(package=package, is_active=version_is_active)
+
+    assert version.is_effectively_active == (package_is_active and version_is_active)


### PR DESCRIPTION
Add PackageVersion.is_effectively_active

Helper method checks that both the PackageVersion and the related
Package are active. This is acts as a pair for the existing
Package.is_effectively_active helper.

Refs TS-2013

Cyberstorm API: include deactived dependencies for package listing

Even if a dependency is deactived, it's still a dependency of the
package, which might not work without it. To avoid misleading
information on the website, include deactived dependencies too.

PackageVersion is considered deactived if the parent Package is
deactived, even if the specific version would be active.

Annotating the "effective active status" to the QuerySet was
considered, but since the related package is prefetched for other
purposes anyway, it seemed like an unnecessary step.

Refs TS-2013

Cyberstorm API: censor deactived package dependencies

The reason why a package has been deactivated may be an obnoxious icon
or description text, so don't send those to clients.

Method serializers are used instead of annotations, since especially
for the icon field the annotation isn't straightforward: the ImageField
can't be directly attached to the object, and parsing the absolute URL
correctly from the path representation stored in the database is
error-prone.

Refs TS-2013