### PR TITLE
Split updating LC's chunked package list into a dedicated celery task

### DIFF
--- a/django/thunderstore/core/tests/test_celery.py
+++ b/django/thunderstore/core/tests/test_celery.py
@@ -36,6 +36,7 @@ KNOWN_CELERY_IDS = (
     "thunderstore.schema_import.tasks.sync_ecosystem_schema",
     "thunderstore.repository.tasks.files.extract_package_version_file_tree",
     "thunderstore.repository.tasks.update_chunked_package_caches",
+    "thunderstore.repository.tasks.update_chunked_package_caches_lc",
     "thunderstore.repository.tasks.update_experimental_package_index",
     "thunderstore.repository.tasks.process_package_submission",
     "thunderstore.repository.tasks.cleanup_package_submissions",

--- a/django/thunderstore/repository/api/v1/tasks.py
+++ b/django/thunderstore/repository/api/v1/tasks.py
@@ -1,3 +1,5 @@
+from typing import Iterator
+
 from thunderstore.community.models import Community, CommunitySite
 from thunderstore.core.utils import capture_exception
 from thunderstore.repository.api.v1.viewsets import serialize_package_list_for_community
@@ -33,7 +35,17 @@ def update_api_v1_indexes() -> None:
 
 
 def update_api_v1_chunked_package_caches() -> None:
-    for community in Community.objects.iterator():
+    communities = Community.objects.exclude(identifier="lethal-company").iterator()
+    _update_api_v1_chunked_package_caches(communities)
+
+
+def update_api_v1_chunked_package_caches_lc() -> None:
+    communities = Community.objects.filter(identifier="lethal-company").iterator()
+    _update_api_v1_chunked_package_caches(communities)
+
+
+def _update_api_v1_chunked_package_caches(communities: Iterator[Community]) -> None:
+    for community in communities:
         try:
             APIV1ChunkedPackageCache.update_for_community(community)
         except Exception as e:  # pragma: no cover

--- a/django/thunderstore/repository/migrations/0057_schedule_lc_chunked_package_caching.py
+++ b/django/thunderstore/repository/migrations/0057_schedule_lc_chunked_package_caching.py
@@ -1,0 +1,41 @@
+import pytz
+from django.db import migrations
+
+TASK = "thunderstore.repository.tasks.update_chunked_package_caches_lc"
+
+
+def forwards(apps, schema_editor):
+    CrontabSchedule = apps.get_model("django_celery_beat", "CrontabSchedule")
+    PeriodicTask = apps.get_model("django_celery_beat", "PeriodicTask")
+
+    schedule, _ = CrontabSchedule.objects.get_or_create(
+        minute="0",
+        hour="*",
+        day_of_week="*",
+        day_of_month="*",
+        month_of_year="*",
+        timezone=pytz.timezone("UTC"),
+    )
+
+    PeriodicTask.objects.get_or_create(
+        crontab=schedule,
+        name="Update APIV1ChunkedPackageCache (Lethal Company)",
+        task=TASK,
+        expire_seconds=300,
+    )
+
+
+def backwards(apps, schema_editor):
+    PeriodicTask = apps.get_model("django_celery_beat", "PeriodicTask")
+    PeriodicTask.objects.filter(task=TASK).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("repository", "0056_packageversion_uploaded_by"),
+        ("django_celery_beat", "0014_remove_clockedschedule_enabled"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, backwards),
+    ]

--- a/django/thunderstore/repository/tasks/caches.py
+++ b/django/thunderstore/repository/tasks/caches.py
@@ -7,6 +7,7 @@ from thunderstore.repository.api.experimental.views.package_index import (
 from thunderstore.repository.api.v1.tasks import (
     update_api_v1_caches,
     update_api_v1_chunked_package_caches,
+    update_api_v1_chunked_package_caches_lc,
 )
 
 
@@ -35,4 +36,21 @@ def update_experimental_package_index():
     time_limit=60 * 60 * 24,
 )
 def update_chunked_community_package_caches():
+    """
+    Update chunked package index cache for all communities excluding
+    Lethal Company.
+    """
     update_api_v1_chunked_package_caches()
+
+
+@shared_task(
+    name="thunderstore.repository.tasks.update_chunked_package_caches_lc",
+    queue=CeleryQueues.BackgroundLongRunning,
+    soft_time_limit=60 * 60 * 23,
+    time_limit=60 * 60 * 24,
+)
+def update_chunked_community_package_caches_lc():
+    """
+    Update chunked package index cache for Lethal Company community.
+    """
+    update_api_v1_chunked_package_caches_lc()


### PR DESCRIPTION
In an attempt to improve the time it takes for uploaded packages to be available in the mod managers, split the celery task into two parts. One will update the package index for Lethal Company, and the other will update indices for all the rest.

Refs TS-2378