### PR TITLE
Add views for deleting users and removing social auth accounts to Cyberstorm API (TS-2317 & TS-2318)

### DIFF
--- a/django/conftest.py
+++ b/django/conftest.py
@@ -14,6 +14,7 @@ from django.core.cache import cache
 from django.core.files.base import File
 from PIL import Image
 from rest_framework.test import APIClient
+from social_django.models import UserSocialAuth
 
 from django_contracts.models import LegalContract, LegalContractVersion
 from thunderstore.account.factories import UserFlagFactory
@@ -118,6 +119,21 @@ def user(django_user_model):
         email="test@example.org",
         password="hunter2",
     )
+
+
+@pytest.fixture()
+def user_with_social_auths(user):
+    UserSocialAuth.objects.create(
+        user=user,
+        provider="discord",
+        uid="1234567890",
+    )
+    UserSocialAuth.objects.create(
+        user=user,
+        provider="github",
+        uid="0987654321",
+    )
+    return user
 
 
 @pytest.fixture()

--- a/django/thunderstore/api/cyberstorm/services/user.py
+++ b/django/thunderstore/api/cyberstorm/services/user.py
@@ -1,0 +1,23 @@
+from django.db import transaction
+from social_django.models import UserSocialAuth
+
+from thunderstore.core.exceptions import PermissionValidationError
+from thunderstore.core.types import UserType
+
+
+@transaction.atomic
+def delete_user_account(target_user: UserType):
+    return target_user.delete()
+
+
+@transaction.atomic
+def delete_user_social_auth(social_auth: UserSocialAuth):
+    target_user = social_auth.user
+
+    auth_qs = UserSocialAuth.objects.select_for_update().filter(user=target_user)
+    count = auth_qs.count()
+
+    if count <= 1:
+        raise PermissionValidationError("Cannot disconnect last linked auth method")
+
+    return auth_qs.filter(pk=social_auth.pk).delete()

--- a/django/thunderstore/api/cyberstorm/tests/endpoint_data.py
+++ b/django/thunderstore/api/cyberstorm/tests/endpoint_data.py
@@ -55,6 +55,8 @@ ENDPOINTS = {
         "/api/cyberstorm/team/{team_name}/disband/",
         "/api/cyberstorm/team/{team_name}/member/{username}/remove/",
         "/api/cyberstorm/team/{team_name}/service-account/delete/{uuid}/",
+        "/api/cyberstorm/user/delete/",
+        "/api/cyberstorm/user/linked-account/{provider}/disconnect/",
     ],
 }
 

--- a/django/thunderstore/api/cyberstorm/tests/services/test_user_services.py
+++ b/django/thunderstore/api/cyberstorm/tests/services/test_user_services.py
@@ -1,0 +1,35 @@
+import pytest
+from django.contrib.auth import get_user_model
+
+from thunderstore.api.cyberstorm.services.user import (
+    delete_user_account,
+    delete_user_social_auth,
+)
+from thunderstore.core.exceptions import PermissionValidationError
+from thunderstore.core.types import UserType
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_delete_user_account_success(user: UserType):
+    assert User.objects.filter(username=user.username).exists()
+    delete_user_account(target_user=user)
+    assert not User.objects.filter(username=user.username).exists()
+
+
+@pytest.mark.django_db
+def test_delete_user_social_auth_success(user_with_social_auths: UserType):
+    social_auth = user_with_social_auths.social_auth.filter(provider="discord").first()
+    delete_user_social_auth(social_auth=social_auth)
+    assert not user_with_social_auths.social_auth.filter(provider="discord").exists()
+
+
+@pytest.mark.django_db
+def test_delete_user_social_auth_last_auth_method_raises_error(
+    user_with_social_auths: UserType,
+):
+    user_with_social_auths.social_auth.filter(provider="discord").delete()
+    social_auth = user_with_social_auths.social_auth.first()
+    with pytest.raises(PermissionValidationError):
+        delete_user_social_auth(social_auth=social_auth)

