### PR TITLE
Cyberstorm api create team (TS-2312)

### DIFF
--- a/django/thunderstore/api/cyberstorm/serializers/__init__.py
+++ b/django/thunderstore/api/cyberstorm/serializers/__init__.py
@@ -7,15 +7,15 @@ from .package import CyberstormPackagePreviewSerializer, PackagePermissionsSeria
 from .team import (
     CyberstormCreateTeamSerializer,
     CyberstormServiceAccountSerializer,
-    CyberstormTeamAddMemberRequestSerialiazer,
-    CyberstormTeamAddMemberResponseSerialiazer,
+    CyberstormTeamAddMemberRequestSerializer,
+    CyberstormTeamAddMemberResponseSerializer,
     CyberstormTeamMemberSerializer,
     CyberstormTeamSerializer,
 )
 
 __all__ = [
-    "CyberstormTeamAddMemberRequestSerialiazer",
-    "CyberstormTeamAddMemberResponseSerialiazer",
+    "CyberstormTeamAddMemberRequestSerializer",
+    "CyberstormTeamAddMemberResponseSerializer",
     "CyberstormCreateTeamSerializer",
     "CyberstormCommunitySerializer",
     "CyberstormPackageCategorySerializer",

--- a/django/thunderstore/api/cyberstorm/serializers/__init__.py
+++ b/django/thunderstore/api/cyberstorm/serializers/__init__.py
@@ -5,12 +5,18 @@ from .community import (
 )
 from .package import CyberstormPackagePreviewSerializer, PackagePermissionsSerializer
 from .team import (
+    CyberstormCreateTeamSerializer,
     CyberstormServiceAccountSerializer,
+    CyberstormTeamAddMemberRequestSerialiazer,
+    CyberstormTeamAddMemberResponseSerialiazer,
     CyberstormTeamMemberSerializer,
     CyberstormTeamSerializer,
 )
 
 __all__ = [
+    "CyberstormTeamAddMemberRequestSerialiazer",
+    "CyberstormTeamAddMemberResponseSerialiazer",
+    "CyberstormCreateTeamSerializer",
     "CyberstormCommunitySerializer",
     "CyberstormPackageCategorySerializer",
     "CyberstormPackageListingSectionSerializer",

--- a/django/thunderstore/api/cyberstorm/serializers/team.py
+++ b/django/thunderstore/api/cyberstorm/serializers/team.py
@@ -55,9 +55,9 @@ class CyberstormCreateTeamSerializer(serializers.Serializer):
     )
 
     def validate_name(self, value: str) -> str:
-        if Team.objects.filter(name__iexact=value.lower()).exists():
+        if Team.objects.filter(name__iexact=value).exists():
             raise ValidationError("A team with the provided name already exists")
-        if Namespace.objects.filter(name__iexact=value.lower()).exists():
+        if Namespace.objects.filter(name__iexact=value).exists():
             raise ValidationError("A namespace with the provided name already exists")
         return value
 

--- a/django/thunderstore/api/cyberstorm/serializers/team.py
+++ b/django/thunderstore/api/cyberstorm/serializers/team.py
@@ -36,14 +36,14 @@ class CyberstormServiceAccountSerializer(serializers.Serializer):
     last_used = serializers.DateTimeField()
 
 
-class CyberstormTeamAddMemberRequestSerialiazer(serializers.Serializer):
+class CyberstormTeamAddMemberRequestSerializer(serializers.Serializer):
     username = serializers.CharField()
     role = serializers.ChoiceField(
         choices=AddTeamMemberForm.base_fields["role"].choices
     )
 
 
-class CyberstormTeamAddMemberResponseSerialiazer(serializers.Serializer):
+class CyberstormTeamAddMemberResponseSerializer(serializers.Serializer):
     username = serializers.CharField(source="user")
     role = serializers.CharField()
     team = serializers.CharField()

--- a/django/thunderstore/api/cyberstorm/serializers/team.py
+++ b/django/thunderstore/api/cyberstorm/serializers/team.py
@@ -1,7 +1,11 @@
 from typing import Optional
 
 from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
 
+from thunderstore.repository.forms import AddTeamMemberForm
+from thunderstore.repository.models import Namespace, Team
+from thunderstore.repository.validators import PackageReferenceComponentValidator
 from thunderstore.social.utils import get_user_avatar_url
 
 
@@ -30,3 +34,36 @@ class CyberstormServiceAccountSerializer(serializers.Serializer):
     identifier = serializers.CharField(source="uuid")
     name = serializers.CharField(source="user.first_name")
     last_used = serializers.DateTimeField()
+
+
+class CyberstormTeamAddMemberRequestSerialiazer(serializers.Serializer):
+    username = serializers.CharField()
+    role = serializers.ChoiceField(
+        choices=AddTeamMemberForm.base_fields["role"].choices
+    )
+
+
+class CyberstormTeamAddMemberResponseSerialiazer(serializers.Serializer):
+    username = serializers.CharField(source="user")
+    role = serializers.CharField()
+    team = serializers.CharField()
+
+
+class CyberstormCreateTeamSerializer(serializers.Serializer):
+    name = serializers.CharField(
+        max_length=64, validators=[PackageReferenceComponentValidator("Author name")]
+    )
+
+    def validate_name(self, value: str) -> str:
+        if Team.objects.filter(name__iexact=value.lower()).exists():
+            raise ValidationError("A team with the provided name already exists")
+        if Namespace.objects.filter(name__iexact=value.lower()).exists():
+            raise ValidationError("A namespace with the provided name already exists")
+        return value
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        user = self.context["request"].user
+        if getattr(user, "service_account", None) is not None:
+            raise ValidationError("Service accounts cannot create teams")
+        return attrs

--- a/django/thunderstore/api/cyberstorm/tests/test_create_team.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_create_team.py
@@ -1,0 +1,142 @@
+import json
+
+import pytest
+from rest_framework.test import APIClient
+
+from thunderstore.core.types import UserType
+from thunderstore.repository.factories import NamespaceFactory
+from thunderstore.repository.models.team import Team
+
+
+def get_create_team_url() -> str:
+    return "/api/cyberstorm/team/new/"
+
+
+def make_request(api_client: APIClient, team_name: str):
+    response = api_client.post(
+        path=get_create_team_url(),
+        data=json.dumps({"name": team_name}),
+        content_type="application/json",
+    )
+    return response
+
+
+@pytest.mark.django_db
+def test_create_team_success(api_client: APIClient, user: UserType):
+    api_client.force_authenticate(user)
+
+    team_count = Team.objects.filter(name="CoolestTeamNameEver").count()
+    assert team_count == 0
+
+    response = make_request(api_client, "CoolestTeamNameEver")
+    assert response.status_code == 201
+    assert response.json()["name"] == "CoolestTeamNameEver"
+
+    team_count = Team.objects.filter(name="CoolestTeamNameEver").count()
+    assert team_count == 1
+
+
+@pytest.mark.django_db
+def test_create_team_fail_because_user_is_not_authenticated(api_client: APIClient):
+    response = make_request(api_client, "CoolestTeamNameEver")
+    assert Team.objects.filter(name="CoolestTeamNameEver").count() == 0
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Authentication credentials were not provided."
+    assert Team.objects.filter(name="CoolestTeamNameEver").count() == 0
+
+
+@pytest.mark.django_db
+def test_create_team__fail_because_team_with_provided_name_exists(
+    api_client: APIClient,
+    user: UserType,
+    team: Team,
+):
+    api_client.force_authenticate(user)
+    response = make_request(api_client, team.name)
+
+    assert response.status_code == 400
+    error_message = "A team with the provided name already exists"
+    assert error_message in response.json()["name"]
+
+
+@pytest.mark.django_db
+def test_create_team__fail_because_team_with_provided_namespace_exists(
+    api_client: APIClient,
+    user: UserType,
+):
+    api_client.force_authenticate(user)
+    NamespaceFactory(name="CoolestTeamNameEver")
+    response = make_request(api_client, "CoolestTeamNameEver")
+
+    assert response.status_code == 400
+    error_message = "A namespace with the provided name already exists"
+    assert error_message in response.json()["name"]
+
+
+@pytest.mark.django_db
+def test_create_team_with_too_long_name(api_client: APIClient, user: UserType):
+    api_client.force_authenticate(user)
+    response = make_request(api_client, "a" * 65)
+
+    assert response.status_code == 400
+    error_message = "Ensure this field has no more than 64 characters."
+    assert error_message in response.json()["name"]
+
+
+@pytest.mark.django_db
+def test_create_team_with_invalid_team_name(api_client: APIClient, user: UserType):
+    api_client.force_authenticate(user)
+    response = make_request(api_client, "hello_")
+
+    assert response.status_code == 400
+    error_message = (
+        "Author name can only contain a-z A-Z 0-9 _ "
+        "characters and must not start or end with _"
+    )
+    assert error_message in response.json()["name"]
+
+
+@pytest.mark.django_db
+def test_create_team_with_blank_name(api_client: APIClient, user: UserType):
+    api_client.force_authenticate(user)
+    response = make_request(api_client, "")
+
+    assert response.status_code == 400
+    error_message = "This field may not be blank."
+    assert error_message in response.json()["name"]
+
+
+@pytest.mark.django_db
+def test_create_team_without_name(api_client: APIClient, user: UserType):
+    api_client.force_authenticate(user)
+    response = make_request(api_client, None)
+
+    assert response.status_code == 400
+    error_message = "This field may not be null."
+    assert error_message in response.json()["name"]
+
+
+@pytest.mark.django_db
+def test_create_team_without_data(api_client: APIClient, user: UserType):
+    api_client.force_authenticate(user)
+    response = api_client.post(
+        path=get_create_team_url(),
+        data=json.dumps({}),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 400
+    error_message = "This field is required."
+    assert error_message in response.json()["name"]
+
+
+@pytest.mark.django_db
+def test_create_team_with_service_account(api_client: APIClient, service_account):
+    api_client.force_authenticate(service_account.user)
+    assert Team.objects.filter(name="CoolestTeamNameEver").count() == 0
+    response = make_request(api_client, "CoolestTeamNameEver")
+
+    assert response.status_code == 400
+    error_message = "Service accounts cannot create teams"
+    assert error_message in response.json()["non_field_errors"]
+    assert Team.objects.filter(name="CoolestTeamNameEver").count() == 0

--- a/django/thunderstore/api/cyberstorm/views/__init__.py
+++ b/django/thunderstore/api/cyberstorm/views/__init__.py
@@ -15,6 +15,7 @@ from .package_version_list import PackageVersionListAPIView
 from .team import (
     DisbandTeamAPIView,
     TeamAPIView,
+    TeamCreateAPIView,
     TeamMemberAddAPIView,
     TeamMemberListAPIView,
     TeamServiceAccountListAPIView,
@@ -35,6 +36,7 @@ __all__ = [
     "PackageVersionListAPIView",
     "PackageVersionReadmeAPIView",
     "TeamAPIView",
+    "TeamCreateAPIView",
     "TeamMemberAddAPIView",
     "TeamMemberListAPIView",
     "TeamServiceAccountListAPIView",

--- a/django/thunderstore/api/cyberstorm/views/team.py
+++ b/django/thunderstore/api/cyberstorm/views/team.py
@@ -1,7 +1,8 @@
 from django.db.models import Q, QuerySet
-from rest_framework import serializers, status
+from rest_framework import status
 from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.generics import (
+    CreateAPIView,
     DestroyAPIView,
     ListAPIView,
     RetrieveAPIView,
@@ -14,7 +15,10 @@ from rest_framework.views import APIView
 
 from thunderstore.account.models.service_account import ServiceAccount
 from thunderstore.api.cyberstorm.serializers import (
+    CyberstormCreateTeamSerializer,
     CyberstormServiceAccountSerializer,
+    CyberstormTeamAddMemberRequestSerialiazer,
+    CyberstormTeamAddMemberResponseSerialiazer,
     CyberstormTeamMemberSerializer,
     CyberstormTeamSerializer,
 )
@@ -24,6 +28,7 @@ from thunderstore.api.utils import (
     conditional_swagger_auto_schema,
 )
 from thunderstore.repository.forms import AddTeamMemberForm
+from thunderstore.repository.models import TeamMemberRole
 from thunderstore.repository.models.team import Team, TeamMember
 
 
@@ -53,6 +58,31 @@ class TeamRestrictedAPIView(TeamPermissionsMixin, ListAPIView):
     pass
 
 
+class TeamCreateAPIView(CreateAPIView):
+    permission_classes = [IsAuthenticated]
+    queryset = Team.objects.exclude(is_active=False)
+    serializer_class = CyberstormCreateTeamSerializer
+
+    def _create_team(self, name: str) -> Team:
+        team = Team.objects.create(name=name)
+        team.add_member(user=self.request.user, role=TeamMemberRole.owner)
+        return team
+
+    def perform_create(self, serializer) -> None:
+        team_name = serializer.validated_data["name"]
+        instance = self._create_team(team_name)
+        serializer.instance = instance
+
+    @conditional_swagger_auto_schema(
+        request_body=serializer_class,
+        responses={201: serializer_class},
+        operation_id="cyberstorm.team.create",
+        tags=["cyberstorm"],
+    )
+    def post(self, request, *args, **kwargs):
+        return super().post(request, *args, **kwargs)
+
+
 class TeamMemberListAPIView(CyberstormAutoSchemaMixin, TeamRestrictedAPIView):
     serializer_class = CyberstormTeamMemberSerializer
     filter_backends = [StrictOrderingFilter]
@@ -64,19 +94,6 @@ class TeamMemberListAPIView(CyberstormAutoSchemaMixin, TeamRestrictedAPIView):
             .exclude(~Q(team__name__iexact=self.kwargs["team_id"]))
             .prefetch_related("user__social_auth")
         )
-
-
-class CyberstormTeamAddMemberRequestSerialiazer(serializers.Serializer):
-    username = serializers.CharField()
-    role = serializers.ChoiceField(
-        choices=AddTeamMemberForm.base_fields["role"].choices
-    )
-
-
-class CyberstormTeamAddMemberResponseSerialiazer(serializers.Serializer):
-    username = serializers.CharField(source="user")
-    role = serializers.CharField()
-    team = serializers.CharField()
 
 
 class TeamMemberAddAPIView(APIView):

--- a/django/thunderstore/api/cyberstorm/views/team.py
+++ b/django/thunderstore/api/cyberstorm/views/team.py
@@ -17,8 +17,8 @@ from thunderstore.account.models.service_account import ServiceAccount
 from thunderstore.api.cyberstorm.serializers import (
     CyberstormCreateTeamSerializer,
     CyberstormServiceAccountSerializer,
-    CyberstormTeamAddMemberRequestSerialiazer,
-    CyberstormTeamAddMemberResponseSerialiazer,
+    CyberstormTeamAddMemberRequestSerializer,
+    CyberstormTeamAddMemberResponseSerializer,
     CyberstormTeamMemberSerializer,
     CyberstormTeamSerializer,
 )
@@ -100,14 +100,14 @@ class TeamMemberAddAPIView(APIView):
     permission_classes = [IsAuthenticated]
 
     @conditional_swagger_auto_schema(
-        request_body=CyberstormTeamAddMemberRequestSerialiazer,
-        responses={200: CyberstormTeamAddMemberResponseSerialiazer},
+        request_body=CyberstormTeamAddMemberRequestSerializer,
+        responses={200: CyberstormTeamAddMemberResponseSerializer},
         operation_id="cyberstorm.team.member.add",
         tags=["cyberstorm"],
     )
     def post(self, request, team_name, format=None):
         team = get_object_or_404(Team, name__iexact=team_name)
-        serializer = CyberstormTeamAddMemberRequestSerialiazer(data=request.data)
+        serializer = CyberstormTeamAddMemberRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
         form = AddTeamMemberForm(
@@ -121,9 +121,7 @@ class TeamMemberAddAPIView(APIView):
 
         if form.is_valid():
             team_member = form.save()
-            return Response(
-                CyberstormTeamAddMemberResponseSerialiazer(team_member).data
-            )
+            return Response(CyberstormTeamAddMemberResponseSerializer(team_member).data)
         else:
             raise ValidationError(form.errors)
 

--- a/django/thunderstore/api/urls.py
+++ b/django/thunderstore/api/urls.py
@@ -16,6 +16,7 @@ from thunderstore.api.cyberstorm.views import (
     PackageVersionReadmeAPIView,
     RatePackageAPIView,
     TeamAPIView,
+    TeamCreateAPIView,
     TeamMemberAddAPIView,
     TeamMemberListAPIView,
     TeamServiceAccountListAPIView,
@@ -86,6 +87,11 @@ cyberstorm_urls = [
         "package/<str:namespace_id>/<str:package_name>/rate/",
         RatePackageAPIView.as_view(),
         name="cyberstorm.package.rate",
+    ),
+    path(
+        "team/new/",
+        TeamCreateAPIView.as_view(),
+        name="cyberstorm.team.create",
     ),
     path(
         "package/<str:namespace_id>/<str:package_name>/deprecate/",


### PR DESCRIPTION
- Implemented CyberstormCreateTeamSerializer
- Added validation for the name field.
- Ensured service accounts cannot create teams.
- Moved serializers from the team views file to the serializers file.
- Implemented TeamCreateAPIView for handling new team creation in the Cyberstorm API.