### PR TITLE
Fix upload page sorting [TS-2344] [TS-2345]

### DIFF
--- a/builder/src/upload.tsx
+++ b/builder/src/upload.tsx
@@ -269,11 +269,12 @@ const SubmissionForm: React.FC<SubmissionFormProps> = observer((props) => {
 
         promise.then((result) => {
             const next = current.concat(result.results);
-            next.sort((a, b) =>
-                a.identifier == props.currentCommunity.identifier
-                    ? -1
-                    : a.name.localeCompare(b.name)
-            );
+            next.sort((a, b) => {
+                if (a.identifier == props.currentCommunity.identifier)
+                    return -1;
+                if (b.identifier == props.currentCommunity.identifier) return 1;
+                return a.name.localeCompare(b.name);
+            });
             setCommunities(next);
             if (result.pagination.next_link) {
                 enumerateCommunities(next, result.pagination.next_link);

--- a/django/thunderstore/social/api/experimental/views/current_user.py
+++ b/django/thunderstore/social/api/experimental/views/current_user.py
@@ -202,6 +202,7 @@ def get_teams(user: UserType) -> List[UserTeam]:
         )
         .exclude(team__is_active=False)
         .exclude(~Q(user=user))
+        .order_by("id")
     )
 
     return [


### PR DESCRIPTION
Fixed incorrect logic in comparison in `upload.tsx` so the current community is always at the top of the communities selection box.

Added `order_by("id")` to `current-user`'s `get_teams()`.