### PR TITLE
Team fixes

### DIFF
--- a/django/thunderstore/repository/forms/team.py
+++ b/django/thunderstore/repository/forms/team.py
@@ -5,7 +5,13 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 
 from thunderstore.core.types import UserType
-from thunderstore.repository.models import Team, TeamMember, TeamMemberRole, transaction
+from thunderstore.repository.models import (
+    Namespace,
+    Team,
+    TeamMember,
+    TeamMemberRole,
+    transaction,
+)
 from thunderstore.repository.validators import PackageReferenceComponentValidator
 
 User = get_user_model()
@@ -28,6 +34,8 @@ class CreateTeamForm(forms.ModelForm):
         name = self.cleaned_data["name"]
         if Team.objects.filter(name__iexact=name.lower()).exists():
             raise ValidationError(f"A team with the provided name already exists")
+        if Namespace.objects.filter(name__iexact=name.lower()).exists():
+            raise ValidationError("A namespace with the provided name already exists")
         return name
 
     def clean(self):

--- a/django/thunderstore/repository/models/team.py
+++ b/django/thunderstore/repository/models/team.py
@@ -127,7 +127,9 @@ class Team(models.Model):
             for validator in self._meta.get_field("name").validators:
                 validator(self.name)
             if Team.objects.filter(name__iexact=self.name.lower()).exists():
-                raise ValidationError("The author name already exists")
+                raise ValidationError("Team with this name already exists")
+            if Namespace.objects.filter(name__iexact=self.name.lower()).exists():
+                raise ValidationError("Namespace with this name already exists")
         if self.donation_link is not None:
             for validator in self._meta.get_field("donation_link").validators:
                 validator(self.donation_link)

--- a/django/thunderstore/repository/views/team_settings.py
+++ b/django/thunderstore/repository/views/team_settings.py
@@ -187,10 +187,7 @@ class SettingsTeamLeaveView(TeamDetailView, UserFormKwargs, FormView):
         context = super().get_context_data(**kwargs)
         context["page_title"] = "Leave Team"
         context["membership"] = self.membership
-        context["can_leave"] = (
-            self.object.members.real_users().filter(role=TeamMemberRole.owner).count()
-            > 1
-        )
+        context["can_leave"] = not self.object.is_last_owner(self.membership.user)
         return context
 
     def form_invalid(self, form):


### PR DESCRIPTION
Addresses issues with teams that were recently reported by the community, including the creation of teams that already have a namespace and the leave team button being unavailable where it should be.

Note that this doesn't fix pre-existing teams who share a name with a namespace, but said namespace does not have a team associated with it. That will require a separate PR / migration. 