### PR TITLE
Bolster zip file validation

### DIFF
--- a/django/thunderstore/repository/validation/tests/test_zip.py
+++ b/django/thunderstore/repository/validation/tests/test_zip.py
@@ -1,0 +1,36 @@
+from io import BytesIO
+from zipfile import ZipFile
+
+import pytest
+
+from thunderstore.repository.validation.zip import (
+    check_relative_paths,
+    check_zero_offset,
+)
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    (("foo.txt", False), ("foo/../foo.txt", True), ("../foo.txt", True)),
+)
+def test_zip_check_relative_paths(path: str, expected: bool):
+    buffer = BytesIO()
+
+    with ZipFile(buffer, "w") as zf:
+        zf.writestr(path, "foo")
+
+    with ZipFile(buffer, "r") as zf:
+        assert check_relative_paths(zf.infolist()) is expected
+
+
+@pytest.mark.parametrize(
+    ("bogus_bytes", "expected"), ((0, True), (1000, False), (1, False))
+)
+def test_zip_check_zero_offset(bogus_bytes: int, expected: bool):
+    buffer = BytesIO(b"a" * bogus_bytes)
+
+    with ZipFile(buffer, "a") as zf:
+        zf.writestr("bar.txt", "foo")
+
+    with ZipFile(buffer, "r") as zf:
+        assert check_zero_offset(zf.infolist()) is expected

--- a/django/thunderstore/repository/validation/zip.py
+++ b/django/thunderstore/repository/validation/zip.py
@@ -1,0 +1,16 @@
+from typing import List
+from zipfile import ZipInfo
+
+
+def check_relative_paths(infolist: List[ZipInfo]) -> bool:
+    for entry in infolist:
+        if entry.filename.startswith("..") or "/.." in entry.filename:
+            return True
+    return False
+
+
+def check_zero_offset(infolist: List[ZipInfo]) -> bool:
+    for entry in infolist:
+        if entry.header_offset == 0:
+            return True
+    return False


### PR DESCRIPTION
Include validation that ensures the zip file starts at offset 0 and that it includes no relative paths in the files.

In theory the zip files might still contain bogus data in the middle, but this is fairly unlikely to happen in practice and shouldn't impact the behavior of other applications.