--- a/django/thunderstore/api/cyberstorm/tests/test_user.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_user.py
@@ -1,0 +1,91 @@
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+
+from thunderstore.core.types import UserType
+
+User = get_user_model()
+
+
+def get_delete_user_url() -> str:
+    return "/api/cyberstorm/user/delete/"
+
+
+def get_disconnect_user_linked_account_url(provider: str) -> str:
+    return f"/api/cyberstorm/user/linked-account/{provider}/disconnect/"
+
+
+@pytest.mark.django_db
+def test_delete_user_success(user: UserType, api_client: APIClient):
+    api_client.force_authenticate(user=user)
+
+    assert User.objects.filter(username=user.username).exists()
+    url = get_delete_user_url()
+    response = api_client.delete(url, content_type="application/json")
+    assert response.status_code == 204
+    assert not User.objects.filter(username=user.username).exists()
+
+
+@pytest.mark.django_db
+def test_delete_user_fail_unauthenticated(api_client: APIClient):
+    url = get_delete_user_url()
+    response = api_client.delete(url, content_type="application/json")
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db
+def test_disconnect_user_linked_account_success(
+    user_with_social_auths: UserType, api_client: APIClient
+):
+    api_client.force_authenticate(user=user_with_social_auths)
+    assert user_with_social_auths.social_auth.filter(provider="discord").exists()
+
+    url = get_disconnect_user_linked_account_url("discord")
+    response = api_client.delete(url, content_type="application/json")
+
+    assert response.status_code == 204
+    assert not user_with_social_auths.social_auth.filter(provider="discord").exists()
+
+
+@pytest.mark.django_db
+def test_disconnect_user_linked_account_fail_unauthenticated(api_client: APIClient):
+    url = get_disconnect_user_linked_account_url("discord")
+    response = api_client.delete(url, content_type="application/json")
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db
+def test_disconnect_user_non_existent_linked_account(
+    user_with_social_auths: UserType, api_client: APIClient
+):
+    api_client.force_authenticate(user=user_with_social_auths)
+    url = get_disconnect_user_linked_account_url("non-existent")
+    response = api_client.delete(url, content_type="application/json")
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Not found."}
+
+
+@pytest.mark.django_db
+def test_disconnect_user_with_no_social_auth(user: UserType, api_client: APIClient):
+    api_client.force_authenticate(user=user)
+    url = get_disconnect_user_linked_account_url("non-existent")
+    response = api_client.delete(url, content_type="application/json")
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Not found."}
+
+
+@pytest.mark.django_db
+def test_disconnect_user_linked_account_fail_last_linked_account(
+    user_with_social_auths: UserType, api_client: APIClient
+):
+    api_client.force_authenticate(user=user_with_social_auths)
+    user_with_social_auths.social_auth.filter(provider="discord").delete()
+    url = get_disconnect_user_linked_account_url("github")
+
+    response = api_client.delete(url, content_type="application/json")
+    expected_response = {
+        "non_field_errors": ["Cannot disconnect last linked auth method"]
+    }
+
+    assert response.status_code == 403
+    assert response.json() == expected_response

--- a/django/thunderstore/api/cyberstorm/tests/utils.py
+++ b/django/thunderstore/api/cyberstorm/tests/utils.py
@@ -5,6 +5,7 @@ from django.db import connection
 from django.test.utils import CaptureQueriesContext
 from jsonschema import RefResolver, ValidationError, validate
 from rest_framework.test import APIClient
+from social_django.models import UserSocialAuth
 
 from thunderstore.core.factories import UserFactory
 from thunderstore.repository.models import PackageListing, TeamMemberRole
@@ -23,6 +24,7 @@ def get_parameter_values(
         "team_id": package_listing.package.owner.name,
         "team_name": package_listing.package.owner.name,
         "uuid": service_account.uuid if service_account else "",
+        "provider": "discord",
     }
 
     if username:
