### PR TITLE
Several cache improvements

### DIFF
--- a/django/thunderstore/cache/utils.py
+++ b/django/thunderstore/cache/utils.py
@@ -8,6 +8,7 @@ CacheName = Literal[
     "default",
     "legacy",
     "profiles",
+    "downloads",
 ]
 
 

--- a/django/thunderstore/core/management/commands/clear_cache.py
+++ b/django/thunderstore/core/management/commands/clear_cache.py
@@ -1,14 +1,25 @@
 from django.conf import settings
-from django.core.cache import cache
-from django.core.management.base import BaseCommand, CommandError
+from django.core.cache import caches
+from django.core.management.base import BaseCommand
 
 
 class Command(BaseCommand):
     help = "Clears all configured caches"
 
+    def add_arguments(self, parser) -> None:
+        parser.add_argument("caches", nargs="*", default=["default"])
+        parser.add_argument("--all", default=False, action="store_true")
+
     def handle(self, *args, **kwargs):
-        if settings.CACHES:
-            cache.clear()
-            self.stdout.write("Caches cleared!")
-        else:
-            raise CommandError("No caches are currently configured")
+        names = kwargs.get("caches", ["default"])
+        if kwargs.get("all") is True:
+            names = settings.CACHES.keys()
+
+        for name in names:
+            if name in settings.CACHES:
+                self.stdout.write(f"Clearing cache: {name}")
+                caches[name].clear()
+            else:
+                self.stderr.write(f"Cache {name} not found, unable to clear")
+
+        self.stdout.write("All done!")

