### PR TITLE
Expose latest package version number via v1 API

### DIFF
--- a/django/thunderstore/repository/api/v1/tests/test_metrics.py
+++ b/django/thunderstore/repository/api/v1/tests/test_metrics.py
@@ -26,6 +26,7 @@ def test_api_v1_package_metrics(
     result = response.json()
     assert result["downloads"] == 200
     assert result["rating_score"] == 1
+    assert result["latest_version"] == active_package.latest.version_number
 
 
 @pytest.mark.django_db

--- a/django/thunderstore/repository/api/v1/views/metrics.py
+++ b/django/thunderstore/repository/api/v1/views/metrics.py
@@ -11,6 +11,7 @@ from thunderstore.repository.models import Package, PackageVersion
 class PackageMetricsSerializer(serializers.Serializer):
     downloads = serializers.IntegerField()
     rating_score = serializers.IntegerField()
+    latest_version = serializers.CharField(source="version_number")
 
 
 # This view is potentialy used by the shields.io project and should be kept


### PR DESCRIPTION
Expose the latest package version number on the package metrics API. The main goal is to provide a future-proof way of integrating to this information, given that the current v1 API has no reasonable way of accessing it directly.

Resolves #970