@@ -31,8 +33,19 @@ def get_parameter_values(
     return parameters
 
 
+def _add_social_auth_to_user(user):
+    providers = ["discord", "github"]
+    for provider in providers:
+        UserSocialAuth.objects.create(
+            user=user,
+            provider=provider,
+            uid=f"1234567890-{provider}",
+        )
+
+
 def setup_superuser_with_package(package_listing, package_category=None):
     user = UserFactory.create(is_superuser=True)
+    _add_social_auth_to_user(user)
 
     UserFactory.create(username="TestUser", email="test@user.dev", is_active=True)
 

--- a/django/thunderstore/api/cyberstorm/views/__init__.py
+++ b/django/thunderstore/api/cyberstorm/views/__init__.py
@@ -32,6 +32,7 @@ from .team import (
     TeamServiceAccountListAPIView,
     UpdateTeamAPIView,
 )
+from .user import DeleteUserAPIView, DisconnectUserLinkedAccountAPIView
 
 __all__ = [
     "CommunityAPIView",
@@ -39,6 +40,8 @@ __all__ = [
     "CommunityListAPIView",
     "CreateServiceAccountAPIView",
     "DeleteServiceAccountAPIView",
+    "DeleteUserAPIView",
+    "DisconnectUserLinkedAccountAPIView",
     "DeprecatePackageAPIView",
     "DisbandTeamAPIView",
     "PackageListingAPIView",

--- a/django/thunderstore/api/cyberstorm/views/user.py
+++ b/django/thunderstore/api/cyberstorm/views/user.py
@@ -1,0 +1,51 @@
+from django.contrib.auth import get_user_model
+from django.http import Http404
+from django.utils.decorators import method_decorator
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from thunderstore.api.cyberstorm.services.user import (
+    delete_user_account,
+    delete_user_social_auth,
+)
+from thunderstore.api.utils import conditional_swagger_auto_schema
+
+User = get_user_model()
+
+
+@method_decorator(
+    name="delete",
+    decorator=conditional_swagger_auto_schema(
+        responses={status.HTTP_204_NO_CONTENT: None},
+        operation_id="cyberstorm.user.delete",
+        tags=["cyberstorm"],
+    ),
+)
+class DeleteUserAPIView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def delete(self, request, *args, **kwargs):
+        delete_user_account(target_user=request.user)
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+@method_decorator(
+    name="delete",
+    decorator=conditional_swagger_auto_schema(
+        responses={status.HTTP_204_NO_CONTENT: None},
+        operation_id="cyberstorm.user.linked_account.disconnect",
+        tags=["cyberstorm"],
+    ),
+)
+class DisconnectUserLinkedAccountAPIView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def delete(self, request, provider: str, *args, **kwargs):
+        social_auth = request.user.social_auth.filter(provider=provider).first()
+        if not social_auth:
+            raise Http404("No linked account found")
+
+        delete_user_social_auth(social_auth=social_auth)
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/django/thunderstore/api/urls.py
+++ b/django/thunderstore/api/urls.py
@@ -7,8 +7,10 @@ from thunderstore.api.cyberstorm.views import (
     CommunityListAPIView,
     CreateServiceAccountAPIView,
     DeleteServiceAccountAPIView,
+    DeleteUserAPIView,
     DeprecatePackageAPIView,
     DisbandTeamAPIView,
+    DisconnectUserLinkedAccountAPIView,
     PackageListingAPIView,
     PackageListingByCommunityListAPIView,
     PackageListingByDependencyListAPIView,
@@ -181,5 +183,15 @@ cyberstorm_urls = [
         "team/<str:team_name>/service-account/delete/<uuid:uuid>/",
         DeleteServiceAccountAPIView.as_view(),
         name="cyberstorm.team.service-account.delete",
+    ),
+    path(
+        "user/delete/",
+        DeleteUserAPIView.as_view(),
+        name="cyberstorm.user.delete",
+    ),
+    path(
+        "user/linked-account/<str:provider>/disconnect/",
+        DisconnectUserLinkedAccountAPIView.as_view(),
+        name="cyberstorm.user.linked-account.disconnect",
     ),
 ]

--- a/django/thunderstore/social/templates/settings/linked_accounts.html
+++ b/django/thunderstore/social/templates/settings/linked_accounts.html
@@ -4,6 +4,9 @@
 {% block title %}Linked Accounts{% endblock %}
 
 {% block settings_content %}
+<div class="text-danger mb-2">
+    {{ form.non_field_errors }}
+</div>
 {% for entry in backends.associated|dictsort:"provider" %}
     <div class="row text-large mb-2">
         <div class="col-5">

--- a/django/thunderstore/social/tests/test_user_forms.py
+++ b/django/thunderstore/social/tests/test_user_forms.py
@@ -1,0 +1,72 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.http import Http404
+
+from thunderstore.social.views import DeleteAccountForm, LinkedAccountDisconnectForm
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "test_data, success", [("github", True), ("", False), (None, False)]
+)
+def test_linked_account_disconnect_form_validation(test_data, success):
+    form = LinkedAccountDisconnectForm(data={"provider": test_data})
+    if success:
+        assert form.is_valid()
+    else:
+
+        assert not form.is_valid()
+        assert "provider" in form.errors
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "test_data, success", [("github", True), ("", False), (None, False)]
+)
+def test_linked_account_disconnect_form_disconnect_account(
+    user_with_social_auths, test_data, success
+):
+    form = LinkedAccountDisconnectForm(data={"provider": test_data})
+
+    if success:
+        assert form.is_valid()
+        form.disconnect_account(test_data, user_with_social_auths)
+        assert form.errors == {}
+        assert not user_with_social_auths.social_auth.filter(
+            provider=test_data
+        ).exists()
+    else:
+        with pytest.raises(Http404, match="Social auth not found"):
+            form.disconnect_account(test_data, user_with_social_auths)
+
+
+@pytest.mark.django_db
+def test_linked_account_disconnect_form_disconnect_last_auth_method(
+    user_with_social_auths,
+):
+    user_with_social_auths.social_auth.filter(provider="discord").delete()
+    form = LinkedAccountDisconnectForm(data={"provider": "github"})
+    with pytest.raises(ValidationError):
+        form.disconnect_account("github", user_with_social_auths)
+    assert form.errors == {"__all__": ["Cannot disconnect last linked auth method"]}
+
+
+@pytest.mark.django_db
+def test_delete_account_form_validation(user):
+    form = DeleteAccountForm(data={"verification": user.username}, user=user)
+    assert form.is_valid()
+
+    form = DeleteAccountForm(data={"verification": "wrong username"}, user=user)
+    assert not form.is_valid()
+    assert "verification" in form.errors
+
+
+@pytest.mark.django_db
+def test_delete_account_form_delete_user(user):
+    form = DeleteAccountForm(data={"verification": user.username}, user=user)
+    assert form.is_valid()
+    form.delete_user()
+    assert not User.objects.filter(username=user.username).exists()

--- a/django/thunderstore/social/tests/test_user_views.py
+++ b/django/thunderstore/social/tests/test_user_views.py
@@ -1,0 +1,132 @@
+import pytest
+from django.test import Client
+from django.urls import reverse_lazy
+
+from thunderstore.community.models import CommunitySite
+from thunderstore.core.types import UserType
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "provider, should_fail", [("discord", False), ("non-existent", True)]
+)
+def test_disconnect_account(
+    client: Client,
+    community_site: CommunitySite,
+    user_with_social_auths: UserType,
+    provider: str,
+    should_fail: bool,
+):
+    client.force_login(user_with_social_auths)
+
+    url = reverse_lazy("settings.linked-accounts")
+    response = client.post(
+        url,
+        HTTP_HOST=community_site.site.domain,
+        data={"provider": provider},
+        follow=True,
+    )
+
+    if should_fail:
+        assert response.status_code == 404
+        assert response.context["exception"].args == ("Social auth not found",)
+    else:
+        assert response.status_code == 200
+        assert not user_with_social_auths.social_auth.filter(provider=provider).exists()
+
+
+@pytest.mark.django_db
+def test_disconnect_account_unauthenticated(
+    client: Client,
+    community_site: CommunitySite,
+):
+    url = reverse_lazy("settings.linked-accounts")
+    response = client.post(
+        url,
+        HTTP_HOST=community_site.site.domain,
+        data={"provider": "discord"},
+        follow=True,
+    )
+    assert response.request["PATH_INFO"] == "/"  # redirects back to index
+
+
+@pytest.mark.django_db
+def test_disconnect_account_cannot_disconnect(
+    client: Client,
+    community_site: CommunitySite,
+    user_with_social_auths: UserType,
+):
+    client.force_login(user_with_social_auths)
+
+    user_with_social_auths.social_auth.filter(provider="discord").delete()
+
+    url = reverse_lazy("settings.linked-accounts")
+    response = client.post(
+        url,
+        HTTP_HOST=community_site.site.domain,
+        data={"provider": "github"},
+        follow=True,
+    )
+
+    assert response.status_code == 200
+    assert user_with_social_auths.social_auth.filter(provider="github").exists()
+    assert response.context["form"].errors == {
+        "__all__": ["Cannot disconnect last linked auth method"]
+    }
+
+
+@pytest.mark.django_db
+def test_delete_account_success(
+    client: Client,
+    community_site: CommunitySite,
+    user: UserType,
+):
+    client.force_login(user)
+    user_pk = user.pk
+
+    url = reverse_lazy("settings.delete-account")
+    response = client.post(
+        url,
+        HTTP_HOST=community_site.site.domain,
+        data={"verification": user.username},
+        follow=True,
+    )
+
+    assert response.status_code == 200
+    assert not user.__class__.objects.filter(pk=user_pk).exists()
+
+
+@pytest.mark.django_db
+def test_delete_account_invalid_verification(
+    client: Client,
+    community_site: CommunitySite,
+    user: UserType,
+):
+    client.force_login(user)
+
+    url = reverse_lazy("settings.delete-account")
+    response = client.post(
+        url,
+        HTTP_HOST=community_site.site.domain,
+        data={"verification": "wrongusername"},
+        follow=True,
+    )
+
+    assert response.status_code == 200
+    assert response.context["form"].errors == {"verification": ["Invalid verification"]}
+    assert user.__class__.objects.filter(pk=user.pk).exists()
+
+
+@pytest.mark.django_db
+def test_delete_account_unauthenticated(
+    client: Client,
+    community_site: CommunitySite,
+):
+    url = reverse_lazy("settings.delete-account")
+    response = client.post(
+        url,
+        HTTP_HOST=community_site.site.domain,
+        data={"verification": "testuser"},
+        follow=True,
+    )
+    assert response.request["PATH_INFO"] == "/"

