### PR TITLE
Package listing action views (TS-2297)

### DIFF
--- a/django/thunderstore/api/cyberstorm/serializers/package_listing.py
+++ b/django/thunderstore/api/cyberstorm/serializers/package_listing.py
@@ -1,0 +1,47 @@
+from rest_framework import serializers
+
+from thunderstore.community.models import PackageCategory
+from thunderstore.repository.api.experimental.serializers import (
+    CommunityFilteredModelChoiceField,
+)
+
+
+class PackageCategorySerializer(serializers.Serializer):
+    name = serializers.CharField()
+    slug = serializers.SlugField()
+
+
+class PackageListingUpdateSerializer(serializers.Serializer):
+    categories = serializers.ListField(
+        child=CommunityFilteredModelChoiceField(
+            queryset=PackageCategory.objects.all(), to_field="slug"
+        ),
+        allow_empty=True,
+    )
+
+    def to_representation(self, instance):
+        categories_data = [
+            PackageCategorySerializer(instance=category).data
+            for category in instance.categories.all()
+        ]
+
+        return {"categories": categories_data}
+
+
+class PackageListingRejectSerializer(serializers.Serializer):
+    rejection_reason = serializers.CharField()
+    internal_notes = serializers.CharField(
+        allow_blank=True, allow_null=True, required=False
+    )
+
+    def to_representation(self, instance):
+        return {}  # Empty response
+
+
+class PackageListingApproveSerializer(serializers.Serializer):
+    internal_notes = serializers.CharField(
+        allow_blank=True, allow_null=True, required=False
+    )
+
+    def to_representation(self, instance):
+        return {}  # Empty response

--- a/django/thunderstore/api/cyberstorm/serializers/package_listing.py
+++ b/django/thunderstore/api/cyberstorm/serializers/package_listing.py
@@ -11,6 +11,10 @@ class PackageCategorySerializer(serializers.Serializer):
     slug = serializers.SlugField()
 
 
+class PackageListingCategoriesSerializer(serializers.Serializer):
+    categories = PackageCategorySerializer(many=True)
+
+
 class PackageListingUpdateSerializer(serializers.Serializer):
     categories = serializers.ListField(
         child=CommunityFilteredModelChoiceField(
@@ -19,14 +23,6 @@ class PackageListingUpdateSerializer(serializers.Serializer):
         allow_empty=True,
     )
 
-    def to_representation(self, instance):
-        categories_data = [
-            PackageCategorySerializer(instance=category).data
-            for category in instance.categories.all()
-        ]
-
-        return {"categories": categories_data}
-
 
 class PackageListingRejectSerializer(serializers.Serializer):
     rejection_reason = serializers.CharField()
@@ -34,14 +30,8 @@ class PackageListingRejectSerializer(serializers.Serializer):
         allow_blank=True, allow_null=True, required=False
     )
 
-    def to_representation(self, instance):
-        return {}  # Empty response
-
 
 class PackageListingApproveSerializer(serializers.Serializer):
     internal_notes = serializers.CharField(
         allow_blank=True, allow_null=True, required=False
     )
-
-    def to_representation(self, instance):
-        return {}  # Empty response

