### PR TITLE
Set maximum height, add scrolling to dependency list on Package Details page

### DIFF
--- a/builder/src/scss/base.scss
+++ b/builder/src/scss/base.scss
@@ -7,3 +7,7 @@ body {
     display: flex;
     flex-direction: column;
 }
+
+:root {
+    color-scheme: dark;
+}

--- a/builder/src/scss/general.scss
+++ b/builder/src/scss/general.scss
@@ -96,3 +96,18 @@
         transform: rotate(360deg);
     }
 }
+
+.dependency-list {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+
+    max-height: 450px;
+    overflow: auto;
+
+    .list-group-item {
+        &:first-child {
+            border-top-left-radius: 0;
+            border-top-right-radius: 0;
+        }
+    }
+}

--- a/django/thunderstore/repository/templates/repository/includes/dependencies.html
+++ b/django/thunderstore/repository/templates/repository/includes/dependencies.html
@@ -1,22 +1,28 @@
 {% load thumbnail %}
 {% load community_url %}
 
-<div class="list-group">
-    <div class="list-group-item flex-column align-items-start active">
+<div class="card">
+    <div class="card-header bg-primary pb-2">
         <h4>This mod requires the following mods to function</h4>
     </div>
-    {% for dependency in object.package.dependencies.all %}
-    <div class="list-group-item flex-column align-items-start media">
-        <div class="media">
-            <img class="align-self-center mr-3" src="{% thumbnail dependency.icon 64x64 %}" alt="{{ dependency }} icon">
-            <div class="media-body">
-                <h5 class="mt-0"><a href="{% community_url "packages.detail" owner=dependency.package.namespace.name name=dependency.package.name %}">
-                    {{ dependency.package }}
-                </a></h5>
-                <p class="mb-0">{{ dependency.description }}</p>
-                <small class="mb-0">Preferred version: <a href="{% community_url "packages.version.detail" owner=dependency.package.namespace.name name=dependency.package.name version=dependency.version_number %}">{{ dependency.version_number }}</a></small>
-            </div>
+    <div class="card-body p-0">
+        <div class="list-group dependency-list">
+            {% for dependency in object.package.dependencies.all %}
+                <div class="list-group-item flex-column align-items-start media">
+                    <div class="media">
+                        <img class="align-self-center mr-3" src="{% thumbnail dependency.icon 64x64 %}" alt="{{ dependency }} icon">
+                        <div class="media-body">
+                            <h5 class="mt-0">
+                                <a href="{% community_url "packages.detail" owner=dependency.package.namespace.name name=dependency.package.name %}">
+                                    {{ dependency.package }}
+                                </a>
+                            </h5>
+                            <p class="mb-0">{{ dependency.description }}</p>
+                            <small class="mb-0">Preferred version: <a href="{% community_url "packages.version.detail" owner=dependency.package.namespace.name name=dependency.package.name version=dependency.version_number %}">{{ dependency.version_number }}</a></small>
+                        </div>
+                    </div>
+                </div>
+            {% endfor %}
         </div>
     </div>
-    {% endfor %}
 </div>


### PR DESCRIPTION
![image](https://github.com/thunderstore-io/Thunderstore/assets/29670227/1587939e-b94f-41b3-b99c-980590d1783b)

This would resolve the underlying issue https://github.com/thunderstore-io/Thunderstore/pull/1040 seeks to fix.

Also changes the color-scheme to dark which means scroll bars will be dark (which scrollable elements inside the page need to not look terrible).