### PR TITLE
 Cyberstorm deprecate package endpoint (TS-2296)

### DIFF
--- a/django/thunderstore/api/cyberstorm/tests/test_package_deprecate.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_package_deprecate.py
@@ -1,0 +1,79 @@
+import json
+from unittest.mock import patch
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from thunderstore.community.models import PackageListing
+from thunderstore.core.types import UserType
+
+ENSURE_USER_CAN_MANAGE_DEPRECATION_PATH = (
+    "thunderstore.repository.models.package.Package.ensure_user_can_manage_deprecation"
+)
+
+
+def get_deprecate_package_url(listing: PackageListing) -> str:
+    namespace_id = listing.package.namespace.name
+    package_name = listing.package.name
+    return f"/api/cyberstorm/package/{namespace_id}/{package_name}/deprecate/"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("is_deprecated", [True, False])
+@patch(ENSURE_USER_CAN_MANAGE_DEPRECATION_PATH)
+def test_deprecate_package(
+    mock_ensure_user_can_manage_deprecation,
+    api_client: APIClient,
+    user: UserType,
+    active_package_listing: PackageListing,
+    is_deprecated: bool,
+) -> None:
+    mock_ensure_user_can_manage_deprecation.return_value = True
+    api_client.force_authenticate(user=user)
+
+    data = json.dumps({"deprecate": is_deprecated})
+    url = get_deprecate_package_url(active_package_listing)
+
+    response = api_client.post(url, data=data, content_type="application/json")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"message": "Success"}
+
+    active_package_listing.refresh_from_db()
+    assert active_package_listing.package.is_deprecated is is_deprecated
+
+
+@pytest.mark.django_db
+@patch(ENSURE_USER_CAN_MANAGE_DEPRECATION_PATH)
+def test_deprecate_package_permission_denied(
+    mock_ensure_user_can_manage_deprecation,
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+    user: UserType,
+) -> None:
+    mock_ensure_user_can_manage_deprecation.return_value = False
+    api_client.force_authenticate(user=user)
+
+    data = json.dumps({"deprecate": True})
+    url = get_deprecate_package_url(active_package_listing)
+
+    response = api_client.post(url, data=data, content_type="application/json")
+    expected_response = {"detail": "You do not have permission to perform this action."}
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json() == expected_response
+
+
+@pytest.mark.django_db
+def test_deprecate_package_not_authenticated(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+) -> None:
+    data = json.dumps({"deprecate": True})
+    url = get_deprecate_package_url(active_package_listing)
+
+    response = api_client.post(url, data=data, content_type="application/json")
+    expected_response = {"detail": "Authentication credentials were not provided."}
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json() == expected_response

--- a/django/thunderstore/api/cyberstorm/tests/test_package_deprecate.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_package_deprecate.py
@@ -8,8 +8,8 @@ from rest_framework.test import APIClient
 from thunderstore.community.models import PackageListing
 from thunderstore.core.types import UserType
 
