### PR TITLE
Add dedicated tabs for package version history and changelog

### DIFF
--- a/django/thunderstore/community/models/package_listing.py
+++ b/django/thunderstore/community/models/package_listing.py
@@ -120,6 +120,15 @@ class PackageListing(TimestampMixin, models.Model):
             )
         )
 
+    def get_versions_url(self) -> str:
+        return reverse(
+            **get_community_url_reverse_args(
+                community=self.community,
+                viewname="packages.detail.versions",
+                kwargs={"owner": self.package.owner.name, "name": self.package.name},
+            )
+        )
+
     def get_full_url(self):
         hostname = (
             settings.PRIMARY_HOST

--- a/django/thunderstore/community/models/package_listing.py
+++ b/django/thunderstore/community/models/package_listing.py
@@ -129,6 +129,15 @@ class PackageListing(TimestampMixin, models.Model):
             )
         )
 
+    def get_changelog_url(self) -> str:
+        return reverse(
+            **get_community_url_reverse_args(
+                community=self.community,
+                viewname="packages.detail.changelog",
+                kwargs={"owner": self.package.owner.name, "name": self.package.name},
+            )
+        )
+
     def get_full_url(self):
         hostname = (
             settings.PRIMARY_HOST

--- a/django/thunderstore/community/templates/community/includes/package_header.html
+++ b/django/thunderstore/community/templates/community/includes/package_header.html
@@ -1,0 +1,19 @@
+{% load thumbnail %}
+
+<div class="card-header">
+    <div class="media">
+        <img class="align-self-center mr-3" src="{% thumbnail object.package.icon 128x128 %}" alt="{{ object.package }} icon">
+        <div class="media-body">
+            <h1 class="mt-0">{{ object.package.display_name }}</h1>
+            <p>{{ object.package.description }}</p>
+            <div class="d-flex w-100 justify-content-between">
+                <h5 class="mb-1">By <a href="{{ object.owner_url }}">{{ object.package.owner.name }}</a></h5>
+                {% if object.package.website_url %}
+                    <a class="text-nowrap" href="{{ object.package.website_url }}">
+                        <span class="fa fa-globe-americas fa-fw"></span>
+                        {{ object.package.website_url }}</a>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</div>

--- a/django/thunderstore/community/templates/community/includes/version_table.html
+++ b/django/thunderstore/community/templates/community/includes/version_table.html
@@ -1,0 +1,19 @@
+<table class="table mb-0">
+    <tr>
+        <th>Upload date</th>
+        <th>Version number</th>
+        <th>Downloads</th>
+        <th>Actions</th>
+    </tr>
+    {% for version in versions %}
+        <tr>
+            <td>{{ version.date_created|date:"Y-n-j" }}</td>
+            <td>{{ version.version_number }}</td>
+            <td>{{ version.downloads }}</td>
+            <td class="d-flex gap-1">
+                <a href="{{ version.full_download_url }}" type="button" class="btn btn-primary">Download</a>
+                <a href="{{ version.install_url }}" type="button" class="btn btn-primary">Install</a>
+            </td>
+        </tr>
+    {% endfor %}
+</table>

--- a/django/thunderstore/community/templates/community/packagelisting_changelog.html
+++ b/django/thunderstore/community/templates/community/packagelisting_changelog.html
@@ -1,0 +1,53 @@
+{% extends 'base.html' %}
+{% load thumbnail %}
+{% load markdownify %}
+{% load cache_until %}
+{% load community_url %}
+
+{% block title %}{{ object.package.display_name }} changelog{% endblock %}
+{% block description %}Changelog of {{ object.package.display_name }}{% endblock %}
+
+{% block opengraph %}
+    <meta property="og:title" content="{{ object.package.display_name }} changelog" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="{{ request.build_absolute_uri }}" />
+    <meta property="og:image" content="{% thumbnail object.package.icon 256x256 %}" />
+    <meta property="og:image:width" content="256" />
+    <meta property="og:image:height" content="256" />
+
+    <meta property="og:description" content="Changelog of {{ object.package.display_name }}" />
+    <meta property="og:site_name" content="{{ site_name }}" />
+{% endblock %}
+
+{% block content %}
+{% cache_until "any_package_updated" "mod-detail-changelog-tab" 300 object.package.pk object.package.latest.pk community_identifier %}
+
+<nav class="mt-3" aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{% community_url "packages.list" %}">Packages</a></li>
+        <li class="breadcrumb-item"><a href="{% community_url "packages.list_by_owner" owner=object.package.owner.name %}">{{ object.package.owner.name }}</a></li>
+        <li class="breadcrumb-item"><a href="{{ object.get_absolute_url }}">{{ object.package.display_name }}</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Changelog</li>
+    </ol>
+</nav>
+
+<div class="card bg-light mt-2">
+    {% include "community/includes/package_tabs.html" with tabs=tabs %}
+    {% include "community/includes/package_header.html" with object=object %}
+</div>
+
+<div class="card bg-light mb-2 mt-2">
+    <div class="card-header"><h4 class="mb-0">CHANGELOG</h4></div>
+    {% if object.package.changelog %}
+    <div class="card-body markdown-body">
+        {{ object.package.changelog|markdownify }}
+    </div>
+    {% else %}
+    <div class="card-body">
+        <p>This package has no changelog available.</p>
+    </div>
+    {% endif %}
+</div>
+
+{% endcache %}
+{% endblock %}

--- a/django/thunderstore/community/templates/community/packagelisting_detail.html
+++ b/django/thunderstore/community/templates/community/packagelisting_detail.html
@@ -185,14 +185,5 @@ window.ts.PackageManagementPanel(
     </div>
 </div>
 
-{% if object.package.changelog %}
-<div class="card bg-light mb-2 mt-2">
-    <div class="card-header"><h4 class="mb-0">CHANGELOG</h4></div>
-    <div class="card-body markdown-body">
-        {{ object.package.changelog|markdownify }}
-    </div>
-</div>
-{% endif %}
-
 {% endcache %}
 {% endblock %}

--- a/django/thunderstore/community/templates/community/packagelisting_detail.html
+++ b/django/thunderstore/community/templates/community/packagelisting_detail.html
@@ -115,23 +115,7 @@ window.ts.PackageManagementPanel(
 <div class="card bg-light mt-2">
     {% include "community/includes/package_tabs.html" with tabs=tabs %}
     {% cache_until "any_package_updated" "mod-detail-content" 300 object.package.pk community_identifier %}
-    <div class="card-header">
-        <div class="media">
-            <img class="align-self-center mr-3" src="{% thumbnail object.package.icon 128x128 %}" alt="{{ object.package }} icon">
-            <div class="media-body">
-                <h1 class="mt-0">{{ object.package.display_name }}</h1>
-                <p>{{ object.package.description }}</p>
-                <div class="d-flex w-100 justify-content-between">
-                    <h5 class="mb-1">By <a href="{{ object.owner_url }}">{{ object.package.owner.name }}</a></h5>
-                    {% if object.package.website_url %}
-                    <a class="text-nowrap" href="{{ object.package.website_url }}">
-                      <span class="fa fa-globe-americas fa-fw"></span>
-                      {{ object.package.website_url }}</a>
-                    {% endif %}
-                </div>
-            </div>
-        </div>
-    </div>
+    {% include "community/includes/package_header.html" with object=object %}
     <div class="card-body pb-1">
         <table class="table mb-0">
             <tr>
@@ -209,38 +193,6 @@ window.ts.PackageManagementPanel(
     </div>
 </div>
 {% endif %}
-
-<div class="card bg-light mt-2 mb-4">
-    <div class="card-header">
-        <h2 class="mb-0">Available versions</h2>
-    </div>
-    <div class="card-body pb-1">
-        <p>
-            Please note that the install buttons only work if you have compatible client
-            software installed, such as the
-            <a href="https://www.overwolf.com/app/Thunderstore-Thunderstore_Mod_Manager">Thunderstore Mod Manager</a>.
-            Otherwise use the zip download links instead.
-        </p>
-        <table class="table mb-0">
-            <tr>
-                <th>Upload date</th>
-                <th>Version number</th>
-                <th>Downloads</th>
-                <th>Download link</th>
-                <th>&nbsp;</th>
-            </tr>
-            {% for version in object.package.available_versions %}
-            <tr>
-                <td>{{ version.date_created|date:"Y-n-j" }}</td>
-                <td>{{ version.version_number }}</td>
-                <td>{{ version.downloads }}</td>
-                <td><a href="{{ version.full_download_url }}">Version {{ version.version_number }}</a></td>
-                <td><a href="{{ version.install_url }}" type="button" class="btn btn-primary">Install</a></td>
-            </tr>
-            {% endfor %}
-        </table>
-    </div>
-</div>
 
 {% endcache %}
 {% endblock %}

--- a/django/thunderstore/community/templates/community/packagelisting_versions.html
+++ b/django/thunderstore/community/templates/community/packagelisting_versions.html
@@ -1,0 +1,54 @@
+{% extends 'base.html' %}
+{% load thumbnail %}
+{% load cache_until %}
+{% load community_url %}
+
+{% block title %}{{ object.package.display_name }} version history{% endblock %}
+{% block description %}Version history of {{ object.package.display_name }}{% endblock %}
+
+{% block opengraph %}
+    <meta property="og:title" content="{{ object.package.display_name }} version history" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="{{ request.build_absolute_uri }}" />
+    <meta property="og:image" content="{% thumbnail object.package.icon 256x256 %}" />
+    <meta property="og:image:width" content="256" />
+    <meta property="og:image:height" content="256" />
+
+    <meta property="og:description" content="Version history of {{ object.package.display_name }}" />
+    <meta property="og:site_name" content="{{ site_name }}" />
+{% endblock %}
+
+{% block content %}
+{% cache_until "any_package_updated" "mod-detail-version-history" 300 object.package.pk community_identifier %}
+
+<nav class="mt-3" aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{% community_url "packages.list" %}">Packages</a></li>
+        <li class="breadcrumb-item"><a href="{% community_url "packages.list_by_owner" owner=object.package.owner.name %}">{{ object.package.owner.name }}</a></li>
+        <li class="breadcrumb-item"><a href="{{ object.get_absolute_url }}">{{ object.package.display_name }}</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Versions</li>
+    </ol>
+</nav>
+
+<div class="card bg-light mt-2">
+    {% include "community/includes/package_tabs.html" with tabs=tabs %}
+    {% include "community/includes/package_header.html" with object=object %}
+</div>
+
+<div class="card bg-light mt-2 mb-4">
+    <div class="card-header">
+        <h2 class="mb-0">Available versions</h2>
+    </div>
+    <div class="card-body pb-1">
+        <p>
+            Please note that the install buttons only work if you have compatible client
+            software installed, such as the
+            <a href="https://www.overwolf.com/app/Thunderstore-Thunderstore_Mod_Manager">Thunderstore Mod Manager</a>.
+            Otherwise use the zip download links instead.
+        </p>
+        {% include "community/includes/version_table.html" with versions=object.package.available_versions %}
+    </div>
+</div>
+
+{% endcache %}
+{% endblock %}

--- a/django/thunderstore/repository/urls.py
+++ b/django/thunderstore/repository/urls.py
@@ -13,6 +13,7 @@ from thunderstore.repository.views import (
     PackageListView,
     PackageVersionDetailView,
 )
+from thunderstore.repository.views.package.tabs.changelog import PackageChangelogTabView
 from thunderstore.repository.views.package.tabs.versions import PackageVersionsTabView
 from thunderstore.repository.views.team_settings import (
     SettingsTeamAddMemberView,
@@ -55,6 +56,11 @@ legacy_package_urls = (
             "<str:owner>/<str:name>/versions/",
             PackageVersionsTabView.as_view(),
             name="packages.detail.versions",
+        ),
+        path(
+            "<str:owner>/<str:name>/changelog/",
+            PackageChangelogTabView.as_view(),
+            name="packages.detail.changelog",
         ),
         path(
             "<str:owner>/<str:name>/wiki/",
@@ -114,6 +120,11 @@ package_urls = [
         "p/<str:owner>/<str:name>/versions/",
         PackageVersionsTabView.as_view(),
         name="packages.detail.versions",
+    ),
+    path(
+        "p/<str:owner>/<str:name>/changelog/",
+        PackageChangelogTabView.as_view(),
+        name="packages.detail.changelog",
     ),
     path(
         "p/<str:owner>/<str:name>/wiki/",

--- a/django/thunderstore/repository/urls.py
+++ b/django/thunderstore/repository/urls.py
@@ -13,6 +13,7 @@ from thunderstore.repository.views import (
     PackageListView,
     PackageVersionDetailView,
 )
+from thunderstore.repository.views.package.tabs.versions import PackageVersionsTabView
 from thunderstore.repository.views.team_settings import (
     SettingsTeamAddMemberView,
     SettingsTeamAddServiceAccountView,
@@ -49,6 +50,11 @@ legacy_package_urls = (
             "<str:owner>/<str:name>/",
             PackageDetailView.as_view(),
             name="packages.detail",
+        ),
+        path(
+            "<str:owner>/<str:name>/versions/",
+            PackageVersionsTabView.as_view(),
+            name="packages.detail.versions",
         ),
         path(
             "<str:owner>/<str:name>/wiki/",
@@ -103,6 +109,11 @@ package_urls = [
         "p/<str:owner>/<str:name>/",
         PackageDetailView.as_view(),
         name="packages.detail",
+    ),
+    path(
+        "p/<str:owner>/<str:name>/versions/",
+        PackageVersionsTabView.as_view(),
+        name="packages.detail.versions",
     ),
     path(
         "p/<str:owner>/<str:name>/wiki/",

--- a/django/thunderstore/repository/views/mixins.py
+++ b/django/thunderstore/repository/views/mixins.py
@@ -41,6 +41,9 @@ class PackageTabsMixin:
         tabs: Dict[str, PartialTab] = {
             **{
                 "details": PartialTab(url=listing.get_absolute_url(), title="Details"),
+                "versions": PartialTab(
+                    url=listing.get_versions_url(), title="Versions"
+                ),
                 "wiki": PartialTab(
                     url=listing.get_wiki_url(),
                     title="Wiki",

--- a/django/thunderstore/repository/views/mixins.py
+++ b/django/thunderstore/repository/views/mixins.py
@@ -44,6 +44,11 @@ class PackageTabsMixin:
                 "versions": PartialTab(
                     url=listing.get_versions_url(), title="Versions"
                 ),
+                "changelog": PartialTab(
+                    url=listing.get_changelog_url(),
+                    title="Changelog",
+                    is_disabled=not listing.package.changelog(),
+                ),
                 "wiki": PartialTab(
                     url=listing.get_wiki_url(),
                     title="Wiki",

--- a/django/thunderstore/repository/views/package/tabs/changelog.py
+++ b/django/thunderstore/repository/views/package/tabs/changelog.py
@@ -1,0 +1,6 @@
+from thunderstore.repository.views.mixins import PackageListingDetailView
+
+
+class PackageChangelogTabView(PackageListingDetailView):
+    tab_name = "changelog"
+    template_name = "community/packagelisting_changelog.html"

--- a/django/thunderstore/repository/views/package/tabs/versions.py
+++ b/django/thunderstore/repository/views/package/tabs/versions.py
@@ -1,0 +1,6 @@
+from thunderstore.repository.views.mixins import PackageListingDetailView
+
+
+class PackageVersionsTabView(PackageListingDetailView):
+    tab_name = "versions"
+    template_name = "community/packagelisting_versions.html"


### PR DESCRIPTION
This PR introduces the following two new tabs on the package detail page:

- Changelog
- Version history

The main goal is to increase the user experience and rendering performance especially for packages with a large amount of content on their page.