### PR TITLE
Moderation permissions via api (TS-2284)

### DIFF
--- a/django/conftest.py
+++ b/django/conftest.py
@@ -53,6 +53,7 @@ from thunderstore.repository.models import (
     Webhook,
 )
 from thunderstore.repository.models.namespace import Namespace
+from thunderstore.repository.views.package.detail import PermissionsChecker
 from thunderstore.schema_server.factories import SchemaChannelFactory
 from thunderstore.usermedia.tests.utils import create_and_upload_usermedia
 from thunderstore.webhooks.models.release import WebhookType
@@ -527,6 +528,11 @@ def async_package_submission(
 @pytest.fixture
 def package_installer() -> PackageInstaller:
     return PackageInstallerFactory()
+
+
+@pytest.fixture(scope="function")
+def permissions_checker(active_package_listing, user) -> PermissionsChecker:
+    return PermissionsChecker(active_package_listing, user)
 
 
 def create_test_service_account_user():

--- a/django/thunderstore/api/cyberstorm/serializers/__init__.py
+++ b/django/thunderstore/api/cyberstorm/serializers/__init__.py
@@ -3,7 +3,7 @@ from .community import (
     CyberstormPackageCategorySerializer,
     CyberstormPackageListingSectionSerializer,
 )
-from .package import CyberstormPackagePreviewSerializer
+from .package import CyberstormPackagePreviewSerializer, PackagePermissionsSerializer
 from .team import (
     CyberstormServiceAccountSerializer,
     CyberstormTeamMemberSerializer,
@@ -18,4 +18,5 @@ __all__ = [
     "CyberstormServiceAccountSerializer",
     "CyberstormTeamMemberSerializer",
     "CyberstormTeamSerializer",
+    "PackagePermissionsSerializer",
 ]

--- a/django/thunderstore/api/cyberstorm/serializers/package.py
+++ b/django/thunderstore/api/cyberstorm/serializers/package.py
@@ -7,6 +7,29 @@ from thunderstore.community.models import Community
 from thunderstore.repository.models import Namespace, Package, PackageVersion
 
 
+class PackageInfoSerializer(serializers.Serializer):
+    community_id = serializers.CharField()
+    namespace_id = serializers.CharField()
+    package_name = serializers.CharField()
+
+
+class PermissionsSerializer(serializers.Serializer):
+    can_manage = serializers.BooleanField()
+    can_manage_deprecation = serializers.BooleanField()
+    can_manage_categories = serializers.BooleanField()
+    can_deprecate = serializers.BooleanField()
+    can_undeprecate = serializers.BooleanField()
+    can_unlist = serializers.BooleanField()
+    can_moderate = serializers.BooleanField()
+    can_view_package_admin_page = serializers.BooleanField()
+    can_view_listing_admin_page = serializers.BooleanField()
+
+
+class PackagePermissionsSerializer(serializers.Serializer):
+    package = PackageInfoSerializer()
+    permissions = PermissionsSerializer()
+
+
 class CyberstormPackagePreviewSerializer(serializers.Serializer):
     """
     Data shown on "PackageCard" component on frontend.

--- a/django/thunderstore/api/cyberstorm/tests/test_package_permissions.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_package_permissions.py
@@ -35,10 +35,10 @@ PERMISSIONS_CHECKER_TEST_PARAMETERS = [
 ]
 
 
-def get_url(lising: PackageListing) -> str:
-    community_id = lising.community.identifier
-    namespace_id = lising.package.namespace.name
-    package_name = lising.package.name
+def get_url(listing: PackageListing) -> str:
+    community_id = listing.community.identifier
+    namespace_id = listing.package.namespace.name
+    package_name = listing.package.name
     base_url = "/api/cyberstorm/package"
     return f"{base_url}/{community_id}/{namespace_id}/{package_name}/permissions/"
 

--- a/django/thunderstore/api/cyberstorm/tests/test_package_permissions.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_package_permissions.py
@@ -1,0 +1,123 @@
+from unittest.mock import PropertyMock, patch
+
+import pytest
+from rest_framework.test import APIClient
+
+from thunderstore.core.types import UserType
+from thunderstore.repository.models import PackageListing
+
+PERMISSIONS_CHECKER_PATH = (
+    "thunderstore.repository.views.package.detail.PermissionsChecker"
+)
+
+
+PERMISSIONS_CHECKER_TEST_PARAMETERS = [
+    # ("name_of_the_permissions_function", expected_value)
+    # See the PermissionsChecker class in the repository/views/package/detail.py file
+    ("can_manage", True),
+    ("can_manage", False),
+    ("can_manage_deprecation", True),
+    ("can_manage_deprecation", False),
+    ("can_manage_categories", True),
+    ("can_manage_categories", False),
+    ("can_deprecate", True),
+    ("can_deprecate", False),
+    ("can_undeprecate", True),
+    ("can_undeprecate", False),
+    ("can_unlist", True),
+    ("can_unlist", False),
+    ("can_moderate", True),
+    ("can_moderate", False),
+    ("can_view_package_admin_page", True),
+    ("can_view_package_admin_page", False),
+    ("can_view_listing_admin_page", True),
+    ("can_view_listing_admin_page", False),
+]
+
+
+def get_url(namespace_id: str, package_name: str) -> str:
+    return f"/api/cyberstorm/package/{namespace_id}/{package_name}/permissions/"
+
+
+@pytest.mark.django_db
+def test_package_permissions_not_logged_in(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+) -> None:
+    package_name = active_package_listing.package.name
+    namespace_id = active_package_listing.package.namespace.name
+    url = get_url(namespace_id, package_name)
+
+    response = api_client.get(url, content_type="application/json")
+    assert response.status_code == 401
+    assert response.json() == {
+        "detail": "Authentication credentials were not provided."
+    }
+
+
+@pytest.mark.django_db
+def test_package_permissions_logged_in(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+    user: UserType,
+) -> None:
+    api_client.force_authenticate(user)
+
+    package_name = active_package_listing.package.name
+    namespace_id = active_package_listing.package.namespace.name
+    url = get_url(namespace_id, package_name)
+
+    response = api_client.get(url, content_type="application/json")
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("permissions_func_name", "expected_value"), PERMISSIONS_CHECKER_TEST_PARAMETERS
+)
+def test_package_permissions_response_values(
+    permissions_func_name: str,
+    expected_value: bool,
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+    user: UserType,
+) -> None:
+    """
+    Test that the response values are matching the return values of the
+    permissions functions in PermissionsChecker.
+    """
+
+    api_client.force_authenticate(user)
+
+    package_name = active_package_listing.package.name
+    namespace_id = active_package_listing.package.namespace.name
+    url = get_url(namespace_id, package_name)
+
+    property_path = f"{PERMISSIONS_CHECKER_PATH}.{permissions_func_name}"
+    with patch(property_path, new_callable=PropertyMock) as mock_checker_function:
+        mock_checker_function.return_value = expected_value
+        response = api_client.get(url, content_type="application/json")
+
+    assert response.status_code == 200
+    assert response.json()[permissions_func_name] == expected_value
+
+
+@pytest.mark.django_db
+@patch(f"{PERMISSIONS_CHECKER_PATH}.get_permissions")
+def test_package_permissions_not_found(
+    mock_get_permissions,
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+    user: UserType,
+) -> None:
+    mock_get_permissions.return_value = {}
+
+    api_client.force_authenticate(user)
+
+    package_name = active_package_listing.package.name
+    namespace_id = active_package_listing.package.namespace.name
+    url = get_url(namespace_id, package_name)
+
+    response = api_client.get(url, content_type="application/json")
+    assert response.status_code == 404
+    assert response.json() == {"message": "Permissions not found."}

--- a/django/thunderstore/api/cyberstorm/views/__init__.py
+++ b/django/thunderstore/api/cyberstorm/views/__init__.py
@@ -9,6 +9,7 @@ from .package_listing_list import (
     PackageListingByDependencyListAPIView,
     PackageListingByNamespaceListAPIView,
 )
+from .package_permissions import PackagePermissionsAPIView
 from .package_rating import RatePackageAPIView
 from .package_version_list import PackageVersionListAPIView
 from .team import (
@@ -27,6 +28,7 @@ __all__ = [
     "PackageListingByCommunityListAPIView",
     "PackageListingByDependencyListAPIView",
     "PackageListingByNamespaceListAPIView",
+    "PackagePermissionsAPIView",
     "PackageVersionChangelogAPIView",
     "PackageVersionListAPIView",
     "PackageVersionReadmeAPIView",

--- a/django/thunderstore/api/cyberstorm/views/package_permissions.py
+++ b/django/thunderstore/api/cyberstorm/views/package_permissions.py
@@ -1,42 +1,20 @@
 from django.http import HttpRequest
-from rest_framework import serializers, status
+from rest_framework import status
 from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from thunderstore.api.cyberstorm.serializers import PackagePermissionsSerializer
 from thunderstore.api.utils import conditional_swagger_auto_schema
 from thunderstore.repository.models import Community, PackageListing
 from thunderstore.repository.views.package._utils import get_package_listing_or_404
 from thunderstore.repository.views.package.detail import PermissionsChecker
 
 
-class PackageInfoSerializer(serializers.Serializer):
-    community_id = serializers.CharField()
-    namespace_id = serializers.CharField()
-    package_name = serializers.CharField()
-
-
-class PermissionsSerializer(serializers.Serializer):
-    can_manage = serializers.BooleanField()
-    can_manage_deprecation = serializers.BooleanField()
-    can_manage_categories = serializers.BooleanField()
-    can_deprecate = serializers.BooleanField()
-    can_undeprecate = serializers.BooleanField()
-    can_unlist = serializers.BooleanField()
-    can_moderate = serializers.BooleanField()
-    can_view_package_admin_page = serializers.BooleanField()
-    can_view_listing_admin_page = serializers.BooleanField()
-
-
-class PackagePermissionsSerializer(serializers.Serializer):
-    package = PackageInfoSerializer()
-    permissions = PermissionsSerializer()
-
-
-class BasePackagePermissionsAPIView(APIView):
+class PackagePermissionsAPIView(APIView):
     """
-    Base class for getting the permissions for the current user on a package listing.
+    View for getting the permissions for the current user on a package.
     """
 
     permission_classes = [IsAuthenticated]
@@ -67,12 +45,6 @@ class BasePackagePermissionsAPIView(APIView):
 
         permission_data = permissions_checker.get_permissions()
         return permission_data
-
-
-class PackagePermissionsAPIView(BasePackagePermissionsAPIView):
-    """
-    View for getting the permissions for the current user on a package.
-    """
 
     @conditional_swagger_auto_schema(
         responses={200: PackagePermissionsSerializer},

--- a/django/thunderstore/api/cyberstorm/views/package_permissions.py
+++ b/django/thunderstore/api/cyberstorm/views/package_permissions.py
@@ -1,0 +1,85 @@
+from django.http import HttpRequest
+from rest_framework import serializers, status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from thunderstore.api.utils import conditional_swagger_auto_schema
+from thunderstore.repository.models import Community, PackageListing
+from thunderstore.repository.views.package._utils import get_package_listing_or_404
+from thunderstore.repository.views.package.detail import PermissionsChecker
+
+
+class PackagePermissionsSerializer(serializers.Serializer):
+    can_manage = serializers.BooleanField()
+    can_manage_deprecation = serializers.BooleanField()
+    can_manage_categories = serializers.BooleanField()
+    can_deprecate = serializers.BooleanField()
+    can_undeprecate = serializers.BooleanField()
+    can_unlist = serializers.BooleanField()
+    can_moderate = serializers.BooleanField()
+    can_view_package_admin_page = serializers.BooleanField()
+    can_view_listing_admin_page = serializers.BooleanField()
+
+
+class BasePackagePermissionsAPIView(APIView):
+    """
+    Base class for getting the permissions for the current user on a package listing.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def permissions_checker(self, listing) -> PermissionsChecker:
+        if not listing or not self.request.user:
+            return None
+        return PermissionsChecker(listing, self.request.user)
+
+    def get_listing(
+        self, namespace_id: str, package_name: str, community: Community
+    ) -> PackageListing:
+        return get_package_listing_or_404(
+            namespace=namespace_id,
+            name=package_name,
+            community=community,
+        )
+
+    def get_permissions_data(
+        self, namespace_id: str, package_name: str, community: Community
+    ) -> dict:
+        listing = self.get_listing(namespace_id, package_name, community)
+
+        permissions_checker = self.permissions_checker(listing)
+        if not permissions_checker:
+            return {}
+
+        permission_data = permissions_checker.get_permissions()
+        return permission_data
+
+    def get(
+        self, request: HttpRequest, namespace_id: str, package_name: str
+    ) -> Response:
+        data = self.get_permissions_data(namespace_id, package_name, request.community)
+        if not data:
+            return Response(
+                {"message": "Permissions not found."}, status=status.HTTP_404_NOT_FOUND
+            )
+
+        serializer = PackagePermissionsSerializer(data=data)
+        serializer.is_valid(raise_exception=True)
+        return Response(serializer.data)
+
+
+class PackagePermissionsAPIView(BasePackagePermissionsAPIView):
+    """
+    View for getting the permissions for the current user on a package.
+    """
+
+    @conditional_swagger_auto_schema(
+        responses={200: PackagePermissionsSerializer},
+        operation_id="cyberstorm.package.permissions",
+        tags=["cyberstorm"],
+    )
+    def get(
+        self, request: HttpRequest, namespace_id: str, package_name: str
+    ) -> Response:
+        return super().get(request, namespace_id, package_name)

--- a/django/thunderstore/api/urls.py
+++ b/django/thunderstore/api/urls.py
@@ -9,6 +9,7 @@ from thunderstore.api.cyberstorm.views import (
     PackageListingByCommunityListAPIView,
     PackageListingByDependencyListAPIView,
     PackageListingByNamespaceListAPIView,
+    PackagePermissionsAPIView,
     PackageVersionChangelogAPIView,
     PackageVersionListAPIView,
     PackageVersionReadmeAPIView,
@@ -89,6 +90,11 @@ cyberstorm_urls = [
         "package/<str:namespace_id>/<str:package_name>/deprecate/",
         DeprecatePackageAPIView.as_view(),
         name="cyberstorm.package.deprecate",
+    ),
+    path(
+        "package/<str:namespace_id>/<str:package_name>/permissions/",
+        PackagePermissionsAPIView.as_view(),
+        name="cyberstorm.package.permissions",
     ),
     path(
         "team/<str:team_id>/",

--- a/django/thunderstore/api/urls.py
+++ b/django/thunderstore/api/urls.py
@@ -92,7 +92,7 @@ cyberstorm_urls = [
         name="cyberstorm.package.deprecate",
     ),
     path(
-        "package/<str:namespace_id>/<str:package_name>/permissions/",
+        "package/<str:community_id>/<str:namespace_id>/<str:package_name>/permissions/",
         PackagePermissionsAPIView.as_view(),
         name="cyberstorm.package.permissions",
     ),

--- a/django/thunderstore/repository/tests/test_package_detail_view.py
+++ b/django/thunderstore/repository/tests/test_package_detail_view.py
@@ -1,0 +1,201 @@
+from unittest.mock import PropertyMock, patch
+
+import pytest
+from django.urls import reverse
+
+PERMISSION_KEYS = [
+    "show_management_panel",
+    "show_listing_admin_link",
+    "show_package_admin_link",
+    "show_review_status",
+    "show_internal_notes",
+    "review_panel_props",
+]
+
+
+PERMISSION_KEYS_TEST_PARAMETERS = [
+    (PERMISSION_KEYS[0], "can_manage", True),
+    (PERMISSION_KEYS[0], "can_manage", False),
+    (PERMISSION_KEYS[1], "can_view_listing_admin_page", True),
+    (PERMISSION_KEYS[1], "can_view_listing_admin_page", False),
+    (PERMISSION_KEYS[2], "can_view_package_admin_page", True),
+    (PERMISSION_KEYS[2], "can_view_package_admin_page", False),
+    (PERMISSION_KEYS[3], "can_manage", True),
+    (PERMISSION_KEYS[3], "can_manage", False),
+    (PERMISSION_KEYS[4], "can_moderate", True),
+    (PERMISSION_KEYS[4], "can_moderate", False),
+]
+
+
+REVIEW_PANEL_PROPS_KEYS = [
+    "reviewStatus",
+    "rejectionReason",
+    "internalNotes",
+    "packageListingId",
+]
+
+
+REVIEW_PANEL_PROPS_TEST_PARAMETERS = [
+    ("can_moderate", False, None),
+    ("can_moderate", True, REVIEW_PANEL_PROPS_KEYS),
+]
+
+
+MANAGEMENT_PANEL_PROPS_KEYS = [
+    "canDeprecate",
+    "canUndeprecate",
+    "canUnlist",
+    "canUpdateCategories",
+]
+
+
+MANAGEMENT_PANEL_PROPS_TEST_PARAMETERS = [
+    (MANAGEMENT_PANEL_PROPS_KEYS[0], "can_deprecate", True),
+    (MANAGEMENT_PANEL_PROPS_KEYS[0], "can_deprecate", False),
+    (MANAGEMENT_PANEL_PROPS_KEYS[1], "can_undeprecate", True),
+    (MANAGEMENT_PANEL_PROPS_KEYS[1], "can_undeprecate", False),
+    (MANAGEMENT_PANEL_PROPS_KEYS[2], "can_unlist", True),
+    (MANAGEMENT_PANEL_PROPS_KEYS[2], "can_unlist", False),
+    (MANAGEMENT_PANEL_PROPS_KEYS[3], "can_manage_categories", True),
+    (MANAGEMENT_PANEL_PROPS_KEYS[3], "can_manage_categories", False),
+]
+
+
+def get_package_detail_view_url(owner: str, name: str):
+    # Note: this is the legacy URL
+    return reverse("old_urls:packages.detail", kwargs={"owner": owner, "name": name})
+
+
+@pytest.mark.django_db
+def test_package_detail_view_permission_keys_in_context(
+    client, active_package_listing, community_site
+):
+    """
+    Test that the expected permission keys are present in the context.
+    """
+
+    owner = active_package_listing.package.owner
+    package = active_package_listing.package
+    url = get_package_detail_view_url(owner=owner.name, name=package.name)
+
+    response = client.get(url, HTTP_HOST=community_site.site.domain)
+    context = response.context[0]
+    management_panel_props = context.get("management_panel_props", {})
+
+    assert response.status_code == 200
+
+    for key in PERMISSION_KEYS:
+        assert key in context
+
+    for key in MANAGEMENT_PANEL_PROPS_KEYS:
+        assert key in management_panel_props
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("permission_key", "permissions_checker_function", "return_value"),
+    PERMISSION_KEYS_TEST_PARAMETERS,
+)
+def test_package_detail_view_permission_keys_test_values(
+    permission_key,
+    permissions_checker_function,
+    return_value,
+    client,
+    active_package_listing,
+    community_site,
+):
+    """
+    Test that the permission keys in the context have the expected values. The values
+    are determined by the return value of the permissions checker function.
+    """
+
+    owner = active_package_listing.package.owner
+    package = active_package_listing.package
+    url = get_package_detail_view_url(owner=owner.name, name=package.name)
+
+    path = (
+        f"thunderstore.repository.views.package.detail."
+        f"PermissionsChecker.{permissions_checker_function}"
+    )
+    with patch(path, new_callable=PropertyMock) as mock_permissions_checker_function:
+        mock_permissions_checker_function.return_value = return_value
+        response = client.get(url, HTTP_HOST=community_site.site.domain)
+
+    context = response.context[0]
+    assert context[permission_key] == return_value
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("permissions_checker_function", "return_value", "expected_keys"),
+    REVIEW_PANEL_PROPS_TEST_PARAMETERS,
+)
+def test_package_detail_view_review_panel_props_keys(
+    permissions_checker_function,
+    return_value,
+    expected_keys,
+    client,
+    active_package_listing,
+    community_site,
+):
+    """
+    Test that the review panel props are present with the correct values in the context.
+    The review panel props are either None or a dictionary with the expected keys.
+    """
+
+    owner = active_package_listing.package.owner
+    package = active_package_listing.package
+    url = get_package_detail_view_url(owner=owner.name, name=package.name)
+
+    path = (
+        f"thunderstore.repository.views.package.detail."
+        f"PermissionsChecker.{permissions_checker_function}"
+    )
+    with patch(path, new_callable=PropertyMock) as mock_permissions_checker_function:
+        mock_permissions_checker_function.return_value = return_value
+        response = client.get(url, HTTP_HOST=community_site.site.domain)
+
+    context = response.context[0]
+    review_panel_props = context["review_panel_props"]
+
+    if return_value:
+        for key in expected_keys:
+            assert key in review_panel_props
+    else:
+        assert review_panel_props is None
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("management_panel_prop_key", "permissions_checker_function", "return_value"),
+    MANAGEMENT_PANEL_PROPS_TEST_PARAMETERS,
+)
+def test_package_detail_view_management_panel_props(
+    management_panel_prop_key,
+    permissions_checker_function,
+    return_value,
+    client,
+    active_package_listing,
+    community_site,
+):
+    """
+    Test that the management panel props are present with the correct values in the
+    context. The values are determined by the return value of the permissions checker
+    properties.
+    """
+
+    owner = active_package_listing.package.owner
+    package = active_package_listing.package
+    url = get_package_detail_view_url(owner=owner.name, name=package.name)
+
+    path = (
+        f"thunderstore.repository.views.package.detail."
+        f"PermissionsChecker.{permissions_checker_function}"
+    )
+    with patch(path, new_callable=PropertyMock) as mock_permissions_checker_function:
+        mock_permissions_checker_function.return_value = return_value
+        response = client.get(url, HTTP_HOST=community_site.site.domain)
+
+    context = response.context[0]
+    management_panel_props = context["management_panel_props"]
+    assert management_panel_props[management_panel_prop_key] == return_value

--- a/django/thunderstore/repository/tests/test_permissions_checker.py
+++ b/django/thunderstore/repository/tests/test_permissions_checker.py
@@ -1,0 +1,154 @@
+from unittest.mock import patch
+
+import pytest
+from django.core.exceptions import ValidationError
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("can_manage_deprecation, can_manage_categories, can_unlist, expected_result"),
+    [
+        (True, True, True, True),
+        (True, True, False, True),
+        (True, False, True, True),
+        (True, False, False, True),
+        (False, True, True, True),
+        (False, True, False, True),
+        (False, False, True, True),
+        (False, False, False, False),
+    ],
+)
+def test_can_manage(
+    permissions_checker,
+    can_manage_deprecation,
+    can_manage_categories,
+    can_unlist,
+    expected_result,
+):
+    permissions_checker.can_manage_deprecation = can_manage_deprecation
+    permissions_checker.can_manage_categories = can_manage_categories
+    permissions_checker.can_unlist = can_unlist
+
+    assert permissions_checker.can_manage == expected_result
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("return_val", (True, False))
+@patch("thunderstore.repository.models.package.Package.can_user_manage_deprecation")
+def test_can_manage_deprecation(
+    mock_can_user_manage_deprecation,
+    return_val,
+    permissions_checker,
+):
+    mock_can_user_manage_deprecation.return_value = return_val
+    assert permissions_checker.can_manage_deprecation == return_val
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("return_val", (True, False))
+@patch(
+    "thunderstore.community.models.PackageListing.ensure_update_categories_permission"
+)
+def test_can_manage_categories(
+    mock_ensure_update_categories_permission, return_val, permissions_checker
+):
+    if return_val is True:
+        mock_ensure_update_categories_permission.return_value = return_val
+    else:
+        mock_ensure_update_categories_permission.side_effect = ValidationError("Failed")
+    assert permissions_checker.can_manage_categories == return_val
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("is_deprecated", "can_manage_deprecation", "expected_result"),
+    [
+        (True, True, False),
+        (True, False, False),
+        (False, True, True),
+        (False, False, False),
+    ],
+)
+def test_can_deprecate(
+    is_deprecated,
+    can_manage_deprecation,
+    expected_result,
+    permissions_checker,
+):
+    permissions_checker.listing.package.is_deprecated = is_deprecated
+    permissions_checker.can_manage_deprecation = can_manage_deprecation
+    assert permissions_checker.can_deprecate == expected_result
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("is_deprecated", "can_manage_deprecation", "expected_result"),
+    [
+        (True, True, True),
+        (True, False, False),
+        (False, True, False),
+        (False, False, False),
+    ],
+)
+def test_can_undeprecate(
+    permissions_checker, is_deprecated, can_manage_deprecation, expected_result
+):
+    permissions_checker.listing.package.is_deprecated = is_deprecated
+    permissions_checker.can_manage_deprecation = can_manage_deprecation
+    assert permissions_checker.can_undeprecate == expected_result
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("is_superuser", (True, False))
+def test_can_unlist(permissions_checker, is_superuser):
+    permissions_checker.user.is_superuser = is_superuser
+    assert permissions_checker.can_unlist == is_superuser
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("return_val", (True, False))
+@patch(
+    "thunderstore.community.models.community.Community."
+    "ensure_user_can_moderate_packages"
+)
+def test_can_moderate(
+    mock_ensure_update_categories_permission, return_val, permissions_checker
+):
+    if return_val is True:
+        mock_ensure_update_categories_permission.return_value = return_val
+    else:
+        mock_ensure_update_categories_permission.side_effect = ValidationError("Failed")
+    assert permissions_checker.can_moderate == return_val
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("return_val", (True, False))
+@patch("thunderstore.repository.views.package.detail.can_view_package_admin")
+def test_can_view_package_admin_page(mock_func, return_val, permissions_checker):
+    mock_func.return_value = return_val
+    assert permissions_checker.can_view_package_admin_page == return_val
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("return_val", (True, False))
+@patch("thunderstore.repository.views.package.detail.can_view_listing_admin")
+def test_can_view_listing_admin_page(mock_func, return_val, permissions_checker):
+    mock_func.return_value = return_val
+    assert permissions_checker.can_view_listing_admin_page == return_val
+
+
+@pytest.mark.django_db
+def test_get_permissions(permissions_checker):
+    permissions = permissions_checker.get_permissions()
+    expected_permissions = {
+        "can_manage": permissions_checker.can_manage,
+        "can_manage_deprecation": permissions_checker.can_manage_deprecation,
+        "can_manage_categories": permissions_checker.can_manage_categories,
+        "can_deprecate": permissions_checker.can_deprecate,
+        "can_undeprecate": permissions_checker.can_undeprecate,
+        "can_unlist": permissions_checker.can_unlist,
+        "can_moderate": permissions_checker.can_moderate,
+        "can_view_package_admin_page": permissions_checker.can_view_package_admin_page,
+        "can_view_listing_admin_page": permissions_checker.can_view_listing_admin_page,
+    }
+    assert permissions == expected_permissions

