### PR TITLE
Fix community list template title

### DIFF
--- a/django/thunderstore/community/templates/community/community_list.html
+++ b/django/thunderstore/community/templates/community/community_list.html
@@ -8,7 +8,7 @@
 {% cache 300 templates.community.list %}
 
 <div class="row">
-    <h3 class="col-12 mt-4">{{ page_title }}</h3>
+    <h3 class="col-12 mt-4">All communities</h3>
 </div>
 
 {% if object_list %}


### PR DESCRIPTION
The community list template was expecting a context variable called page_title to be used for rendering the page title even though the view using the template doesn't populate such a variable.

Replace the variable usage with a constant value in the template directly.