### PR TITLE
Change search to match every sub part

### DIFF
--- a/django/thunderstore/api/cyberstorm/views/package_listing_list.py
+++ b/django/thunderstore/api/cyberstorm/views/package_listing_list.py
@@ -457,10 +457,12 @@ def filter_by_query(
     parts = [x for x in query.split(" ") if x]
 
     for part in parts:
+        part_query = Q()
         for field in search_fields:
-            icontains_query &= ~Q(**{f"{field}__icontains": part})
+            part_query |= Q(**{f"{field}__icontains": part})
+        icontains_query &= part_query
 
-    return queryset.exclude(icontains_query).distinct()
+    return queryset.filter(icontains_query).distinct()
 
 
 def filter_by_review_status(

--- a/django/thunderstore/frontend/api/experimental/views/community_package_list.py
+++ b/django/thunderstore/frontend/api/experimental/views/community_package_list.py
@@ -194,10 +194,12 @@ class CommunityPackageListApiView(APIView):
         parts = [x for x in query.split(" ") if x]
 
         for part in parts:
+            part_query = Q()
             for field in search_fields:
-                icontains_query &= ~Q(**{f"{field}__icontains": part})
+                part_query |= Q(**{f"{field}__icontains": part})
+            icontains_query &= part_query
 
-        return queryset.exclude(icontains_query).distinct()
+        return queryset.filter(icontains_query).distinct()
 
     def order_queryset(
         self, ordering: str, queryset: QuerySet[Package]

--- a/django/thunderstore/repository/views/package/list.py
+++ b/django/thunderstore/repository/views/package/list.py
@@ -202,11 +202,14 @@ class PackageListSearchView(CommunityMixin, ListView):
 
         icontains_query = Q()
         parts = [x for x in search_query.split(" ") if x]
-        for part in parts:
-            for field in search_fields:
-                icontains_query &= ~Q(**{f"{field}__icontains": part})
 
-        return queryset.exclude(icontains_query).distinct()
+        for part in parts:
+            part_query = Q()
+            for field in search_fields:
+                part_query |= Q(**{f"{field}__icontains": part})
+            icontains_query &= part_query
+
+        return queryset.filter(icontains_query).distinct()
 
     def filter_approval_status(
         self, queryset: QuerySet[PackageListing]


### PR DESCRIPTION
Instead of matching any part of the query with any field, this ensures that every part is matched in any field. Similar how r2modman works.

The search in Thunderstore is currently barely usable for searches with more than one term.
For example in Valheim, searching 'Epic Loot' returns about 100 packages (4 pages), with the actual package burred in the last page because it is named 'EpicLoot'. With this PR, the result is only about 6 packages (in my dev environment that is populated with Valheim package names).

Overall, this makes the search more strict. However, this is usually the expected behaviour. Adding more terms to the search should narrow down the results, not give more matches.