### PR TITLE
Implement update team endpoint (TS-2314)

### DIFF
--- a/django/thunderstore/api/cyberstorm/serializers/__init__.py
+++ b/django/thunderstore/api/cyberstorm/serializers/__init__.py
@@ -11,6 +11,7 @@ from .team import (
     CyberstormTeamAddMemberResponseSerializer,
     CyberstormTeamMemberSerializer,
     CyberstormTeamSerializer,
+    CyberstormTeamUpdateSerializer,
 )
 
 __all__ = [
@@ -25,4 +26,5 @@ __all__ = [
     "CyberstormTeamMemberSerializer",
     "CyberstormTeamSerializer",
     "PackagePermissionsSerializer",
+    "CyberstormTeamUpdateSerializer",
 ]

--- a/django/thunderstore/api/cyberstorm/serializers/team.py
+++ b/django/thunderstore/api/cyberstorm/serializers/team.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from django.core.validators import URLValidator
 from rest_framework import serializers
 
 from thunderstore.repository.forms import AddTeamMemberForm
@@ -52,4 +53,10 @@ class CyberstormTeamAddMemberResponseSerializer(serializers.Serializer):
 class CyberstormCreateTeamSerializer(serializers.Serializer):
     name = serializers.CharField(
         max_length=64, validators=[PackageReferenceComponentValidator("Author name")]
+    )
+
+
+class CyberstormTeamUpdateSerializer(serializers.Serializer):
+    donation_link = serializers.CharField(
+        max_length=1024, validators=[URLValidator(["https"])]
     )

--- a/django/thunderstore/api/cyberstorm/services/team.py
+++ b/django/thunderstore/api/cyberstorm/services/team.py
@@ -31,3 +31,14 @@ def create_team(user: UserType, team_name: str) -> Team:
     team = Team.objects.create(name=team_name)
     team.add_member(user=user, role=TeamMemberRole.owner)
     return team
+
+
+@transaction.atomic
+def update_team(agent: UserType, team: Team, donation_link: str) -> Team:
+    team.ensure_user_can_access(agent)
+    team.ensure_user_can_edit_info(agent)
+
+    team.donation_link = donation_link
+    team.save()
+
+    return team

--- a/django/thunderstore/api/cyberstorm/tests/services/test_team_services.py
+++ b/django/thunderstore/api/cyberstorm/tests/services/test_team_services.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ValidationError
 from django.http import Http404
 
 from thunderstore.api.cyberstorm.services import team as team_services
+from thunderstore.core.exceptions import PermissionValidationError
 from thunderstore.repository.models import Namespace, Team, TeamMemberRole
 
 
@@ -67,3 +68,38 @@ def test_create_team_success(user):
     assert Team.objects.filter(name=team_name).exists()
     assert team.name == team_name
     assert team.members.filter(user=user, role=TeamMemberRole.owner).exists()
+
+
+@pytest.mark.django_db
+def test_update_team_success(team_owner):
+    team = team_owner.team
+    new_donation_link = "https://example.com/donate"
+    updated_team = team_services.update_team(
+        agent=team_owner.user, team=team, donation_link=new_donation_link
+    )
+
+    assert updated_team.donation_link == new_donation_link
+
+
+@pytest.mark.django_db
+def test_update_team_user_cannot_access(user, team):
+    new_donation_link = "https://example.com/donate"
+
+    error_msg = "Must be a member to access team"
+    with pytest.raises(PermissionValidationError, match=error_msg):
+        team_services.update_team(
+            agent=user, team=team, donation_link=new_donation_link
+        )
+
+
+@pytest.mark.django_db
+def test_update_team_user_cannot_edit_info(team_member):
+    new_donation_link = "https://example.com/donate"
+
+    error_msg = "Must be an owner to edit team info"
+    with pytest.raises(PermissionValidationError, match=error_msg):
+        team_services.update_team(
+            agent=team_member.user,
+            team=team_member.team,
+            donation_link=new_donation_link,
+        )

--- a/django/thunderstore/api/cyberstorm/tests/test_endpoints.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_endpoints.py
@@ -42,7 +42,11 @@ post_payload_map = {
 put_payload_map = {}
 
 
-patch_payload_map = {}
+patch_payload_map = {
+    "/api/cyberstorm/team/{team_name}/update/": {
+        "donation_link": "https://example.com/donate",
+    }
+}
 
 
 payload_mapping = {
@@ -162,7 +166,7 @@ def test_validate_extracted_paths_with_urlpatterns(api_client):
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("http_verb", ["put", "patch", "post"])
-def test_find_missing_post_endpoints(api_client, http_verb):
+def test_find_missing_endpoints(api_client, http_verb):
     schema = get_schema(api_client)
     api_paths = extract_paths(schema, "cyberstorm", http_verb)
     failures = []

--- a/django/thunderstore/api/cyberstorm/views/__init__.py
+++ b/django/thunderstore/api/cyberstorm/views/__init__.py
@@ -24,6 +24,7 @@ from .team import (
     TeamMemberAddAPIView,
     TeamMemberListAPIView,
     TeamServiceAccountListAPIView,
+    UpdateTeamAPIView,
 )
 
 __all__ = [
@@ -49,4 +50,5 @@ __all__ = [
     "UpdatePackageListingCategoriesAPIView",
     "RejectPackageListingAPIView",
     "ApprovePackageListingAPIView",
+    "UpdateTeamAPIView",
 ]

--- a/django/thunderstore/api/urls.py
+++ b/django/thunderstore/api/urls.py
@@ -23,6 +23,7 @@ from thunderstore.api.cyberstorm.views import (
     TeamMemberListAPIView,
     TeamServiceAccountListAPIView,
     UpdatePackageListingCategoriesAPIView,
+    UpdateTeamAPIView,
 )
 
 cyberstorm_urls = [
@@ -125,6 +126,11 @@ cyberstorm_urls = [
         "team/<str:team_id>/",
         TeamAPIView.as_view(),
         name="cyberstorm.team",
+    ),
+    path(
+        "team/<str:team_name>/update/",
+        UpdateTeamAPIView.as_view(),
+        name="cyberstorm.team.update",
     ),
     path(
         "team/<str:team_name>/disband/",

--- a/django/thunderstore/repository/tests/test_team_forms.py
+++ b/django/thunderstore/repository/tests/test_team_forms.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 import pytest
+from django.core.exceptions import ValidationError
 
 from conftest import TestUserTypes
 from thunderstore.core.factories import UserFactory
@@ -552,8 +553,11 @@ def test_form_donation_link_team_form_permissions(
         team.refresh_from_db()
         assert team.donation_link == link
     else:
+        form.save()
         assert form.is_valid() is False
         assert form.errors
+        team.refresh_from_db()
+        assert team.donation_link is None
 
 
 @pytest.mark.django_db

--- a/django/thunderstore/repository/views/team_settings.py
+++ b/django/thunderstore/repository/views/team_settings.py
@@ -16,6 +16,7 @@ from thunderstore.account.forms import (
     CreateServiceAccountForm,
     DeleteServiceAccountForm,
 )
+from thunderstore.api.cyberstorm.services.team import update_team
 from thunderstore.core.mixins import RequireAuthenticationMixin
 from thunderstore.core.utils import capture_exception
 from thunderstore.frontend.views import SettingsViewMixin
@@ -26,7 +27,6 @@ from thunderstore.repository.forms import (
     DonationLinkTeamForm,
     EditTeamMemberForm,
     RemoveTeamMemberForm,
-    TeamMemberRole,
 )
 from thunderstore.repository.models import Team, TeamMember, reverse
 
@@ -276,5 +276,8 @@ class SettingsTeamDonationLinkView(TeamDetailView, UserFormKwargs, UpdateView):
         return self.object.donation_link_url
 
     def form_valid(self, form: DonationLinkTeamForm):
+        self.object = form.save()
+        if form.errors:  # Check if service layer raised an error
+            return super().form_invalid(form)
         messages.success(self.request, "Donation link saved")
-        return super().form_valid(form)
+        return redirect(self.get_success_url())


### PR DESCRIPTION
* Implement and endpoint in cyberstorm api for updating teams
* Support only updating donation_link for now
* Implement tests
* Implement service layer function for updating teams, and implement tests
* Use the service layer function in the form view responsible for updating team donation links