### PR TITLE
Disable checksum search from listing admin list

### DIFF
--- a/django/thunderstore/community/admin/package_listing.py
+++ b/django/thunderstore/community/admin/package_listing.py
@@ -64,7 +64,6 @@ class PackageListingAdmin(admin.ModelAdmin):
         "package__namespace__name",
         "package__owner__name",
         "package__name",
-        "package__versions__file_tree__entries__blob__checksum_sha256",
     )
     list_select_related = (
         "package",


### PR DESCRIPTION
Disable searching on file checksums from the package listing admin list view as the queries take too long to run against the production dataset.

This is nearly identical to https://github.com/thunderstore-io/Thunderstore/pull/1057 just for the Package Listing admin.

This functionality remains in the data blob reference admin.