### PR TITLE
Add detect_and_assign_modpack_category task [TS-2363]

### DIFF
--- a/django/thunderstore/community/models/package_listing.py
+++ b/django/thunderstore/community/models/package_listing.py
@@ -298,6 +298,13 @@ class PackageListing(TimestampMixin, AdminLinkMixin, models.Model):
 
     @staticmethod
     def post_save(sender, instance, created, **kwargs):
+        if created:
+            from thunderstore.community.tasks import detect_and_assign_modpack_category
+
+            transaction.on_commit(
+                lambda: (detect_and_assign_modpack_category.delay(instance.pk))
+            )
+
         invalidate_cache_on_commit_async(CacheBustCondition.any_package_updated)
 
     @staticmethod

--- a/django/thunderstore/community/tasks.py
+++ b/django/thunderstore/community/tasks.py
@@ -2,7 +2,12 @@ import logging
 
 from celery import shared_task
 
-from thunderstore.community.models import Community, CommunityAggregatedFields
+from thunderstore.community.models import (
+    Community,
+    CommunityAggregatedFields,
+    PackageCategory,
+    PackageListing,
+)
 from thunderstore.core.settings import CeleryQueues
 
 logger = logging.getLogger(__name__)
@@ -18,3 +23,33 @@ def update_community_aggregated_fields() -> None:
     logger.info("Updating fields values for listed communities")
     for c in Community.objects.all():
         CommunityAggregatedFields.update_for_community(c)
+
+
+@shared_task(
+    queue=CeleryQueues.BackgroundTask,
+    name="thunderstore.community.tasks.detect_and_assign_modpack_category",
+)
+def detect_and_assign_modpack_category(package_listing_pk: int):
+    listing = PackageListing.objects.select_related("package__latest", "community").get(
+        pk=package_listing_pk
+    )
+    latest = listing.package.latest
+    community = listing.community
+
+    mod_dependencies_count = (
+        PackageListing.objects.filter(
+            package_id__in=latest.dependencies.values_list("package_id", flat=True),
+            community=community,
+        )
+        .exclude(categories__slug="libraries")
+        .count()
+    )
+
+    if mod_dependencies_count > 4:
+        modpacks_category = PackageCategory.objects.filter(
+            slug="modpacks", community=community
+        ).first()
+        if not modpacks_category:
+            return f"{community.identifier} community has no modpacks category"
+        listing.categories.add(modpacks_category)
+        return f"Added modpacks category to listing {package_listing_pk}"

--- a/django/thunderstore/core/tests/test_celery.py
+++ b/django/thunderstore/core/tests/test_celery.py
@@ -28,6 +28,7 @@ KNOWN_CELERY_IDS = (
     "celery.chain",
     "celery.starmap",
     "celery.backend_cleanup",
+    "thunderstore.community.tasks.detect_and_assign_modpack_category",
     "thunderstore.community.tasks.update_community_aggregated_fields",
     "thunderstore.core.tasks.celery_post",
     "thunderstore.cache.tasks.invalidate_cache",


### PR DESCRIPTION
Add detect_and_assign_modpack_category task
Run task on post_save() when a new listing is created
Add tests for the task


This will eventually be replaced with a more robust system