### PR TITLE
Prevent creation of lower case versions of existing usernames

### DIFF
--- a/django/thunderstore/social/api/experimental/views/complete_login.py
+++ b/django/thunderstore/social/api/experimental/views/complete_login.py
@@ -133,7 +133,9 @@ def get_unique_username(original_username: str) -> str:
     username = slugified
     attempts_remaining = 10  # Prevent infinite loops in case of bugs.
 
-    while attempts_remaining and User.objects.filter(username=username).exists():
+    while (
+        attempts_remaining and User.objects.filter(username__iexact=username).exists()
+    ):
         suffix = uuid4().hex[:suffix_length]
         username = slugified[: (max_length - suffix_length)] + suffix
         attempts_remaining -= 1

--- a/django/thunderstore/social/tests/test_complete_login.py
+++ b/django/thunderstore/social/tests/test_complete_login.py
@@ -242,6 +242,21 @@ def test_get_unique_username_clips_usernames_only_when_needed() -> None:
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("old_name", "new_name"),
+    (
+        ("fabio", "Fabio"),
+        ("Fabio", "fabio"),
+    ),
+)
+def test_get_unique_username_is_case_insensitive(old_name, new_name) -> None:
+    User.objects.create(username=old_name)
+    actual = get_unique_username(new_name)
+
+    assert actual.lower() != old_name.lower()
+
+
+@pytest.mark.django_db
 def test_get_unique_username_adds_random_suffixes_only_when_needed() -> None:
     username1 = get_unique_username("Fabio")
     User.objects.create(username=username1)


### PR DESCRIPTION
The old implementation prevented creation of upper case versions of existing usernames, but didn't prevent creation of lower case version of existing uppercase usernames.