### PR TITLE
Add unavailable status (TS-2276)

### DIFF
--- a/django/thunderstore/community/models/package_listing.py
+++ b/django/thunderstore/community/models/package_listing.py
@@ -329,6 +329,10 @@ class PackageListing(TimestampMixin, AdminLinkMixin, VisibilityMixin):
                 )
         self.categories.set(categories)
 
+    @property
+    def is_unavailable(self):
+        return self.is_rejected or self.is_waiting_for_approval
+
     def can_be_moderated_by_user(self, user: Optional[UserType]) -> bool:
         return self.community.can_user_manage_packages(user)
 

--- a/django/thunderstore/repository/models/package.py
+++ b/django/thunderstore/repository/models/package.py
@@ -137,6 +137,13 @@ class Package(VisibilityMixin, AdminLinkMixin):
             listing.categories.add(*categories)
         listing.save(update_fields=("has_nsfw_content",))
 
+    def is_unavailable(self, community) -> bool:
+        if not self.is_effectively_active:
+            return True
+
+        listing = self.get_package_listing(community)
+        return listing is None or listing.is_unavailable
+
     @cached_property
     def has_wiki(self) -> bool:
         try:

--- a/django/thunderstore/repository/models/package_version.py
+++ b/django/thunderstore/repository/models/package_version.py
@@ -213,6 +213,9 @@ class PackageVersion(VisibilityMixin, AdminLinkMixin):
             },
         )
 
+    def is_unavailable(self, community) -> bool:
+        return self.package.is_unavailable(community) or not self.is_active
+
     @cached_property
     def is_removed(self):
         if self.package.is_removed:


### PR DESCRIPTION
Add a new is_unavailable status to the Package and PackageVersion
models to determine whether a package or package version is unavailable.

A package is considered unavailable if there is no PackageListing
object linking the package to the currently viewed community.

Even if a PackageListing object exists linking the package to the
community, its status might be "rejected," which would render the
package unavailable.