### PR TITLE
Move dependency list under README

### DIFF
--- a/django/thunderstore/community/templates/community/packagelisting_detail.html
+++ b/django/thunderstore/community/templates/community/packagelisting_detail.html
@@ -172,18 +172,18 @@ window.ts.PackageManagementPanel(
 
 {% dynamic_html "package_page_actions" %}
 
-{% with object.package.dependencies as dependencies %}
-{% if dependencies %}
-    {% include "repository/includes/dependencies.html" with dependencies=dependencies %}
-{% endif %}
-{% endwith %}
-
 <div class="card bg-light mb-2 mt-2">
     <div class="card-header"><h4 class="mb-0">README</h4></div>
     <div class="card-body markdown-body">
         {{ object.package.readme|markdownify }}
     </div>
 </div>
+
+{% with object.package.dependencies as dependencies %}
+{% if dependencies %}
+    {% include "repository/includes/dependencies.html" with dependencies=dependencies %}
+{% endif %}
+{% endwith %}
 
 {% endcache %}
 {% endblock %}


### PR DESCRIPTION
Modpack dependency lists can get quite large, moving the dependency list to under the README will encourage people to read it

The dependency list is still accessible to the people who want to look at it and doesn't hinder navigation