-ENSURE_USER_CAN_MANAGE_DEPRECATION_PATH = (
-    "thunderstore.repository.models.package.Package.ensure_user_can_manage_deprecation"
+CAN_USER_MANAGE_DEPRECATION_PATH = (
+    "thunderstore.repository.models.package.Package.can_user_manage_deprecation"
 )
 
 
@@ -21,7 +21,7 @@ def get_deprecate_package_url(listing: PackageListing) -> str:
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("is_deprecated", [True, False])
-@patch(ENSURE_USER_CAN_MANAGE_DEPRECATION_PATH)
+@patch(CAN_USER_MANAGE_DEPRECATION_PATH)
 def test_deprecate_package(
     mock_ensure_user_can_manage_deprecation,
     api_client: APIClient,
@@ -44,7 +44,7 @@ def test_deprecate_package(
 
 
 @pytest.mark.django_db
-@patch(ENSURE_USER_CAN_MANAGE_DEPRECATION_PATH)
+@patch(CAN_USER_MANAGE_DEPRECATION_PATH)
 def test_deprecate_package_permission_denied(
     mock_ensure_user_can_manage_deprecation,
     api_client: APIClient,

--- a/django/thunderstore/api/cyberstorm/views/__init__.py
+++ b/django/thunderstore/api/cyberstorm/views/__init__.py
@@ -2,6 +2,7 @@ from .community import CommunityAPIView
 from .community_filters import CommunityFiltersAPIView
 from .community_list import CommunityListAPIView
 from .markdown import PackageVersionChangelogAPIView, PackageVersionReadmeAPIView
+from .package_deprecate import DeprecatePackageAPIView
 from .package_listing import PackageListingAPIView
 from .package_listing_list import (
     PackageListingByCommunityListAPIView,
@@ -21,6 +22,7 @@ __all__ = [
     "CommunityAPIView",
     "CommunityFiltersAPIView",
     "CommunityListAPIView",
+    "DeprecatePackageAPIView",
     "PackageListingAPIView",
     "PackageListingByCommunityListAPIView",
     "PackageListingByDependencyListAPIView",

--- a/django/thunderstore/api/cyberstorm/views/package_deprecate.py
+++ b/django/thunderstore/api/cyberstorm/views/package_deprecate.py
@@ -1,0 +1,43 @@
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework import serializers, status
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.generics import get_object_or_404
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from thunderstore.repository.models import Namespace, Package
+
+
+class DeprecatePackageSerializer(serializers.Serializer):
+    deprecate = serializers.BooleanField(required=True)
+
+
+class DeprecatePackageAPIView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get_object(self, namespace_id: str, package_name: str) -> Package:
+        namespace = get_object_or_404(Namespace, name=namespace_id)
+        package = get_object_or_404(Package, name=package_name, namespace=namespace)
+        return package
+
+    def validate_permissions(self, package: Package) -> None:
+        if not package.ensure_user_can_manage_deprecation(self.request.user):
+            raise PermissionDenied()
+
+    @swagger_auto_schema(
+        operation_id="cyberstorm.package.deprecate",
+        request_body=DeprecatePackageSerializer,
+        tags=["cyberstorm"],
+    )
+    def post(self, request, namespace_id: str, package_name: str) -> Response:
+        package = self.get_object(namespace_id, package_name)
+        self.validate_permissions(package)
+
+        serializer = DeprecatePackageSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        should_deprecate = serializer.validated_data["deprecate"]
+        package.deprecate() if should_deprecate else package.undeprecate()
+
+        return Response({"message": "Success"}, status=status.HTTP_200_OK)

--- a/django/thunderstore/api/cyberstorm/views/package_deprecate.py
+++ b/django/thunderstore/api/cyberstorm/views/package_deprecate.py
@@ -21,10 +21,6 @@ class DeprecatePackageAPIView(APIView):
         package = get_object_or_404(Package, name=package_name, namespace=namespace)
         return package
 
-    def validate_permissions(self, package: Package) -> None:
-        if not package.can_user_manage_deprecation(self.request.user):
-            raise PermissionDenied()
-
     @swagger_auto_schema(
         operation_id="cyberstorm.package.deprecate",
         request_body=DeprecatePackageSerializer,
@@ -32,7 +28,9 @@ class DeprecatePackageAPIView(APIView):
     )
     def post(self, request, namespace_id: str, package_name: str) -> Response:
         package = self.get_object(namespace_id, package_name)
-        self.validate_permissions(package)
+
+        if not package.can_user_manage_deprecation(self.request.user):
+            raise PermissionDenied()
 
         serializer = DeprecatePackageSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/django/thunderstore/api/cyberstorm/views/package_deprecate.py
+++ b/django/thunderstore/api/cyberstorm/views/package_deprecate.py
@@ -22,7 +22,7 @@ class DeprecatePackageAPIView(APIView):
         return package
 
     def validate_permissions(self, package: Package) -> None:
-        if not package.ensure_user_can_manage_deprecation(self.request.user):
+        if not package.can_user_manage_deprecation(self.request.user):
             raise PermissionDenied()
 
     @swagger_auto_schema(

--- a/django/thunderstore/api/urls.py
+++ b/django/thunderstore/api/urls.py
@@ -4,6 +4,7 @@ from thunderstore.api.cyberstorm.views import (
     CommunityAPIView,
     CommunityFiltersAPIView,
     CommunityListAPIView,
+    DeprecatePackageAPIView,
     PackageListingAPIView,
     PackageListingByCommunityListAPIView,
     PackageListingByDependencyListAPIView,
@@ -83,6 +84,11 @@ cyberstorm_urls = [
         "package/<str:namespace_id>/<str:package_name>/rate/",
         RatePackageAPIView.as_view(),
         name="cyberstorm.package.rate",
+    ),
+    path(
+        "package/<str:namespace_id>/<str:package_name>/deprecate/",
+        DeprecatePackageAPIView.as_view(),
+        name="cyberstorm.package.deprecate",
     ),
     path(
         "team/<str:team_id>/",


### PR DESCRIPTION
A new view and serializer were added to the Cyberstorm API to handle package deprecation. The endpoint requires user authentication and proper permissions to manage deprecations. It leverages existing `deprecate` and `undeprecate` functions from the `Package` model. Additionally, tests were implemented to verify functionality.