### PR TITLE
Disable checksum search from package admin list

### DIFF
--- a/django/thunderstore/repository/admin/package.py
+++ b/django/thunderstore/repository/admin/package.py
@@ -116,7 +116,6 @@ class PackageAdmin(admin.ModelAdmin):
         "name",
         "namespace__name",
         "owner__name",
-        "versions__file_tree__entries__blob__checksum_sha256",
     )
     list_select_related = (
         "latest",

--- a/django/thunderstore/repository/admin/package_version.py
+++ b/django/thunderstore/repository/admin/package_version.py
@@ -42,7 +42,6 @@ class PackageVersionAdmin(admin.ModelAdmin):
         "package__owner__name",
         "package__namespace__name",
         "version_number",
-        "file_tree__entries__blob__checksum_sha256",
     )
     date_hierarchy = "date_created"
     readonly_fields = [x.name for x in PackageVersion._meta.fields] + [


### PR DESCRIPTION
Disable searching on file checksums from the package & package version admin list views as the queries take too long to run against the production dataset.