### PR TITLE
Make visibility read-only in PackageVersionInline

### DIFF
--- a/django/thunderstore/repository/admin/package.py
+++ b/django/thunderstore/repository/admin/package.py
@@ -22,6 +22,7 @@ class PackageVersionInline(admin.StackedInline):
         "version_number",
         "website_url",
         "file_tree",
+        "visibility",
     )
     exclude = ("readme", "changelog", "dependencies", "name")
     extra = 0


### PR DESCRIPTION
Make the "visibility" field read-only in the PackageVersionInline on Package detail admin page.