--- a/django/thunderstore/api/cyberstorm/tests/test_package_listing_actions.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_package_listing_actions.py
@@ -169,3 +169,27 @@ def test_approve_package_listing_permission_denied(
     response = api_client.post(url, data=data, content_type="application/json")
     active_package_listing.refresh_from_db()
     assert response.status_code == 403
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("url_action", ["update", "approve", "reject"])
+def test_get_community_404(
+    url_action: str,
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+):
+    namespace_id = active_package_listing.package.namespace.name
+    package_name = active_package_listing.package.name
+    url = (
+        f"/api/cyberstorm/listing/invalid_community_id/"
+        f"{namespace_id}/{package_name}/{url_action}/"
+    )
+    data = json.dumps(
+        {
+            "rejection_reason": "Invalid content",
+            "internal_notes": "Some internal notes",
+        }
+    )
+    response = api_client.post(url, data=data, content_type="application/json")
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Not found."}

--- a/django/thunderstore/api/cyberstorm/tests/test_package_listing_actions.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_package_listing_actions.py
@@ -1,0 +1,171 @@
+import json
+from unittest.mock import patch
+
+import pytest
+from rest_framework.test import APIClient
+
+from conftest import UserType
+from thunderstore.community.consts import PackageListingReviewStatus
+from thunderstore.community.models import PackageCategory, PackageListing
+
+
+def get_base_url(package_listing):
+    namespace_id = package_listing.package.namespace.name
+    package_name = package_listing.package.name
+    community_id = package_listing.community.identifier
+    return f"/api/cyberstorm/listing/{community_id}/{namespace_id}/{package_name}"
+
+
+def get_update_categories_url(package_listing):
+    return f"{get_base_url(package_listing)}/update/"
+
+
+def get_approve_url(package_listing):
+    return f"{get_base_url(package_listing)}/approve/"
+
+
+def get_reject_url(package_listing):
+    return f"{get_base_url(package_listing)}/reject/"
+
+
+@pytest.mark.django_db
+@patch(
+    "thunderstore.community.models.package_listing.PackageListing.check_update_categories_permission"
+)
+@patch(
+    "thunderstore.community.models.package_listing.PackageListing.can_be_moderated_by_user"
+)
+def test_update_categories_success(
+    mock_can_be_moderated_by_user,
+    mock_check_update_categories_permission,
+    active_package_listing: PackageListing,
+    api_client: APIClient,
+    user: UserType,
+    package_category: PackageCategory,
+):
+    mock_check_update_categories_permission.return_value = True
+    mock_can_be_moderated_by_user.return_value = True
+    api_client.force_authenticate(user=user)
+
+    url = get_update_categories_url(active_package_listing)
+    data = json.dumps({"categories": [package_category.slug]})
+
+    expected_response = {
+        "categories": [{"name": package_category.name, "slug": package_category.slug}]
+    }
+
+    assert active_package_listing.categories.count() == 0
+
+    response = api_client.post(url, data=data, content_type="application/json")
+
+    assert response.status_code == 200
+    assert response.json() == expected_response
+    assert active_package_listing.categories.count() == 1
+    assert package_category in active_package_listing.categories.all()
+
+
+@pytest.mark.django_db
+def test_update_categories_permission_denied(
+    active_package_listing: PackageListing,
+    api_client: APIClient,
+    package_category: PackageCategory,
+):
+    url = get_update_categories_url(active_package_listing)
+    data = json.dumps({"categories": [package_category.slug]})
+
+    expected_response = {"detail": "You do not have permission to perform this action."}
+    response = api_client.post(url, data=data, content_type="application/json")
+
+    assert response.status_code == 403
+    assert response.json() == expected_response
+
+
+@patch(
+    "thunderstore.community.models.package_listing.PackageListing.can_user_manage_approval_status"
+)
+@pytest.mark.django_db
+def test_reject_package_listing_success(
+    mock_can_user_manage_approval_status,
+    api_client: APIClient,
+    user: UserType,
+    active_package_listing: PackageListing,
+):
+    mock_can_user_manage_approval_status.return_value = True
+    api_client.force_authenticate(user=user)
+    data = json.dumps(
+        {
+            "rejection_reason": "Invalid content",
+            "internal_notes": "Some internal notes",
+        }
+    )
+
+    assert active_package_listing.rejection_reason != "Invalid content"
+    assert active_package_listing.notes != "Some internal notes"
+    assert active_package_listing.review_status != PackageListingReviewStatus.rejected
+
+    url = get_reject_url(active_package_listing)
+    response = api_client.post(url, data, content_type="application/json")
+
+    active_package_listing.refresh_from_db()
+
+    assert response.status_code == 200
+    assert response.json() == {"message": "Success"}
+    assert active_package_listing.rejection_reason == "Invalid content"
+    assert active_package_listing.notes == "Some internal notes"
+    assert active_package_listing.review_status == PackageListingReviewStatus.rejected
+
+
+@pytest.mark.django_db
+def test_reject_package_listing_permission_denied(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+):
+    data = json.dumps(
+        {
+            "rejection_reason": "Invalid content",
+            "internal_notes": "Some internal notes",
+        }
+    )
+    url = get_reject_url(active_package_listing)
+    response = api_client.post(url, data, content_type="application/json")
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+@patch(
+    "thunderstore.community.models.package_listing.PackageListing.can_user_manage_approval_status"
+)
+def test_approve_package_listing_success(
+    mock_can_user_manage_approval_status,
+    api_client: APIClient,
+    user: UserType,
+    active_package_listing: PackageListing,
+):
+    mock_can_user_manage_approval_status.return_value = True
+    api_client.force_authenticate(user=user)
+    url = get_approve_url(active_package_listing)
+
+    assert active_package_listing.notes != "Some internal notes"
+    assert active_package_listing.review_status != PackageListingReviewStatus.approved
+
+    data = json.dumps({"internal_notes": "Some internal notes"})
+    response = api_client.post(url, data=data, content_type="application/json")
+
+    active_package_listing.refresh_from_db()
+
+    assert response.status_code == 200
+    assert response.json() == {"message": "Success"}
+    assert active_package_listing.notes == "Some internal notes"
+    assert active_package_listing.review_status == PackageListingReviewStatus.approved
+
+
+@pytest.mark.django_db
+def test_approve_package_listing_permission_denied(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+):
+    url = get_approve_url(active_package_listing)
+    data = json.dumps({"internal_notes": "Some internal notes"})
+    response = api_client.post(url, data=data, content_type="application/json")
+    active_package_listing.refresh_from_db()
+    assert response.status_code == 403

--- a/django/thunderstore/api/cyberstorm/views/__init__.py
+++ b/django/thunderstore/api/cyberstorm/views/__init__.py
@@ -3,6 +3,11 @@ from .community_filters import CommunityFiltersAPIView
 from .community_list import CommunityListAPIView
 from .markdown import PackageVersionChangelogAPIView, PackageVersionReadmeAPIView
 from .package_listing import PackageListingAPIView
+from .package_listing_actions import (
+    ApprovePackageListingAPIView,
+    RejectPackageListingAPIView,
+    UpdatePackageListingCategoriesAPIView,
+)
 from .package_listing_list import (
     PackageListingByCommunityListAPIView,
     PackageListingByDependencyListAPIView,
@@ -33,4 +38,7 @@ __all__ = [
     "TeamMemberListAPIView",
     "TeamServiceAccountListAPIView",
     "RatePackageAPIView",
+    "UpdatePackageListingCategoriesAPIView",
+    "RejectPackageListingAPIView",
+    "ApprovePackageListingAPIView",
 ]

--- a/django/thunderstore/api/cyberstorm/views/package_listing_actions.py
+++ b/django/thunderstore/api/cyberstorm/views/package_listing_actions.py
@@ -1,0 +1,140 @@
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework import status
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.generics import GenericAPIView
+from rest_framework.response import Response
+
+from thunderstore.api.cyberstorm.serializers.package_listing import (
+    PackageListingApproveSerializer,
+    PackageListingRejectSerializer,
+    PackageListingUpdateSerializer,
+)
+from thunderstore.community.models import Community, PackageListing
+from thunderstore.repository.views.package._utils import get_package_listing_or_404
+
+
+class BasePackageListingActionView(GenericAPIView):
+    def get_community(self) -> Community:
+        return Community.objects.get(identifier=self.kwargs["community_id"])
+
+    def get_object(self) -> PackageListing:
+        return get_package_listing_or_404(
+            namespace=self.kwargs["namespace_id"],
+            name=self.kwargs["package_name"],
+            community=self.get_community(),
+        )
+
+    def clear_package_listing_cache_with_args(self, listing: PackageListing) -> None:
+        get_package_listing_or_404.clear_cache_with_args(
+            namespace=listing.package.namespace.name,
+            name=listing.package.name,
+            community=listing.community,
+        )
+
+    def validate_serializer_and_get_params(self, data: dict) -> dict:
+        serializer = self.serializer_class(data=data)
+        serializer.is_valid(raise_exception=True)
+        return serializer.validated_data
+
+
+class UpdatePackageListingCategoriesAPIView(BasePackageListingActionView):
+    queryset = PackageListing.objects.active().select_related(
+        "community",
+        "package",
+    )
+    serializer_class = PackageListingUpdateSerializer
+
+    def _update_categories(self, listing: PackageListing, categories: list) -> None:
+        listing.update_categories(
+            agent=self.request.user,
+            categories=categories,
+        )
+        self.clear_package_listing_cache_with_args(listing)
+
+    def get_object(self) -> PackageListing:
+        listing = super().get_object()
+        if not listing.check_update_categories_permission(self.request.user):
+            raise PermissionDenied()
+        return listing
+
+    def validate_data(
+        self, data: dict, listing: PackageListing
+    ) -> PackageListingUpdateSerializer:
+        ctx = {"community": listing.community}
+        serializer = self.serializer_class(data=data, context=ctx)
+        serializer.is_valid(raise_exception=True)
+        return serializer
+
+    @swagger_auto_schema(
+        operation_id="cyberstorm.package_listing.update",
+        request_body=PackageListingUpdateSerializer,
+        responses={200: serializer_class()},
+        tags=["cyberstorm"],
+    )
+    def post(self, request, *args, **kwargs) -> Response:
+        listing: PackageListing = self.get_object()
+        serializer = self.validate_data(request.data, listing)
+        categories = serializer.validated_data["categories"]
+
+        self._update_categories(listing, categories)
+
+        serializer = self.serializer_class(instance=listing)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+class RejectPackageListingAPIView(BasePackageListingActionView):
+    queryset = PackageListing.objects.select_related("community", "package")
+    serializer_class = PackageListingRejectSerializer
+
+    def _reject(self, listing: PackageListing, params: dict) -> None:
+        reason = params["rejection_reason"]
+        notes = params.get("internal_notes")
+
+        listing.reject(
+            agent=self.request.user, rejection_reason=reason, internal_notes=notes
+        )
+        listing.clear_review_request()
+        self.clear_package_listing_cache_with_args(listing)
+
+    @swagger_auto_schema(
+        operation_id="cyberstorm.package_listing.reject",
+        request_body=PackageListingRejectSerializer,
+        responses={200: "Success"},
+        tags=["cyberstorm"],
+    )
+    def post(self, request, *args, **kwargs) -> Response:
+        listing: PackageListing = self.get_object()
+        params = self.validate_serializer_and_get_params(request.data)
+
+        try:
+            self._reject(listing, params)
+            return Response({"message": "Success"}, status=200)
+        except PermissionError:
+            raise PermissionDenied()
+
+
+class ApprovePackageListingAPIView(BasePackageListingActionView):
+    queryset = PackageListing.objects.select_related("community", "package")
+    serializer_class = PackageListingApproveSerializer
+
+    def _approve(self, listing: PackageListing, params: dict) -> None:
+        notes = params.get("internal_notes")
+        listing.approve(agent=self.request.user, internal_notes=notes)
+        listing.clear_review_request()
+        self.clear_package_listing_cache_with_args(listing)
+
+    @swagger_auto_schema(
+        operation_id="cyberstorm.package_listing.approve",
+        request_body=PackageListingApproveSerializer,
+        responses={200: "Success"},
+        tags=["cyberstorm"],
+    )
+    def post(self, request, *args, **kwargs) -> Response:
+        listing: PackageListing = self.get_object()
+        params = self.validate_serializer_and_get_params(request.data)
+
+        try:
+            self._approve(listing, params)
+            return Response({"message": "Success"}, status=200)
+        except PermissionError:
+            raise PermissionDenied()

--- a/django/thunderstore/api/cyberstorm/views/package_listing_actions.py
+++ b/django/thunderstore/api/cyberstorm/views/package_listing_actions.py
@@ -1,7 +1,7 @@
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
 from rest_framework.exceptions import PermissionDenied
-from rest_framework.generics import GenericAPIView
+from rest_framework.generics import GenericAPIView, get_object_or_404
 from rest_framework.response import Response
 
 from thunderstore.api.cyberstorm.serializers.package_listing import (
@@ -15,7 +15,9 @@ from thunderstore.repository.views.package._utils import get_package_listing_or_
 
 class BasePackageListingActionView(GenericAPIView):
     def get_community(self) -> Community:
-        return Community.objects.get(identifier=self.kwargs["community_id"])
+        community_id = self.kwargs.get("community_id")
+        community = get_object_or_404(Community, identifier=community_id)
+        return community
 
     def get_object(self) -> PackageListing:
         return get_package_listing_or_404(

--- a/django/thunderstore/api/urls.py
+++ b/django/thunderstore/api/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
 from thunderstore.api.cyberstorm.views import (
+    ApprovePackageListingAPIView,
     CommunityAPIView,
     CommunityFiltersAPIView,
     CommunityListAPIView,
@@ -12,10 +13,12 @@ from thunderstore.api.cyberstorm.views import (
     PackageVersionListAPIView,
     PackageVersionReadmeAPIView,
     RatePackageAPIView,
+    RejectPackageListingAPIView,
     TeamAPIView,
     TeamMemberAddAPIView,
     TeamMemberListAPIView,
     TeamServiceAccountListAPIView,
+    UpdatePackageListingCategoriesAPIView,
 )
 
 cyberstorm_urls = [
@@ -53,6 +56,21 @@ cyberstorm_urls = [
         "listing/<str:community_id>/<str:namespace_id>/<str:package_name>/dependants/",
         PackageListingByDependencyListAPIView.as_view(),
         name="cyberstorm.listing.by-dependency-list",
+    ),
+    path(
+        "listing/<str:community_id>/<str:namespace_id>/<str:package_name>/update/",
+        UpdatePackageListingCategoriesAPIView.as_view(),
+        name="cyberstorm.listing.update",
+    ),
+    path(
+        "listing/<str:community_id>/<str:namespace_id>/<str:package_name>/approve/",
+        ApprovePackageListingAPIView.as_view(),
+        name="cyberstorm.listing.approve",
+    ),
+    path(
+        "listing/<str:community_id>/<str:namespace_id>/<str:package_name>/reject/",
+        RejectPackageListingAPIView.as_view(),
+        name="cyberstorm.listing.reject",
     ),
     path(
         "package/<str:namespace_id>/<str:package_name>/latest/changelog/",


### PR DESCRIPTION
This PR introduces serializers and views in the Cyberstorm API for package listing actions: update categories, reject, and approve.

Changes Introduced:
- New serializers for package listing actions.
- New views implementing the actions: update categories, reject, and approve.
- Unit tests to validate the functionality.
- URL configuration updated to include the new views.

The code is based on the existing logic from the experimental API, but it has been heavily refactored. While the underlying functionality remains the same, the implementation is more cleaner.