--- a/django/thunderstore/social/views.py
+++ b/django/thunderstore/social/views.py
@@ -1,14 +1,34 @@
 from django import forms
+from django.core.exceptions import ValidationError
+from django.db import transaction
+from django.http import Http404
 from django.urls import reverse_lazy
 from django.views.generic.edit import FormView
 
+from thunderstore.api.cyberstorm.services.user import (
+    delete_user_account,
+    delete_user_social_auth,
+)
 from thunderstore.core.mixins import RequireAuthenticationMixin
+from thunderstore.core.types import UserType
 from thunderstore.frontend.views import SettingsViewMixin
 from thunderstore.repository.models import TeamMember
 
 
 class LinkedAccountDisconnectForm(forms.Form):
     provider = forms.CharField()
+
+    @transaction.atomic
+    def disconnect_account(self, provider: str, user: UserType):
+        social_auth = user.social_auth.filter(provider=provider).first()
+        if not social_auth:
+            raise Http404("Social auth not found")
+
+        try:
+            delete_user_social_auth(social_auth=social_auth)
+        except ValidationError as e:
+            self.add_error(None, e)
+            raise ValidationError(self.errors)
 
 
 class LinkedAccountsView(SettingsViewMixin, RequireAuthenticationMixin, FormView):
@@ -26,14 +46,11 @@ class LinkedAccountsView(SettingsViewMixin, RequireAuthenticationMixin, FormView
     def can_disconnect(self):
         return self.request.user.social_auth.count() > 1
 
-    def disconnect_account(self, provider):
-        if not self.can_disconnect:
-            return
-        social_auth = self.request.user.social_auth.filter(provider=provider).first()
-        social_auth.delete()
-
     def form_valid(self, form):
-        self.disconnect_account(form.cleaned_data["provider"])
+        try:
+            form.disconnect_account(form.cleaned_data["provider"], self.request.user)
+        except ValidationError:
+            return self.form_invalid(form)
         return super().form_valid(form)
 
 
@@ -49,6 +66,10 @@ class DeleteAccountForm(forms.Form):
         if data != self.user.username:
             raise forms.ValidationError("Invalid verification")
         return data
+
+    @transaction.atomic
+    def delete_user(self):
+        delete_user_account(target_user=self.user)
 
 
 class DeleteAccountView(SettingsViewMixin, RequireAuthenticationMixin, FormView):
@@ -73,5 +94,5 @@ class DeleteAccountView(SettingsViewMixin, RequireAuthenticationMixin, FormView)
         return kwargs
 
     def form_valid(self, form):
-        self.request.user.delete()
+        form.delete_user()
         return super().form_valid(form)


### PR DESCRIPTION
Implemented in this PR:

Delete user Cyberstorm API endpoint:
- This view allows users to delete their own accounts.
- Users are restricted from deleting other users' accounts.

API endpoint for disconnecting(deleting) social auth account:
- This view enables users to delete their associated social authentication accounts.
- Users must maintain at least one active authentication account.
- Users can only remove their own social authentication accounts.

Service layer functions for the views mentioned above.

Update existing form views to utilize service layer functions.

Implement missing tests for form views and forms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added endpoints to delete your account and disconnect a linked social account by provider; operations run atomically and prevent removing a user’s last linked auth.
  - Added confirmation-based account deletion form and UI wiring; settings show whether disconnect is allowed.

- Bug Fixes
  - Linked Accounts settings now displays form-level (non-field) errors.

- Tests
  - Added tests and fixtures covering account deletion, linked-account disconnect flows, validations, and error cases (401/403/404).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->