### PR TITLE
Reduce noice in v1 API URLs (rebased)

### DIFF
--- a/django/thunderstore/repository/api/v1/tests/test_metrics.py
+++ b/django/thunderstore/repository/api/v1/tests/test_metrics.py
@@ -38,7 +38,7 @@ def test_api_v1_package_version_metrics(
     active_package.latest.downloads = 200
     active_package.latest.save()
 
-    assert active_package.latest.downloads == 200
+    assert active_package.downloads == 200
 
     namespace = active_package.namespace.name
     name = active_package.name

--- a/django/thunderstore/repository/api/v1/urls.py
+++ b/django/thunderstore/repository/api/v1/urls.py
@@ -12,7 +12,11 @@ from thunderstore.social.api.v1.views.current_user import CurrentUserInfoView
 v1_router = routers.DefaultRouter()
 v1_router.register(r"package", PackageViewSet, basename="package")
 
-urls = [
+
+community_urls = [
+    path("", include(v1_router.urls)),
+]
+communityless_urls = [
     path("current-user/info/", CurrentUserInfoView.as_view(), name="current-user.info"),
     path("bot/deprecate-mod/", DeprecateModApiView.as_view(), name="bot.deprecate-mod"),
     path(
@@ -25,5 +29,10 @@ urls = [
         PackageVersionMetricsApiView.as_view(),
         name="package-metrics.package-version",
     ),
-    path("", include(v1_router.urls)),
+]
+
+
+urls = [
+    *communityless_urls,
+    *community_urls,
 ]

--- a/django/thunderstore/repository/api/v1/views/deprecate.py
+++ b/django/thunderstore/repository/api/v1/views/deprecate.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework.exceptions import NotFound, PermissionDenied
 from rest_framework.response import Response
@@ -47,8 +45,6 @@ class DeprecateModApiView(JWTApiView):
     def post(
         self,
         request: HttpRequestType,
-        format: Optional[str] = None,
-        community_identifier: Optional[str] = None,
     ) -> Response:
         package = self.get_package(request.decoded.get("package"))
 

--- a/django/thunderstore/repository/tests/test_bot_api.py
+++ b/django/thunderstore/repository/tests/test_bot_api.py
@@ -3,19 +3,15 @@ import pytest
 from django.urls import reverse
 from rest_framework.test import APIClient
 
-from thunderstore.community.models.community import Community
 from thunderstore.core.models import IncomingJWTAuthConfiguration, SecretTypeChoices
 from thunderstore.repository.models import DiscordUserBotPermission, Package
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("old_urls", (False, True))
 def test_bot_api_deprecate_mod_200(
     api_client: APIClient,
     admin_user,
     package: Package,
-    community: Community,
-    old_urls: bool,
 ):
     assert package.is_deprecated is False
     jwt_secret = "superSecret"
@@ -39,16 +35,8 @@ def test_bot_api_deprecate_mod_200(
         algorithm=SecretTypeChoices.HS256,
         headers={"kid": str(auth.key_id)},
     )
-
-    if old_urls:
-        url = reverse("api:v1:bot.deprecate-mod")
-    else:
-        url = reverse(
-            "communities:community:api:bot.deprecate-mod",
-            kwargs={"community_identifier": community.identifier},
-        )
     response = api_client.post(
-        url,
+        path=reverse("api:v1:bot.deprecate-mod"),
         data=encoded,
         content_type="application/jwt",
     )
@@ -59,13 +47,10 @@ def test_bot_api_deprecate_mod_200(
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("old_urls", (False, True))
 def test_bot_api_deprecate_mod_403_thunderstore_perms(
     api_client: APIClient,
     user,
     package: Package,
-    community: Community,
-    old_urls: bool,
 ):
     assert package.is_deprecated is False
     jwt_secret = "superSecret"
@@ -89,16 +74,8 @@ def test_bot_api_deprecate_mod_403_thunderstore_perms(
         algorithm=SecretTypeChoices.HS256,
         headers={"kid": str(auth.key_id)},
     )
-
-    if old_urls:
-        url = reverse("api:v1:bot.deprecate-mod")
-    else:
-        url = reverse(
-            "communities:community:api:bot.deprecate-mod",
-            kwargs={"community_identifier": community.identifier},
-        )
     response = api_client.post(
-        url,
+        path=reverse("api:v1:bot.deprecate-mod"),
         data=encoded,
         content_type="application/jwt",
     )
@@ -112,13 +89,10 @@ def test_bot_api_deprecate_mod_403_thunderstore_perms(
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("old_urls", (False, True))
 def test_bot_api_deprecate_mod_403_discord_perms(
     api_client: APIClient,
     admin_user,
     package: Package,
-    community: Community,
-    old_urls: bool,
 ):
     assert package.is_deprecated is False
     jwt_secret = "superSecret"
@@ -142,16 +116,8 @@ def test_bot_api_deprecate_mod_403_discord_perms(
         algorithm=SecretTypeChoices.HS256,
         headers={"kid": str(auth.key_id)},
     )
-
-    if old_urls:
-        url = reverse("api:v1:bot.deprecate-mod")
-    else:
-        url = reverse(
-            "communities:community:api:bot.deprecate-mod",
-            kwargs={"community_identifier": community.identifier},
-        )
     response = api_client.post(
-        url,
+        path=reverse("api:v1:bot.deprecate-mod"),
         data=encoded,
         content_type="application/jwt",
     )
@@ -162,12 +128,9 @@ def test_bot_api_deprecate_mod_403_discord_perms(
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("old_urls", (False, True))
 def test_bot_api_deprecate_mod_404(
     api_client: APIClient,
     admin_user,
-    community: Community,
-    old_urls: bool,
 ):
     jwt_secret = "superSecret"
     auth = IncomingJWTAuthConfiguration.objects.create(
@@ -190,16 +153,8 @@ def test_bot_api_deprecate_mod_404(
         algorithm=SecretTypeChoices.HS256,
         headers={"kid": str(auth.key_id)},
     )
-
-    if old_urls:
-        url = reverse("api:v1:bot.deprecate-mod")
-    else:
-        url = reverse(
-            "communities:community:api:bot.deprecate-mod",
-            kwargs={"community_identifier": community.identifier},
-        )
     response = api_client.post(
-        url,
+        path=reverse("api:v1:bot.deprecate-mod"),
         data=encoded,
         content_type="application/jwt",
     )

--- a/django/thunderstore/repository/urls.py
+++ b/django/thunderstore/repository/urls.py
@@ -1,7 +1,7 @@
 from django.urls import include, path, re_path
 
 from thunderstore.plugins.registry import plugin_registry
-from thunderstore.repository.api.v1.urls import urls as v1_urls
+from thunderstore.repository.api.v1.urls import community_urls as v1_community_urls
 from thunderstore.repository.views import (
     PackageCreateOldView,
     PackageCreateView,
@@ -107,7 +107,7 @@ legacy_package_urls = (
 
 package_urls = [
     path("", PackageListView.as_view(), name="packages.list"),
-    path("api/v1/", include((v1_urls, "api"), namespace="api")),
+    path("api/v1/", include((v1_community_urls, "api"), namespace="api")),
     path("create/", PackageCreateView.as_view(), name="packages.create"),
     path("create/old/", PackageCreateOldView.as_view(), name="packages.create.old"),
     path("create/docs/", PackageDocsView.as_view(), name="packages.create.docs"),


### PR DESCRIPTION
Aimed to replace #951:

- Rebase to current HEAD of master branch
- After rebase, all that's left of the first commit is [a single line change to test case](https://github.com/thunderstore-io/Thunderstore/commit/a7e45a9208cea265f9c78de7b22d3231ce10941b#diff-d9f69ab2e04c0994729fcac1a309dc2acf7a04591afcd84bb584a04c052fc2c5R41)
- The second commit remains unchanged
- Introduce a third commit which adjusts unit tests to not test the dropped redundant endpoints