--- a/django/thunderstore/core/settings.py
+++ b/django/thunderstore/core/settings.py
@@ -108,6 +108,7 @@ env = environ.Env(
     REDIS_URL=(str, ""),
     REDIS_URL_LEGACY=(str, None),
     REDIS_URL_PROFILES=(str, None),
+    REDIS_URL_DOWNLOADS=(str, None),
     DB_CERT_DIR=(str, ""),
     DB_CLIENT_CERT=(str, ""),
     DB_CLIENT_KEY=(str, ""),
@@ -138,8 +139,7 @@ env = environ.Env(
     IS_CYBERSTORM_ENABLED=(bool, False),
     SHOW_CYBERSTORM_API_DOCS=(bool, False),
     USE_ASYNC_PACKAGE_SUBMISSION_FLOW=(bool, False),
-    USE_TIME_SERIES_PACKAGE_DOWNLOAD_METRICS=(bool, False),
-    USE_LEGACY_PACKAGE_DOWNLOAD_METRICS=(bool, True),
+    USE_TIME_SERIES_PACKAGE_DOWNLOAD_METRICS=(bool, True),
 )
 
 ALWAYS_RAISE_EXCEPTIONS = env.bool("ALWAYS_RAISE_EXCEPTIONS")
@@ -377,6 +377,7 @@ SESSION_COOKIE_DOMAIN = env.str("SESSION_COOKIE_DOMAIN") or None
 # Celery
 class CeleryQueues:
     Default = "celery"
+    LogDownloads = "log.downloads"
     BackgroundCache = "background.cache"
     BackgroundTask = "background.task"
     BackgroundLongRunning = "background.long_running"
@@ -492,6 +493,10 @@ CACHES = {
     "legacy": get_redis_cache("REDIS_URL_LEGACY", "REDIS_URL"),
     "profiles": {
         **get_redis_cache("REDIS_URL_PROFILES", "REDIS_URL"),
+        "TIMEOUT": None,
+    },
+    "downloads": {
+        **get_redis_cache("REDIS_URL_DOWNLOADS", "REDIS_URL"),
         "TIMEOUT": None,
     },
 }
@@ -791,9 +796,6 @@ USE_ASYNC_PACKAGE_SUBMISSION_FLOW = env.bool("USE_ASYNC_PACKAGE_SUBMISSION_FLOW"
 USE_TIME_SERIES_PACKAGE_DOWNLOAD_METRICS = env.bool(
     "USE_TIME_SERIES_PACKAGE_DOWNLOAD_METRICS"
 )
-
-# Enable the legacy package download metrics implementation
-USE_LEGACY_PACKAGE_DOWNLOAD_METRICS = env.bool("USE_LEGACY_PACKAGE_DOWNLOAD_METRICS")
 
 # Seconds to wait between logging download events
 DOWNLOAD_METRICS_TTL_SECONDS = env.int("DOWNLOAD_METRICS_TTL_SECONDS")

--- a/django/thunderstore/core/tests/test_celery.py
+++ b/django/thunderstore/core/tests/test_celery.py
@@ -38,6 +38,7 @@ KNOWN_CELERY_IDS = (
     "thunderstore.repository.tasks.update_experimental_package_index",
     "thunderstore.repository.tasks.process_package_submission",
     "thunderstore.repository.tasks.cleanup_package_submissions",
+    "thunderstore.repository.tasks.log_version_download",
     "thunderstore.webhooks.tasks.process_audit_event",
 )
 

--- a/django/thunderstore/modpacks/tests/test_legacyprofile.py
+++ b/django/thunderstore/modpacks/tests/test_legacyprofile.py
@@ -1,4 +1,5 @@
 import pytest
+from django.core.cache import cache
 
 from thunderstore.modpacks.factories import LegacyProfileFactory
 from thunderstore.modpacks.models import LegacyProfile
@@ -8,11 +9,15 @@ from thunderstore.modpacks.models import LegacyProfile
 def test_legacyprofile_manager_get_total_used_disk_space():
     assert LegacyProfile.objects.count() == 0
     assert LegacyProfile.objects.get_total_used_disk_space() == 0
+
     p1 = LegacyProfileFactory()
+    cache.delete(LegacyProfile.objects.size_cache())
     assert LegacyProfile.objects.count() == 1
     assert LegacyProfile.objects.get_total_used_disk_space() == p1.file_size
+
     p2 = LegacyProfileFactory(file_size=32)
     p3 = LegacyProfileFactory(file_size=32890)
+    cache.delete(LegacyProfile.objects.size_cache())
     assert LegacyProfile.objects.count() == 3
     assert LegacyProfile.objects.get_total_used_disk_space() == (
         p1.file_size + p2.file_size + p3.file_size

--- a/django/thunderstore/repository/tasks/__init__.py
+++ b/django/thunderstore/repository/tasks/__init__.py
@@ -1,3 +1,4 @@
 from .caches import *
+from .downloads import *
 from .files import *
 from .submission import *

--- a/django/thunderstore/repository/tasks/downloads.py
+++ b/django/thunderstore/repository/tasks/downloads.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+
+from celery import shared_task
+from django.db import transaction
+from django.db.models import F
+
+from thunderstore.core.settings import CeleryQueues
+from thunderstore.metrics.models import PackageVersionDownloadEvent
+from thunderstore.repository.models import PackageVersion
+
+TASK_LOG_VERSION_DOWNLOAD = "thunderstore.repository.tasks.log_version_download"
+
+
+@shared_task(queue=CeleryQueues.LogDownloads, name=TASK_LOG_VERSION_DOWNLOAD)
+def log_version_download(version_id: int, timestamp: str):
+    with transaction.atomic():
+        PackageVersionDownloadEvent.objects.create(
+            version_id=version_id,
+            timestamp=datetime.fromisoformat(timestamp),
+        )
+        PackageVersion.objects.filter(id=version_id).update(
+            downloads=F("downloads") + 1
+        )

--- a/django/thunderstore/repository/tests/test_download_metrics.py
+++ b/django/thunderstore/repository/tests/test_download_metrics.py
@@ -13,35 +13,31 @@ from thunderstore.repository.models import PackageVersion
 from thunderstore.repository.models import (
     PackageVersionDownloadEvent as LegacyDownloadEvent,
 )
+from thunderstore.repository.tasks.downloads import log_version_download
 
 
 @pytest.mark.django_db
 def test_download_metrics__can_log_download_event__no_ip(
     package_version: PackageVersion,
 ):
-    assert PackageVersion._can_log_download_event(package_version, None) is False
+    assert PackageVersion._can_log_download_event(package_version.id, None) is False
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("use_legacy", (False, True))
 @pytest.mark.parametrize("use_timeseries", (False, True))
 def test_download_metrics__can_log_download_event__settings(
     package_version: PackageVersion,
-    use_legacy: bool,
     use_timeseries: bool,
     settings: Any,
 ):
-    settings.USE_LEGACY_PACKAGE_DOWNLOAD_METRICS = use_legacy
     settings.USE_TIME_SERIES_PACKAGE_DOWNLOAD_METRICS = use_timeseries
-
-    expected = use_legacy or use_timeseries
 
     assert (
         PackageVersion._can_log_download_event(
-            package_version,
+            package_version.id,
             "127.0.0.1",
         )
-        is expected
+        is use_timeseries
     )
 
 
@@ -52,100 +48,43 @@ def test_download_metrics__can_log_download_event__rate_limit(
     v = package_version
     ip_a = "127.0.0.1"
     ip_b = "192.168.0.1"
-    assert PackageVersion._can_log_download_event(v, ip_a) is True
-    assert PackageVersion._can_log_download_event(v, ip_a) is False
+    assert PackageVersion._can_log_download_event(v.id, ip_a) is True
+    assert PackageVersion._can_log_download_event(v.id, ip_a) is False
 
-    assert PackageVersion._can_log_download_event(v, ip_b) is True
-    assert PackageVersion._can_log_download_event(v, ip_b) is False
-    assert PackageVersion._can_log_download_event(v, ip_a) is False
+    assert PackageVersion._can_log_download_event(v.id, ip_b) is True
+    assert PackageVersion._can_log_download_event(v.id, ip_b) is False
+    assert PackageVersion._can_log_download_event(v.id, ip_a) is False
 
-    cache.delete(PackageVersion._get_log_key(v, ip_b))
-    assert PackageVersion._can_log_download_event(v, ip_b) is True
-    assert PackageVersion._can_log_download_event(v, ip_a) is False
+    cache.delete(PackageVersion._get_log_key(v.id, ip_b))
+    assert PackageVersion._can_log_download_event(v.id, ip_b) is True
+    assert PackageVersion._can_log_download_event(v.id, ip_a) is False
 
-    cache.delete(PackageVersion._get_log_key(v, ip_a))
-    assert PackageVersion._can_log_download_event(v, ip_b) is False
-    assert PackageVersion._can_log_download_event(v, ip_a) is True
-
-
-@pytest.mark.django_db
-def test_download_metrics__log_download_event_legacy(
-    package_version: PackageVersion,
-):
-    v = package_version
-    ip = "127.0.0.1"
-    assert LegacyDownloadEvent.objects.count() == 0
-    PackageVersion._log_download_event_legacy(v, ip)
-    assert LegacyDownloadEvent.objects.count() == 1
-    event = LegacyDownloadEvent.objects.first()
-
-    assert event.source_ip == ip
-    assert event.total_downloads == 1
-    assert event.counted_downloads == 1
-
-    PackageVersion._log_download_event_legacy(v, ip)
-    event.refresh_from_db()
-    assert event.total_downloads == 2
-    assert event.counted_downloads == 1
-
-    event.last_download = timezone.now() - timedelta(
-        seconds=settings.DOWNLOAD_METRICS_TTL_SECONDS + 1
-    )
-    event.save()
-
-    PackageVersion._log_download_event_legacy(v, ip)
-    event.refresh_from_db()
-    assert event.total_downloads == 3
-    assert event.counted_downloads == 2
+    cache.delete(PackageVersion._get_log_key(v.id, ip_a))
+    assert PackageVersion._can_log_download_event(v.id, ip_b) is False
+    assert PackageVersion._can_log_download_event(v.id, ip_a) is True
 
 
 @pytest.mark.django_db
-def test_download_metrics__log_download_event_timeseries(
+def test_download_metrics_log_download_event(
     package_version: PackageVersion,
 ):
     assert TimeseriesDownloadEvent.objects.count() == 0
-    PackageVersion._log_download_event_timeseries(package_version)
+    assert package_version.downloads == 0
+
+    PackageVersion.log_download_event(package_version.id, "127.0.0.1")
+    package_version.refresh_from_db()
     assert TimeseriesDownloadEvent.objects.count() == 1
-    PackageVersion._log_download_event_timeseries(package_version)
-    assert TimeseriesDownloadEvent.objects.count() == 2
+    assert package_version.downloads == 1
+
+    PackageVersion.log_download_event(package_version.id, "127.0.0.1")
+    package_version.refresh_from_db()
+    assert TimeseriesDownloadEvent.objects.count() == 1
+    assert package_version.downloads == 1
+
+    log_version_download(package_version.id, timezone.now().isoformat())
+    package_version.refresh_from_db()
     assert (
         TimeseriesDownloadEvent.objects.filter(version_id=package_version.id).count()
         == 2
     )
-
-
-@pytest.mark.django_db
-@pytest.mark.parametrize("use_legacy", (False, True))
-@pytest.mark.parametrize("use_timeseries", (False, True))
-def test_download_metrics__log_download_event(
-    package_version: PackageVersion,
-    use_legacy: bool,
-    use_timeseries: bool,
-    settings: Any,
-    mocker,
-):
-    settings.USE_LEGACY_PACKAGE_DOWNLOAD_METRICS = use_legacy
-    settings.USE_TIME_SERIES_PACKAGE_DOWNLOAD_METRICS = use_timeseries
-
-    precheck = mocker.spy(PackageVersion, "_can_log_download_event")
-    legacy = mocker.spy(PackageVersion, "_log_download_event_legacy")
-    timeseries = mocker.spy(PackageVersion, "_log_download_event_timeseries")
-
-    should_log = use_legacy or use_timeseries
-    expected_count = int(should_log)
-
-    PackageVersion.log_download_event(package_version, "127.0.0.1")
-
-    assert precheck.call_count == 1
-    assert precheck.spy_return is should_log
-
-    assert legacy.call_count == int(use_legacy)
-    assert timeseries.call_count == int(use_timeseries)
-
-    assert package_version.downloads == expected_count
-
-    PackageVersion.log_download_event(package_version, "127.0.0.1")
-
-    assert precheck.call_count == 2
-    assert precheck.spy_return is False
-    assert package_version.downloads == expected_count
+    assert package_version.downloads == 2

--- a/django/thunderstore/repository/views/package/download.py
+++ b/django/thunderstore/repository/views/package/download.py
@@ -1,24 +1,63 @@
-from django.http import HttpRequest
+from django.http import Http404, HttpRequest
 from django.shortcuts import get_object_or_404, redirect
 from django.views import View
 from ipware import get_client_ip
+from pydantic import BaseModel, ValidationError
 
+from thunderstore.cache.utils import get_cache
 from thunderstore.core.utils import replace_cdn
 from thunderstore.repository.mixins import CommunityMixin
 from thunderstore.repository.models import PackageVersion
 
+cache = get_cache("downloads")
+
+
+class DownloadMetaCache(BaseModel):
+    id: int
+    file: str
+
+
+def get_download_meta(
+    namespace: str, name: str, version_number: str
+) -> DownloadMetaCache:
+    key = f"{namespace}-{name}-{version_number}"
+    if cached_value := cache.get(key):
+        try:
+            return DownloadMetaCache.parse_obj(cached_value)
+        except ValidationError:
+            pass
+
+    data = (
+        PackageVersion.objects.filter(
+            package__namespace__name=namespace,
+            package__name=name,
+            version_number=version_number,
+        )
+        .values("id", "file")
+        .first()
+    )
+    if not data or not data["file"]:
+        raise PackageVersion.DoesNotExist
+    meta = DownloadMetaCache(**data)
+    cache.set(key, data)
+    return meta
+
 
 class PackageDownloadView(CommunityMixin, View):
     def get(self, request: HttpRequest, *args, **kwargs):
-        obj = get_object_or_404(
-            PackageVersion,
-            package__owner__name=kwargs["owner"],
-            package__name=kwargs["name"],
-            version_number=kwargs["version"],
-        )
-        client_ip, _ = get_client_ip(self.request)
-        PackageVersion.log_download_event(obj.id, client_ip)
+        try:
+            meta = get_download_meta(
+                namespace=kwargs["owner"],
+                name=kwargs["name"],
+                version_number=kwargs["version"],
+            )
+        except PackageVersion.DoesNotExist:
+            raise Http404
 
-        url = self.request.build_absolute_uri(obj.file.url)
+        client_ip, _ = get_client_ip(self.request)
+        PackageVersion.log_download_event(meta.id, client_ip)
+
+        url = PackageVersion._meta.get_field("file").storage.url(meta.file)
+        url = self.request.build_absolute_uri(url)
         url = replace_cdn(url, request.GET.get("cdn"))
         return redirect(url)

--- a/django/thunderstore/repository/views/package/download.py
+++ b/django/thunderstore/repository/views/package/download.py
@@ -17,7 +17,7 @@ class PackageDownloadView(CommunityMixin, View):
             version_number=kwargs["version"],
         )
         client_ip, _ = get_client_ip(self.request)
-        PackageVersion.log_download_event(obj, client_ip)
+        PackageVersion.log_download_event(obj.id, client_ip)
 
         url = self.request.build_absolute_uri(obj.file.url)
         url = replace_cdn(url, request.GET.get("cdn"))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,12 @@ x-django-service: &django-service
       BUILD_INSTALL_EXTRAS: ${BUILD_INSTALL_EXTRAS}
   environment:
     CELERY_BROKER_URL: "pyamqp://django:django@rabbitmq/django"
-    CELERY_QUEUES: "celery,background.cache,background.task,background.long_running"
+    CELERY_QUEUES: "celery,background.cache,background.task,background.long_running,log.downloads"
     DATABASE_URL: "psql://django:django@dbpool/django"
     REDIS_URL: "redis://redis:6379/0"
     REDIS_URL_LEGACY: "redis://redis:6379/1"
     REDIS_URL_PROFILES: "redis://redis:6379/2"
+    REDIS_URL_DOWNLOADS: "redis://redis:6379/3"
     PROTOCOL: "http://"
 
     AWS_ACCESS_KEY_ID: "thunderstore"


### PR DESCRIPTION
This PR contains caching for the download URL endpoint and profile storage size check. Additionally, the download log has been moved to a background task as to not block request processing unnecessarily long.

Finally, the management command for clearing caches was updated to support selecting which cache(s) to clear.