--- a/django/thunderstore/repository/tests/test_permissions_checker.py
+++ b/django/thunderstore/repository/tests/test_permissions_checker.py
@@ -112,12 +112,12 @@ def test_can_unlist(permissions_checker, is_superuser):
     "ensure_user_can_moderate_packages"
 )
 def test_can_moderate(
-    mock_ensure_update_categories_permission, return_val, permissions_checker
+    mock_ensure_can_moderate_packages, return_val, permissions_checker
 ):
     if return_val is True:
-        mock_ensure_update_categories_permission.return_value = return_val
+        mock_ensure_can_moderate_packages.return_value = return_val
     else:
-        mock_ensure_update_categories_permission.side_effect = ValidationError("Failed")
+        mock_ensure_can_moderate_packages.side_effect = ValidationError("Failed")
     assert permissions_checker.can_moderate == return_val
 
 


### PR DESCRIPTION
- A new `PermissionsChecker` class has been created to centralize the logic for handling permission checks. Previously, permission checks were implemented in the PackageDetailView. The logic has now been moved to `PermissionsChecker`.
- The PackageDetailView has been updated to use PermissionsChecker.
- Tests for the PackageDetailView have been implemented to ensure that the transition to using the PermissionsChecker class has not introduced any errors.
- Dedicated tests have been written for the PermissionsChecker class.
- A new API endpoint has been implemented to allow users to retrieve the permissions they have for a specific package. The current user is implicitly determined from the request, so the endpoint automatically applies the correct user context.
- A serializer has been implemented to format the permissions data correctly for the API response.
- Tests for the new API endpoint have been implemented to ensure that the permissions retrieval works as expected.
- A `BasePackagePermissionsAPIView` has been implemented as a parent class for the `PackagePermissionsAPIView`. This approach ensures that the logic is reusable across other API endpoints beyond just the Cyberstorm API when needed.