### PR TITLE
Add and use AllowAllCORSMixin

### DIFF
--- a/django/thunderstore/core/mixins.py
+++ b/django/thunderstore/core/mixins.py
@@ -118,3 +118,12 @@ class AdminLinkMixin(models.Model):
 
     class Meta:
         abstract = True
+
+
+# AllowAllCORSMixin must be inherited before APIView / GenericAPIView
+class AllowAllCORSMixin:
+    def finalize_response(self, request, response, *args, **kwargs):
+        response = super().finalize_response(request, response, *args, **kwargs)
+        response["Access-Control-Allow-Origin"] = "*"
+        response["Access-Control-Allow-Methods"] = "GET"
+        return response

--- a/django/thunderstore/modpacks/api/experimental/views/legacyprofile.py
+++ b/django/thunderstore/modpacks/api/experimental/views/legacyprofile.py
@@ -9,6 +9,7 @@ from rest_framework.response import Response
 from rest_framework.throttling import UserRateThrottle
 from rest_framework.views import APIView
 
+from thunderstore.core.mixins import AllowAllCORSMixin
 from thunderstore.core.utils import replace_cdn
 from thunderstore.modpacks.models import LegacyProfile
 
@@ -53,7 +54,7 @@ class LegacyProfileCreateApiView(APIView):
         )
 
 
-class LegacyProfileRetrieveApiView(APIView):
+class LegacyProfileRetrieveApiView(AllowAllCORSMixin, APIView):
     permission_classes = []
 
     @swagger_auto_schema(

--- a/django/thunderstore/repository/api/experimental/views/package.py
+++ b/django/thunderstore/repository/api/experimental/views/package.py
@@ -6,6 +6,7 @@ from rest_framework.pagination import CursorPagination
 
 from thunderstore.cache.cache import ManualCacheCommunityMixin
 from thunderstore.cache.enums import CacheBustCondition
+from thunderstore.core.mixins import AllowAllCORSMixin
 from thunderstore.repository.api.experimental.serializers import (
     PackageSerializerExperimental,
 )
@@ -64,7 +65,9 @@ class PackageListApiView(ManualCacheCommunityMixin, ListAPIView):
         return get_package_queryset()
 
 
-class PackageDetailApiView(ManualCacheCommunityMixin, RetrieveAPIView):
+class PackageDetailApiView(
+    AllowAllCORSMixin, ManualCacheCommunityMixin, RetrieveAPIView
+):
     """
     Get a single package
     """

--- a/django/thunderstore/repository/api/experimental/views/package_version.py
+++ b/django/thunderstore/repository/api/experimental/views/package_version.py
@@ -5,6 +5,7 @@ from rest_framework.response import Response
 
 from thunderstore.cache.cache import ManualCacheCommunityMixin
 from thunderstore.cache.enums import CacheBustCondition
+from thunderstore.core.mixins import AllowAllCORSMixin
 from thunderstore.repository.api.experimental.serializers import (
     MarkdownResponseSerializer,
     PackageVersionSerializerExperimental,
@@ -54,7 +55,7 @@ class PackageVersionDetailMixin(ManualCacheCommunityMixin, RetrieveAPIView):
         )
 
 
-class PackageVersionDetailApiView(PackageVersionDetailMixin):
+class PackageVersionDetailApiView(AllowAllCORSMixin, PackageVersionDetailMixin):
     """
     Get a single package version
     """
@@ -69,7 +70,7 @@ class PackageVersionDetailApiView(PackageVersionDetailMixin):
         return super().get(*args, **kwargs)
 
 
-class PackageVersionChangelogApiView(PackageVersionDetailMixin):
+class PackageVersionChangelogApiView(AllowAllCORSMixin, PackageVersionDetailMixin):
     """
     Get a package verion's changelog
     """
@@ -89,7 +90,7 @@ class PackageVersionChangelogApiView(PackageVersionDetailMixin):
         return Response(serializer.data)
 
 
-class PackageVersionReadmeApiView(PackageVersionDetailMixin):
+class PackageVersionReadmeApiView(AllowAllCORSMixin, PackageVersionDetailMixin):
     """
     Get a package verion's readme
     """


### PR DESCRIPTION
Sets the Access-Control-Allow-Origin header to * for package version, package retrieval, and legacy profile retrieval APIs. This allows other websites to call them. 

The likely result of this is that we'll have websites that call `/api/experimental/package/{namespace}/{name}/` hundreds of times while reading a modpack. The Mod Managers don't currently have that problem because they pull that info directly from the package index which is retrieved once.