### PR TITLE
Make community discord link title unambiguous

### DIFF
--- a/django/thunderstore/frontend/templates/base.html
+++ b/django/thunderstore/frontend/templates/base.html
@@ -153,7 +153,7 @@
                 {% endif %}
                 {% if site_discord_url %}
                     <li class="nav-item">
-                        <a class="nav-link" href="{{ site_discord_url }}"><span class="fab fa-discord"></span> &nbsp;Join community Discord</a>
+                        <a class="nav-link" href="{{ site_discord_url }}"><span class="fab fa-discord"></span> &nbsp;Join {{ community }} modding Discord</a>
                     </li>
                 {% endif %}
                 {% for link in community_nav_links %}


### PR DESCRIPTION
Makes the header do this:
![image](https://github.com/thunderstore-io/Thunderstore/assets/18232881/36f1c0c9-8e81-4173-abcc-e73e446afbc5)
-----
![Discord_oO5WmlTEOp](https://github.com/thunderstore-io/Thunderstore/assets/18232881/1f75b1d5-7787-4994-9199-e72a3f486a71)
