### PR TITLE
Fix Manual Download button styling (TS-2367)

### DIFF
--- a/django/thunderstore/community/templates/community/packagelisting_detail.html
+++ b/django/thunderstore/community/templates/community/packagelisting_detail.html
@@ -158,11 +158,13 @@ window.ts.PackageManagementPanel(
         </a>
     </div>
     {% endif %}
-    <div class="col-12 col-sm-6 px-3 pr-sm-3 pl-sm-1 mt-1 mt-sm-0">
+
+    <div class="{% if object.has_mod_manager_support %} col-12 col-sm-6 px-3 pr-sm-3 pl-sm-1 mt-1 mt-sm-0 {% else %}col-12{% endif %}">
         <a href="{{ object.package.latest.full_download_url }}" type="button" class="btn btn-primary w-100 text-large">
             <i class="fa fa-download mr-2" aria-hidden="true"></i>Manual Download
         </a>
     </div>
+
     {% if object.package.owner.donation_link %}
     <div class="col-12 mt-2">
         <a href="{{ object.package.owner.donation_link }}" target="_blank" rel="noopener" type="button" class="btn btn-info w-100 text-large">


### PR DESCRIPTION
Update styling for the "Manual Download" button to use a conditional check. If the listing can be installed with mod manager, and the "Install with mod manager" button is rendered, the styles remain the same as before. However, if the "Install with mod manager" button is not rendered, the "Manual Download" button will adjust to the same size as the "Support the creator" button for a more consistent layout.

Refs. TS-2367