### PR TITLE
Cyberstorm API: Only render public team members

### DIFF
--- a/django/thunderstore/api/cyberstorm/tests/test_package_listing.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_package_listing.py
@@ -255,11 +255,7 @@ def test_package_listing_view__returns_info(api_client: APIClient) -> None:
     assert actual["rating_count"] == 8
     assert actual["size"] == latest.file_size
     assert actual["team"]["name"] == listing.package.owner.name
-    assert len(actual["team"]["members"]) == 2
-    assert actual["team"]["members"][0]["identifier"] == owner.user.id
-    assert actual["team"]["members"][0]["role"] == "owner"
-    assert actual["team"]["members"][1]["identifier"] == member.user.id
-    assert actual["team"]["members"][1]["role"] == "member"
+    assert len(actual["team"]["members"]) == 0
     assert actual["website_url"] == latest.website_url
 
 

--- a/django/thunderstore/api/cyberstorm/views/package_listing.py
+++ b/django/thunderstore/api/cyberstorm/views/package_listing.py
@@ -63,7 +63,7 @@ class TeamSerializer(serializers.Serializer):
     """
 
     name = serializers.CharField()
-    members = CyberstormTeamMemberSerializer(many=True)
+    members = CyberstormTeamMemberSerializer(many=True, source="public_members")
 
 
 class EmptyStringAsNoneField(serializers.Field):

--- a/django/thunderstore/repository/models/team.py
+++ b/django/thunderstore/repository/models/team.py
@@ -139,6 +139,11 @@ class Team(models.Model):
         super().save(*args, **kwargs)
 
     @property
+    def public_members(self) -> "Manager[TeamMember]":
+        # TODO: Filter & return team members that are publicly visible
+        return self.members.none()
+
+    @property
     def real_user_count(self):
         return self.members.real_users().count()
 


### PR DESCRIPTION
Modify the cyberstorm package listing API to only render public team members in the team details. Currently there is no way to mark a team membership as public, so an empty set is always returned.