### PR TITLE
Add is_staff to two endpoints (TS-2283)

### DIFF
--- a/django/thunderstore/social/api/experimental/views/current_user.py
+++ b/django/thunderstore/social/api/experimental/views/current_user.py
@@ -94,7 +94,7 @@ class UserProfileSerializer(serializers.Serializer):
         serializers.ListField()
     )  # This is in active use by the Django frontend react components at least
     teams_full = UserTeamSerializer(many=True)
-    is_staff = serializers.BooleanField(allow_null=True)
+    is_staff = serializers.BooleanField()
 
 
 def get_empty_profile() -> UserProfile:
@@ -106,7 +106,7 @@ def get_empty_profile() -> UserProfile:
         "rated_packages": [],
         "teams": [],
         "teams_full": [],
-        "is_staff": None,
+        "is_staff": False,
     }
 
 

--- a/django/thunderstore/social/api/experimental/views/current_user.py
+++ b/django/thunderstore/social/api/experimental/views/current_user.py
@@ -81,6 +81,7 @@ class UserProfile(TypedDict):
     rated_packages: List[str]
     teams: List[str]
     teams_full: List[UserTeam]
+    is_staff: Optional[bool]
 
 
 class UserProfileSerializer(serializers.Serializer):
@@ -93,6 +94,7 @@ class UserProfileSerializer(serializers.Serializer):
         serializers.ListField()
     )  # This is in active use by the Django frontend react components at least
     teams_full = UserTeamSerializer(many=True)
+    is_staff = serializers.BooleanField(allow_null=True)
 
 
 def get_empty_profile() -> UserProfile:
@@ -104,6 +106,7 @@ def get_empty_profile() -> UserProfile:
         "rated_packages": [],
         "teams": [],
         "teams_full": [],
+        "is_staff": None,
     }
 
 
@@ -133,6 +136,7 @@ def get_user_profile(user: UserType) -> UserProfile:
     username = user.username
     capabilities = {"package.rate"}
     teams = get_teams(user)
+    is_staff = user.is_staff
 
     return UserProfileSerializer(
         {
@@ -143,6 +147,7 @@ def get_user_profile(user: UserType) -> UserProfile:
             "rated_packages": [],
             "teams": [x.name for x in teams],
             "teams_full": teams,
+            "is_staff": is_staff,
         }
     ).data
 

--- a/django/thunderstore/social/api/v1/views/current_user.py
+++ b/django/thunderstore/social/api/v1/views/current_user.py
@@ -15,9 +15,19 @@ class CurrentUserInfoView(APIView):
     def get(self, request, format=None, community_identifier=None):
         capabilities = set()
         rated_packages = []
+        is_staff = None
+
         if request.user.is_authenticated:
             capabilities.add("package.rate")
             rated_packages = request.user.package_ratings.select_related(
                 "package"
             ).values_list("package__uuid4", flat=True)
-        return Response({"capabilities": capabilities, "ratedPackages": rated_packages})
+            is_staff = request.user.is_staff
+
+        return Response(
+            {
+                "capabilities": capabilities,
+                "ratedPackages": rated_packages,
+                "is_staff": is_staff,
+            }
+        )

--- a/django/thunderstore/social/api/v1/views/current_user.py
+++ b/django/thunderstore/social/api/v1/views/current_user.py
@@ -15,7 +15,7 @@ class CurrentUserInfoView(APIView):
     def get(self, request, format=None, community_identifier=None):
         capabilities = set()
         rated_packages = []
-        is_staff = None
+        is_staff = False
 
         if request.user.is_authenticated:
             capabilities.add("package.rate")

--- a/django/thunderstore/social/tests/test_current_user.py
+++ b/django/thunderstore/social/tests/test_current_user.py
@@ -249,8 +249,8 @@ def _run_current_user_is_staff_test(
     [
         (True, True, True),
         (True, False, False),
-        (False, True, None),
-        (False, False, None),
+        (False, True, False),
+        (False, False, False),
     ],
 )
 def test_current_user_is_staff_experimental_api(
@@ -271,8 +271,8 @@ def test_current_user_is_staff_experimental_api(
     [
         (True, True, True),
         (True, False, False),
-        (False, True, None),
-        (False, False, None),
+        (False, True, False),
+        (False, False, False),
     ],
 )
 def test_current_user_is_staff_v1_api(

--- a/django/thunderstore/social/tests/test_current_user.py
+++ b/django/thunderstore/social/tests/test_current_user.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import Optional
 
 import pytest
 from django.utils import timezone
@@ -18,6 +19,11 @@ def request_user_info(api_client: APIClient) -> Response:
         "/api/experimental/current-user/",
         HTTP_ACCEPT="application/json",
     )
+
+
+def request_user_info_v1(api_client: APIClient) -> Response:
+    url = "/api/v1/current-user/info/"
+    return api_client.get(url, HTTP_ACCEPT="application/json")
 
 
 @pytest.mark.django_db
@@ -212,3 +218,75 @@ def test_current_user_info__for_team_member__has_teams(
     team2 = next(t for t in user_info["teams_full"] if t["name"] == member2.team.name)
     assert team2["role"] == TeamMemberRole.member
     assert team2["member_count"] == 2  # ServiceAccounts do not count.
+
+
+def _run_current_user_is_staff_test(
+    api_client: APIClient,
+    user: UserType,
+    is_authorized: bool,
+    is_staff: bool,
+    expected_status: Optional[bool],
+    is_v1_api: bool,
+):
+    user.is_staff = is_staff
+
+    if is_authorized:
+        api_client.force_authenticate(user=user)
+
+    if is_v1_api:
+        response = request_user_info_v1(api_client)
+    else:
+        # Experimental API
+        response = request_user_info(api_client)
+
+    assert response.status_code == 200
+    assert response.json()["is_staff"] == expected_status
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("is_authorized", "is_staff", "expected_status"),
+    [
+        (True, True, True),
+        (True, False, False),
+        (False, True, None),
+        (False, False, None),
+    ],
+)
+def test_current_user_is_staff_experimental_api(
+    api_client: APIClient,
+    user: UserType,
+    is_authorized: bool,
+    is_staff: bool,
+    expected_status: Optional[bool],
+):
+    _run_current_user_is_staff_test(
+        api_client, user, is_authorized, is_staff, expected_status, False
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("is_authorized", "is_staff", "expected_status"),
+    [
+        (True, True, True),
+        (True, False, False),
+        (False, True, None),
+        (False, False, None),
+    ],
+)
+def test_current_user_is_staff_v1_api(
+    api_client: APIClient,
+    user: UserType,
+    is_authorized: bool,
+    is_staff: bool,
+    expected_status: Optional[bool],
+):
+    _run_current_user_is_staff_test(
+        api_client,
+        user,
+        is_authorized,
+        is_staff,
+        expected_status,
+        True,
+    )


### PR DESCRIPTION
Added is_staff field to the payload of /api/experimental/current-user/ and /api/v1/current-user/info/. The field returns true or false if the user is authenticated, and null if the user is not authenticated.

Refs. TS-2283