### PR TITLE
Add is removed status (TS-2275)

### DIFF
--- a/django/thunderstore/api/cyberstorm/views/package_listing.py
+++ b/django/thunderstore/api/cyberstorm/views/package_listing.py
@@ -44,7 +44,7 @@ class DependencySerializer(serializers.Serializer):
     name = serializers.CharField()
     namespace = serializers.CharField(source="package.namespace.name")
     version_number = serializers.CharField()
-    is_removed = serializers.BooleanField(source="is_removed")
+    is_removed = serializers.BooleanField()
 
     def get_description(self, obj: PackageVersion) -> str:
         return (

--- a/django/thunderstore/api/cyberstorm/views/package_listing.py
+++ b/django/thunderstore/api/cyberstorm/views/package_listing.py
@@ -44,6 +44,7 @@ class DependencySerializer(serializers.Serializer):
     name = serializers.CharField()
     namespace = serializers.CharField(source="package.namespace.name")
     version_number = serializers.CharField()
+    is_removed = serializers.BooleanField(source="is_removed")
 
     def get_description(self, obj: PackageVersion) -> str:
         return (

--- a/django/thunderstore/repository/models/package.py
+++ b/django/thunderstore/repository/models/package.py
@@ -220,6 +220,10 @@ class Package(AdminLinkMixin, models.Model):
         )
 
     @cached_property
+    def is_removed(self):
+        return not self.is_effectively_active
+
+    @cached_property
     def is_effectively_active(self):
         return self.is_active and self.versions.filter(is_active=True).count() > 0
 

--- a/django/thunderstore/repository/models/package_version.py
+++ b/django/thunderstore/repository/models/package_version.py
@@ -191,6 +191,12 @@ class PackageVersion(VisibilityMixin, AdminLinkMixin):
         )
 
     @cached_property
+    def is_removed(self):
+        if self.package.is_removed:
+            return True
+        return not self.is_active
+
+    @cached_property
     def display_name(self):
         return self.name.replace("_", " ")
 

--- a/django/thunderstore/repository/tests/test_package.py
+++ b/django/thunderstore/repository/tests/test_package.py
@@ -10,7 +10,7 @@ from conftest import TestUserTypes
 from thunderstore.community.factories import PackageCategoryFactory, SiteFactory
 from thunderstore.community.models.package_listing import PackageListing
 from thunderstore.core.types import UserType
-from thunderstore.repository.factories import PackageFactory
+from thunderstore.repository.factories import PackageFactory, PackageVersionFactory
 from thunderstore.repository.models import (
     Namespace,
     Package,
@@ -224,3 +224,24 @@ def test_package_update_listing(
     assert listing.categories.count() == 3
     for entry in cats:
         assert entry in listing.categories.all()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("package_is_active", "version_is_active", "expected_is_removed"),
+    (
+        (False, False, True),
+        (True, False, True),
+        (False, True, True),
+        (True, True, False),
+    ),
+)
+def test_package_is_removed(
+    package_is_active: bool,
+    version_is_active: bool,
+    expected_is_removed: bool,
+) -> None:
+    package = PackageFactory(is_active=package_is_active)
+    PackageVersionFactory(package=package, is_active=version_is_active)
+
+    assert package.is_removed == expected_is_removed

--- a/django/thunderstore/repository/tests/test_package_version.py
+++ b/django/thunderstore/repository/tests/test_package_version.py
@@ -129,3 +129,24 @@ def test_package_version_is_effectively_active(
     version = PackageVersionFactory(package=package, is_active=version_is_active)
 
     assert version.is_effectively_active == (package_is_active and version_is_active)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("package_is_active", "version_is_active", "expected_is_removed"),
+    (
+        (False, False, True),
+        (True, False, True),
+        (False, True, True),
+        (True, True, False),
+    ),
+)
+def test_package_version_is_removed(
+    package_is_active: bool,
+    version_is_active: bool,
+    expected_is_removed: bool,
+) -> None:
+    package = PackageFactory(is_active=package_is_active)
+    version = PackageVersionFactory(package=package, is_active=version_is_active)
+
+    assert version.is_removed == expected_is_removed


### PR DESCRIPTION
- Added an is_removed property to the Package and PackageVersion models to determine whether the respective packages and package versions are marked as removed.

- Included the is_removed field in the DependencySerializer.

- Implemented corresponding unit tests.