### PR TITLE
Add Client-Side Pre-Upload Package Validation

### DIFF
--- a/builder/src/components/DragDropFileInput.tsx
+++ b/builder/src/components/DragDropFileInput.tsx
@@ -1,13 +1,19 @@
-import React, { CSSProperties, useEffect, useRef, useState } from "react";
+import React, {
+    CSSProperties,
+    MutableRefObject,
+    useEffect,
+    useState,
+} from "react";
 
 interface DragDropFileInputProps {
     title: string;
     onChange?: (files: FileList) => void;
     readonly?: boolean;
+    fileInputRef: MutableRefObject<HTMLInputElement | null>;
 }
 
 export const DragDropFileInput: React.FC<DragDropFileInputProps> = (props) => {
-    const fileInputRef = useRef<HTMLInputElement>(null);
+    const fileInput = props.fileInputRef.current;
     const [fileDropStyle, setFileDropStyle] = useState<CSSProperties>({});
     const [lastTarget, setLastTarget] = useState<EventTarget | null>(null);
     const [isDragging, setIsDragging] = useState<boolean>(false);
@@ -39,8 +45,7 @@ export const DragDropFileInput: React.FC<DragDropFileInputProps> = (props) => {
     };
     const fileChange = () => {
         if (!props.readonly) {
-            const inp = fileInputRef.current;
-            const files = inp?.files;
+            const files = fileInput?.files;
             if (props.onChange && files) {
                 props.onChange(files);
             }
@@ -49,9 +54,8 @@ export const DragDropFileInput: React.FC<DragDropFileInputProps> = (props) => {
     };
     const onDrop = (e: React.DragEvent) => {
         if (!props.readonly) {
-            const inp = fileInputRef.current;
-            if (inp) {
-                inp.files = e.dataTransfer.files;
+            if (fileInput) {
+                fileInput.files = e.dataTransfer.files;
             }
             if (props.onChange) {
                 props.onChange(e.dataTransfer.files);
@@ -92,7 +96,7 @@ export const DragDropFileInput: React.FC<DragDropFileInputProps> = (props) => {
                 type="file"
                 name="newfile"
                 style={{ display: "none" }}
-                ref={fileInputRef}
+                ref={props.fileInputRef}
                 onChange={fileChange}
                 disabled={props.readonly}
             />

--- a/builder/src/uploadZipValidation.ts
+++ b/builder/src/uploadZipValidation.ts
@@ -14,6 +14,12 @@ export async function validateZip(
         return { errors, blockUpload };
     }
 
+    if (file.name.toLowerCase().includes("test")) {
+        errors.fileErrors.push(
+            "If you need to test your mod, you can import it locally through the 'Import local mod' option in your mod manager's settings."
+        );
+    }
+
     try {
         const blobReader = new BlobReader(file);
         const zipReader = new ZipReader(blobReader);

--- a/builder/src/uploadZipValidation.ts
+++ b/builder/src/uploadZipValidation.ts
@@ -1,0 +1,197 @@
+import { FormErrors } from "./upload";
+import { BlobReader, ZipReader } from "./vendor/zip-fs-full";
+
+export async function validateZip(
+    file: File
+): Promise<{ errors: FormErrors; blockUpload: boolean }> {
+    let errors = new FormErrors();
+
+    let blockUpload = false;
+
+    if (!file.name.toLowerCase().endsWith(".zip")) {
+        errors.fileErrors.push("The file you selected is not a .zip!");
+        blockUpload = true;
+        return { errors, blockUpload };
+    }
+
+    try {
+        const blobReader = new BlobReader(file);
+        const zipReader = new ZipReader(blobReader);
+
+        const entries = await zipReader.getEntries();
+
+        let dllCount = 0;
+        let hasBepInEx = false;
+        let hasAssemblyCSharp = false;
+        let maybeModpack = false;
+        let rootManifest = false;
+        let hasIcon = false;
+        let rootIcon = false;
+        let hasManifest = false;
+        let hasReadMe = false;
+        let rootReadMe = false;
+        let wrongCase = false;
+        let wrongExtension = false;
+        let noExtension = false;
+        for (const entry of entries) {
+            console.log(entry.filename);
+            if (!entry || !(typeof entry.getData === "function")) {
+                continue;
+            }
+
+            if (entry.filename.toLowerCase().endsWith(".dll")) {
+                dllCount++;
+            }
+
+            if (
+                entry.filename.toLowerCase().split("/").pop() ==
+                "assembly-csharp.dll"
+            ) {
+                hasAssemblyCSharp = true;
+            }
+
+            if (
+                entry.filename.toLowerCase().split("/").pop() == "bepinex.dll"
+            ) {
+                hasBepInEx = true;
+                maybeModpack = true;
+            }
+
+            if (entry.filename.toLowerCase().endsWith("manifest.json")) {
+                hasManifest = true;
+                if (entry.filename == "manifest.json") {
+                    rootManifest = true;
+                } else if (entry.filename.toLowerCase() == "manifest.json") {
+                    wrongCase = true;
+                    rootManifest = true;
+                }
+            }
+            if (entry.filename.toLowerCase().endsWith("icon.png")) {
+                hasIcon = true;
+                if (entry.filename == "icon.png") {
+                    rootIcon = true;
+                } else if (entry.filename.toLowerCase() == "icon.png") {
+                    wrongCase = true;
+                    rootIcon = true;
+                }
+            }
+            if (entry.filename.toLowerCase().endsWith("readme.md")) {
+                hasReadMe = true;
+                if (entry.filename == "README.md") {
+                    rootReadMe = true;
+                } else if (entry.filename.toLowerCase() == "readme.md") {
+                    wrongCase = true;
+                    rootReadMe = true;
+                }
+            }
+
+            if (
+                entry.filename.toLowerCase() == "readme.txt" ||
+                entry.filename.toLowerCase() == "manifest.txt" ||
+                entry.filename.toLowerCase() == "icon.jpg" ||
+                entry.filename.toLowerCase() == "icon.jpeg"
+            ) {
+                wrongExtension = true;
+            }
+
+            if (
+                entry.filename.toLowerCase() == "readme" ||
+                entry.filename.toLowerCase() == "manifest" ||
+                entry.filename.toLowerCase() == "icon"
+            ) {
+                noExtension = true;
+            }
+        }
+
+        if (hasBepInEx) {
+            errors.fileErrors.push(
+                "You have BepInEx.dll in your .zip file. BepInEx should probably be a dependency in your manifest.json file instead."
+            );
+        }
+
+        if (hasAssemblyCSharp) {
+            errors.fileErrors.push(
+                "You have Assembly-CSharp.dll in your .zip file. Your package may be removed if you do not have permission to distribute this file."
+            );
+        }
+
+        if (dllCount > 8) {
+            errors.fileErrors.push(
+                "You have " +
+                    dllCount +
+                    " .dll files in your .zip file. Some of these files may be unnecessary."
+            );
+            maybeModpack = true;
+        }
+
+        if (maybeModpack) {
+            errors.fileErrors.push(
+                "If you're making a modpack, do not include the files for each mod in your .zip file. Instead, put the dependency string for each mod inside your manifest.json file."
+            );
+        }
+
+        if (wrongCase) {
+            blockUpload = true;
+            errors.fileErrors.push(
+                "The file names of manifest.json, icon.png, and README.md are case-sensitive."
+            );
+        }
+
+        if (wrongExtension) {
+            blockUpload = true;
+            errors.fileErrors.push(
+                "Your manifest.json, icon.png, and README.md files must have the correct file extensions."
+            );
+        }
+
+        if (
+            hasManifest &&
+            hasIcon &&
+            hasReadMe &&
+            !rootManifest &&
+            !rootIcon &&
+            !rootReadMe
+        ) {
+            blockUpload = true;
+            errors.fileErrors.push(
+                "Your manifest, icon, and README files should be at the root of the .zip file. You can prevent this by compressing the contents of a folder, rather than the folder itself."
+            );
+        } else {
+            if ((!hasManifest || !hasIcon || !hasReadMe) && noExtension) {
+                blockUpload = true;
+                errors.fileErrors.push(
+                    "Your manifest.json, icon.png, or README.md file is missing its file extension."
+                );
+            }
+
+            if (!hasManifest) {
+                blockUpload = true;
+                errors.fileErrors.push(
+                    "Your package is missing a manifest.json file!"
+                );
+            }
+
+            if (!hasIcon) {
+                blockUpload = true;
+                errors.fileErrors.push(
+                    "Your package is missing an icon.png file!"
+                );
+            }
+
+            if (!hasReadMe) {
+                blockUpload = true;
+                errors.fileErrors.push(
+                    "Your package is missing a README.md file!"
+                );
+            }
+        }
+
+        await zipReader.close();
+    } catch (e) {
+        blockUpload = true;
+        errors = new FormErrors();
+        errors.fileErrors.push("Your .zip file could not be read.");
+    }
+
+    return { errors, blockUpload };
+}

--- a/builder/src/vendor/zip-fs-full.d.ts
+++ b/builder/src/vendor/zip-fs-full.d.ts
@@ -5,6 +5,13 @@
 
 interface FileEntry {}
 
+export var useWebWorkers: boolean;
+export var workerScriptsPath: string;
+export var workerScripts: {
+    deflater?: string[] | undefined;
+    inflater?: string[] | undefined;
+};
+
 export class Reader {
     public size: number;
     public init(callback: () => void, onerror: (error: any) => void): void;

--- a/builder/src/vendor/zip-fs-full.d.ts
+++ b/builder/src/vendor/zip-fs-full.d.ts
@@ -5,122 +5,121 @@
 
 interface FileEntry {}
 
-declare module zip {
-    export var useWebWorkers: boolean;
-    export var workerScriptsPath: string;
-    export var workerScripts: {
-        deflater?: string[] | undefined;
-        inflater?: string[] | undefined;
-    };
+export var useWebWorkers: boolean;
+export var workerScriptsPath: string;
+export var workerScripts: {
+    deflater?: string[] | undefined;
+    inflater?: string[] | undefined;
+};
 
-    export class Reader {
-        public size: number;
-        public init(callback: () => void, onerror: (error: any) => void): void;
-        public readUint8Array(
-            index: number,
-            length: number,
-            callback: (result: Uint8Array) => void,
-            onerror?: (error: any) => void
-        ): void;
-    }
-
-    export class TextReader extends Reader {
-        constructor(text: string);
-    }
-
-    export class BlobReader extends Reader {
-        constructor(blob: Blob);
-    }
-
-    export class Data64URIReader extends Reader {
-        constructor(dataURI: string);
-    }
-
-    export class HttpReader extends Reader {
-        constructor(url: string);
-    }
-
-    export function createReader(
-        reader: zip.Reader,
-        callback: (zipReader: ZipReader) => void,
+export class Reader {
+    public size: number;
+    public init(callback: () => void, onerror: (error: any) => void): void;
+    public readUint8Array(
+        index: number,
+        length: number,
+        callback: (result: Uint8Array) => void,
         onerror?: (error: any) => void
     ): void;
+}
 
-    export class ZipReader {
-        async getEntries(options: any): Promise<Entry[]>;
-        close(callback?: () => void): void;
-    }
+export class TextReader extends Reader {
+    constructor(text: string);
+}
 
-    export interface Entry {
-        filename: string;
-        directory: boolean;
-        compressedSize: number;
-        uncompressedSize: number;
-        lastModDate: Date;
-        lastModDateRaw: number;
-        comment: string;
-        crc32: number;
+export class BlobReader extends Reader {
+    constructor(blob: Blob);
+}
 
-        getData(
-            writer: zip.Writer,
-            onend: (result: any) => void,
-            onprogress?: (progress: number, total: number) => void,
-            checkCrc32?: boolean
-        ): void;
-    }
+export class Data64URIReader extends Reader {
+    constructor(dataURI: string);
+}
 
-    export class Writer {
-        public init(callback: () => void, onerror?: (error: any) => void): void;
-        public writeUint8Array(
-            array: Uint8Array,
-            callback: () => void,
-            onerror?: (error: any) => void
-        ): void;
-        public getData(
-            callback: (data: any) => void,
-            onerror?: (error: any) => void
-        ): void;
-    }
+export class HttpReader extends Reader {
+    constructor(url: string);
+}
 
-    export class TextWriter extends Writer {
-        constructor(encoding: string);
-    }
+export function createReader(
+    reader: zip.Reader,
+    callback: (zipReader: ZipReader) => void,
+    onerror?: (error: any) => void
+): void;
 
-    export class BlobWriter extends Writer {
-        constructor(contentType: string);
-    }
+export class ZipReader {
+    constructor(reader: BlobReader);
+    async getEntries(options?: any): Promise<Entry[]>;
+    close(callback?: () => void): void;
+}
 
-    export class FileWriter extends Writer {
-        constructor(fileEntry: FileEntry);
-    }
+export interface Entry {
+    filename: string;
+    directory: boolean;
+    compressedSize: number;
+    uncompressedSize: number;
+    lastModDate: Date;
+    lastModDateRaw: number;
+    comment: string;
+    crc32: number;
 
-    export class Data64URIWriter extends Writer {
-        constructor(mimeString?: string);
-    }
-
-    export function createWriter(
+    getData(
         writer: zip.Writer,
-        callback: (zipWriter: zip.ZipWriter) => void,
-        onerror?: (error: any) => void,
-        dontDeflate?: boolean
+        onend: (result: any) => void,
+        onprogress?: (progress: number, total: number) => void,
+        checkCrc32?: boolean
     ): void;
+}
 
-    export interface WriteOptions {
-        directory?: boolean | undefined;
-        level?: number | undefined;
-        comment?: string | undefined;
-        lastModDate?: Date | undefined;
-        version?: number | undefined;
-    }
+export class Writer {
+    public init(callback: () => void, onerror?: (error: any) => void): void;
+    public writeUint8Array(
+        array: Uint8Array,
+        callback: () => void,
+        onerror?: (error: any) => void
+    ): void;
+    public getData(
+        callback: (data: any) => void,
+        onerror?: (error: any) => void
+    ): void;
+}
 
-    export class ZipWriter {
-        public add(
-            name: string,
-            reader: zip.Reader,
-            onend: () => void,
-            onprogress?: (progress: number, total: number) => void,
-            options?: WriteOptions
-        ): void;
-        public close(callback: (result: any) => void): void;
-    }
+export class TextWriter extends Writer {
+    constructor(encoding: string);
+}
+
+export class BlobWriter extends Writer {
+    constructor(contentType: string);
+}
+
+export class FileWriter extends Writer {
+    constructor(fileEntry: FileEntry);
+}
+
+export class Data64URIWriter extends Writer {
+    constructor(mimeString?: string);
+}
+
+export function createWriter(
+    writer: zip.Writer,
+    callback: (zipWriter: zip.ZipWriter) => void,
+    onerror?: (error: any) => void,
+    dontDeflate?: boolean
+): void;
+
+export interface WriteOptions {
+    directory?: boolean | undefined;
+    level?: number | undefined;
+    comment?: string | undefined;
+    lastModDate?: Date | undefined;
+    version?: number | undefined;
+}
+
+export class ZipWriter {
+    public add(
+        name: string,
+        reader: zip.Reader,
+        onend: () => void,
+        onprogress?: (progress: number, total: number) => void,
+        options?: WriteOptions
+    ): void;
+    public close(callback: (result: any) => void): void;
 }

--- a/builder/src/vendor/zip-fs-full.d.ts
+++ b/builder/src/vendor/zip-fs-full.d.ts
@@ -5,13 +5,6 @@
 
 interface FileEntry {}
 
-export var useWebWorkers: boolean;
-export var workerScriptsPath: string;
-export var workerScripts: {
-    deflater?: string[] | undefined;
-    inflater?: string[] | undefined;
-};
-
 export class Reader {
     public size: number;
     public init(callback: () => void, onerror: (error: any) => void): void;


### PR DESCRIPTION
Prevents users from attempting to upload packages that aren't zips or packages without a manifest, icon, and readme in the root of the zip.

Warns the user when uploading packages with > 8 DLL files, an Assembly-CSharp.dll file, or BepInEx.dll.

Fixes a chromium bug preventing the selection of a file that was previously selected and canceled.

![image](https://github.com/user-attachments/assets/0d0a7a95-e724-42f3-8f35-72f98c41f35d)
