### PR TITLE
Pin snok/install-poetry to 1.4.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
         run: echo "::set-output name=node-version::$(node --version)"
       - uses: snok/install-poetry@v1
         with:
+          version: 1.4.1
           virtualenvs-in-project: true
       - name: Cache poetry venv
         id: cache-poetry


### PR DESCRIPTION
Pin snok/install-poetry to 1.4.1 to fix poetry failing to install in the GitHub workflow