### PR TITLE
Update .env.template DECOMPILER_API_HOST

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -61,4 +61,4 @@ PROTOCOL=http://
 IS_CYBERSTORM_ENABLED=
 SHOW_CYBERSTORM_API_DOCS=
 
-DECOMPILER_API_HOST=docker.for.win.localhost:8000
+DECOMPILER_API_HOST=http://host.docker.internal:8000


### PR DESCRIPTION
Replaced URL for .env.template's DECOMPILER_API_HOST so that decompiler functions correctly