### PR TITLE
Add option to reuse PackageVersion icon on test data creation

### DIFF
--- a/django/thunderstore/core/management/commands/content/base.py
+++ b/django/thunderstore/core/management/commands/content/base.py
@@ -1,10 +1,13 @@
 import functools
+import io
 import os
 from abc import ABC
 from dataclasses import dataclass, field
 from typing import Collection, List, Type
 
+from django.core.files.base import File
 from django.db.models import Model
+from PIL import Image
 
 from django_contracts.models import LegalContract
 from thunderstore.community.models import Community
@@ -27,6 +30,7 @@ class ContentPopulatorContext:
     contract_count: int = 0
     contract_version_count: int = 0
     wiki_page_count: int = 0
+    reuse_icon: bool = False
 
 
 class ContentPopulator(ABC):
@@ -75,3 +79,11 @@ aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi 
 Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
 occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 """
+
+
+def dummy_package_icon() -> File:
+    file_obj = io.BytesIO()
+    image = Image.new("RGB", (256, 256), "#231F36")
+    image.save(file_obj, format="PNG")
+    file_obj.seek(0)
+    return File(file_obj, name="dummy.png")

--- a/django/thunderstore/core/management/commands/create_test_data.py
+++ b/django/thunderstore/core/management/commands/create_test_data.py
@@ -73,6 +73,15 @@ class Command(BaseCommand):
         parser.add_argument("--dependency-count", type=int, default=20)
         parser.add_argument("--clear", default=False, action="store_true")
         parser.add_argument(
+            "--reuse-icon",
+            default=False,
+            action="store_true",
+            help=(
+                "Reuse the same icon file for all PackageVersions to speed up"
+                "creating large data sets."
+            ),
+        )
+        parser.add_argument(
             "--only",
             type=str,
             default=None,
@@ -130,5 +139,6 @@ class Command(BaseCommand):
             contract_count=kwargs.get("contract_count", 0),
             contract_version_count=kwargs.get("contract_version_count", 0),
             wiki_page_count=kwargs.get("wiki_page_count", 0),
+            reuse_icon=kwargs.get("reuse_icon", False),
         )
         self.populate(context)

--- a/django/thunderstore/core/tests/test_management_commands.py
+++ b/django/thunderstore/core/tests/test_management_commands.py
@@ -198,3 +198,38 @@ def test_create_test_data_only_filter_invalid() -> None:
         CommandError, match="Invalid --only selection provided, options are"
     ):
         call_command("create_test_data", "--only", "badfilter")
+
+
+@override_settings(DEBUG=True)
+@pytest.mark.django_db
+@pytest.mark.parametrize("reuse", (True, False))
+def test_create_test_data_reuse_icon(reuse: bool) -> None:
+    args = [
+        "create_test_data",
+        "--community-count",
+        1,
+        "--team-count",
+        1,
+        "--package-count",
+        1,
+        "--version-count",
+        2,
+        "--dependency-count",
+        0,
+        "--wiki-page-count",
+        0,
+        "--contract-count",
+        0,
+        "--contract-version-count",
+        0,
+    ]
+    if reuse:
+        args.append("--reuse-icon")
+
+    assert not PackageVersion.objects.exists()
+
+    call_command(*args)
+    icon_paths = PackageVersion.objects.values_list("icon", flat=True)
+
+    assert len(icon_paths) == 2
+    assert (icon_paths[0] == icon_paths[1]) == reuse


### PR DESCRIPTION
Reusing the same image means we don't need to upload so many images to S3 bucket (or multiple buckets if mirrors are configured), significantly speeding up creating larger data sets.

The implementation reuses the path of the first created image, which uses the team-package-version naming pattern, instead of using something more descriptive like "default.png". Bypassing the generated name would have required hacky stuff for the function that calculates the value for ImageField's upload_to attribute, or the models save method. As this would make it theoretically possible to things go wrong in the production, it was deemed better to just use the misleading image name in test environments.