### PR TITLE
Add version count to package listing endpoint(TS-2370)

### DIFF
--- a/django/thunderstore/api/cyberstorm/tests/test_package_listing.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_package_listing.py
@@ -257,6 +257,7 @@ def test_package_listing_view__returns_info(api_client: APIClient) -> None:
     assert actual["team"]["name"] == listing.package.owner.name
     assert len(actual["team"]["members"]) == 0
     assert actual["website_url"] == latest.website_url
+    assert actual["version_count"] == listing.package.version_count
 
 
 @pytest.mark.django_db

--- a/django/thunderstore/api/cyberstorm/views/package_listing.py
+++ b/django/thunderstore/api/cyberstorm/views/package_listing.py
@@ -106,6 +106,7 @@ class ResponseSerializer(serializers.Serializer):
     latest_version_number = serializers.CharField(
         source="package.latest.version_number",
     )
+    version_count = serializers.IntegerField(source="package.version_count")
     name = serializers.CharField(source="package.name")
     namespace = serializers.CharField(source="package.namespace.name")
     rating_count = serializers.IntegerField(min_value=0)

--- a/django/thunderstore/repository/models/package.py
+++ b/django/thunderstore/repository/models/package.py
@@ -183,6 +183,10 @@ class Package(AdminLinkMixin, models.Model):
         )
 
     @cached_property
+    def version_count(self):
+        return self.versions.filter(is_active=True).count()
+
+    @cached_property
     def downloads(self):
         # TODO: Caching
         return self.versions.aggregate(downloads=Sum("downloads"))["downloads"]


### PR DESCRIPTION
Add version_count to package listing endpoint. Implement cached_property to Package model for getting versions count.
