### PR TITLE
Add css for dismissible alerts

### DIFF
--- a/builder/src/scss/general.scss
+++ b/builder/src/scss/general.scss
@@ -111,3 +111,11 @@
         }
     }
 }
+
+.dismissible-alert {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border: none;
+    color: #fff;
+}

--- a/builder/src/scss/theme/_variables.scss
+++ b/builder/src/scss/theme/_variables.scss
@@ -23,7 +23,7 @@ $purple: #6f42c1 !default;
 $pink: #e83e8c !default;
 $red: #e74c3c !default;
 $orange: #fd7e14 !default;
-$yellow: #f39c12 !default;
+$yellow: #b8860b !default;
 $green: #00bc8c !default;
 $teal: #20c997 !default;
 $cyan: #3498db !default;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d16265ed-8ffe-439d-8a26-fa41ebdab7f7)
See this banner in the Boneworks community?
- It's too hard to read
- I've already read it and I can't get rid of it

This PR changes the color of yellow to a darker shade of yellow and adds some css that isn't used anywhere, but could be used in dynamic HTML to let us make dismissible alerts:
![image](https://github.com/user-attachments/assets/00f11645-5d24-4a22-913e-9828b4f63058)

If they're dismissible we can use them more liberally such as when a game updates to cut down on the amount of support people need.