### PR TITLE
Implement retries and max parallelism to uploads

### DIFF
--- a/builder/src/retry.ts
+++ b/builder/src/retry.ts
@@ -1,0 +1,21 @@
+import { sleep } from "./utils";
+
+export async function retry<T>(
+    attempts: number,
+    fn: () => Promise<T>,
+    canRetry: () => boolean,
+    onError: (e: Error | unknown) => void
+): Promise<T> {
+    for (let retries = attempts; retries > 0; retries--) {
+        if (!canRetry()) {
+            throw new Error("Retries interrupted");
+        }
+        try {
+            return await fn();
+        } catch (e) {
+            onError(e);
+            await sleep(5000);
+        }
+    }
+    throw new Error(`Promise failed after ${attempts} retries!`);
+}

--- a/builder/src/throttle.ts
+++ b/builder/src/throttle.ts
@@ -1,0 +1,27 @@
+import { sleep } from "./utils";
+
+export class PromiseThrottler {
+    private readonly parallelism: number;
+
+    private ongoing: number = 0;
+
+    constructor(parallelism: number) {
+        this.parallelism = parallelism;
+    }
+
+    private get canStartNext(): boolean {
+        return this.parallelism - this.ongoing > 0;
+    }
+
+    async throttle<T>(fn: () => Promise<T>): Promise<T> {
+        while (!this.canStartNext) {
+            await sleep(100);
+        }
+        try {
+            this.ongoing += 1;
+            return await fn();
+        } finally {
+            this.ongoing -= 1;
+        }
+    }
+}


### PR DESCRIPTION
Implement automatic retrying for failed file part upload attempts and limit the maximum parallelism to 3 instead of attempting to upload all parts in parallel.

This should significantly improve the experience for uploaders of large files on slower connections without degrading performance on faster connection speeds. The assumption is that limiting the parallelism should promote actually completing file parts as individual parts no longer compete on bandwidth with each other as much, and automatic retries should make the uploader more robust for failures overall.