### PR TITLE
Review comments and minor adjustments

### DIFF
--- a/django/thunderstore/api/cyberstorm/serializers/team.py
+++ b/django/thunderstore/api/cyberstorm/serializers/team.py
@@ -53,17 +53,3 @@ class CyberstormCreateTeamSerializer(serializers.Serializer):
     name = serializers.CharField(
         max_length=64, validators=[PackageReferenceComponentValidator("Author name")]
     )
-
-    def validate_name(self, value: str) -> str:
-        if Team.objects.filter(name__iexact=value).exists():
-            raise ValidationError("A team with the provided name already exists")
-        if Namespace.objects.filter(name__iexact=value).exists():
-            raise ValidationError("A namespace with the provided name already exists")
-        return value
-
-    def validate(self, attrs):
-        attrs = super().validate(attrs)
-        user = self.context["request"].user
-        if getattr(user, "service_account", None) is not None:
-            raise ValidationError("Service accounts cannot create teams")
-        return attrs

--- a/django/thunderstore/api/cyberstorm/services/team.py
+++ b/django/thunderstore/api/cyberstorm/services/team.py
@@ -1,36 +1,32 @@
+from django.core.exceptions import ValidationError
+from django.db import transaction
 from django.shortcuts import get_object_or_404
-from rest_framework.exceptions import PermissionDenied, ValidationError
 
-from thunderstore.api import error_messages
 from thunderstore.core.types import UserType
 from thunderstore.repository.models import Namespace, Team
 from thunderstore.repository.models.team import TeamMemberRole
 
 
+@transaction.atomic
 def disband_team(user: UserType, team_name: str) -> None:
     teams = Team.objects.exclude(is_active=False)
     team = get_object_or_404(teams, name=team_name)
-
-    if not team.can_user_access(user):
-        raise PermissionDenied(error_messages.RESOURCE_DENIED_ERROR)
-
-    if not team.can_user_disband(user):
-        raise PermissionDenied(error_messages.ACTION_DENIED_ERROR)
-
+    team.ensure_user_can_access(user)
+    team.ensure_user_can_disband(user)
     team.delete()
 
 
+@transaction.atomic
 def create_team(user: UserType, team_name: str) -> Team:
-    if Team.objects.filter(name=team_name).exists():
-        raise ValidationError(error_messages.RESOURCE_EXISTS_ERROR)
-
-    if Namespace.objects.filter(name=team_name).exists():
-        raise ValidationError(error_messages.RESOURCE_EXISTS_ERROR)
-
+    if not user or not user.is_authenticated or not user.is_active:
+        raise ValidationError("Must be authenticated to create teams")
     if getattr(user, "service_account", None) is not None:
-        raise ValidationError(error_messages.ACTION_DENIED_ERROR)
+        raise ValidationError("Service accounts cannot create teams")
+    if Team.objects.filter(name=team_name).exists():
+        raise ValidationError("A team with the provided name already exists")
+    if Namespace.objects.filter(name=team_name).exists():
+        raise ValidationError("A namespace with the provided name already exists")
 
     team = Team.objects.create(name=team_name)
     team.add_member(user=user, role=TeamMemberRole.owner)
-
     return team

--- a/django/thunderstore/api/cyberstorm/services/team.py
+++ b/django/thunderstore/api/cyberstorm/services/team.py
@@ -1,9 +1,10 @@
 from django.shortcuts import get_object_or_404
-from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import PermissionDenied, ValidationError
 
 from thunderstore.api import error_messages
 from thunderstore.core.types import UserType
-from thunderstore.repository.models import Team
+from thunderstore.repository.models import Namespace, Team
+from thunderstore.repository.models.team import TeamMemberRole
 
 
 def disband_team(user: UserType, team_name: str) -> None:
@@ -17,3 +18,19 @@ def disband_team(user: UserType, team_name: str) -> None:
         raise PermissionDenied(error_messages.ACTION_DENIED_ERROR)
 
     team.delete()
+
+
+def create_team(user: UserType, team_name: str) -> Team:
+    if Team.objects.filter(name=team_name).exists():
+        raise ValidationError(error_messages.RESOURCE_EXISTS_ERROR)
+
+    if Namespace.objects.filter(name=team_name).exists():
+        raise ValidationError(error_messages.RESOURCE_EXISTS_ERROR)
+
+    if getattr(user, "service_account", None) is not None:
+        raise ValidationError(error_messages.ACTION_DENIED_ERROR)
+
+    team = Team.objects.create(name=team_name)
+    team.add_member(user=user, role=TeamMemberRole.owner)
+
+    return team

--- a/django/thunderstore/api/cyberstorm/services/team.py
+++ b/django/thunderstore/api/cyberstorm/services/team.py
@@ -1,0 +1,19 @@
+from django.shortcuts import get_object_or_404
+from rest_framework.exceptions import PermissionDenied
+
+from thunderstore.api import error_messages
+from thunderstore.core.types import UserType
+from thunderstore.repository.models import Team
+
+
+def disband_team(user: UserType, team_name: str) -> None:
+    teams = Team.objects.exclude(is_active=False)
+    team = get_object_or_404(teams, name=team_name)
+
+    if not team.can_user_access(user):
+        raise PermissionDenied(error_messages.RESOURCE_DENIED_ERROR)
+
+    if not team.can_user_disband(user):
+        raise PermissionDenied(error_messages.ACTION_DENIED_ERROR)
+
+    team.delete()

--- a/django/thunderstore/api/cyberstorm/tests/services/test_team_services.py
+++ b/django/thunderstore/api/cyberstorm/tests/services/test_team_services.py
@@ -1,0 +1,33 @@
+import pytest
+from django.http import Http404
+from rest_framework.exceptions import PermissionDenied
+
+from thunderstore.api.cyberstorm.services import error_messages
+from thunderstore.api.cyberstorm.services import team as team_services
+from thunderstore.repository.models import Team
+
+
+@pytest.mark.django_db
+def test_disband_team_success(team_owner):
+    team_pk = team_owner.team.pk
+    team_services.disband_team(team_owner.user, team_owner.team.name)
+    assert not Team.objects.filter(pk=team_pk).exists()
+
+
+@pytest.mark.django_db
+def test_disband_team_team_not_found(user):
+    with pytest.raises(Http404):
+        team_services.disband_team(user, "NonExistentTeam")
+
+
+@pytest.mark.django_db
+def test_disband_team_user_cannot_access_team(user):
+    team = Team.objects.create(name="TestTeam")
+    with pytest.raises(PermissionDenied, match=error_messages.CANNOT_ACCESS_TEAM):
+        team_services.disband_team(user, team.name)
+
+
+@pytest.mark.django_db
+def test_disband_team_user_cannot_disband(team_member):
+    with pytest.raises(PermissionDenied, match=error_messages.CANNOT_DISBAND_TEAM):
+        team_services.disband_team(team_member.user, team_member.team.name)

--- a/django/thunderstore/api/cyberstorm/tests/services/test_team_services.py
+++ b/django/thunderstore/api/cyberstorm/tests/services/test_team_services.py
@@ -1,10 +1,10 @@
 import pytest
 from django.http import Http404
-from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import PermissionDenied, ValidationError
 
-from thunderstore.api.cyberstorm.services import error_messages
+from thunderstore.api import error_messages
 from thunderstore.api.cyberstorm.services import team as team_services
-from thunderstore.repository.models import Team
+from thunderstore.repository.models import Namespace, Team, TeamMemberRole
 
 
 @pytest.mark.django_db
@@ -23,11 +23,45 @@ def test_disband_team_team_not_found(user):
 @pytest.mark.django_db
 def test_disband_team_user_cannot_access_team(user):
     team = Team.objects.create(name="TestTeam")
-    with pytest.raises(PermissionDenied, match=error_messages.CANNOT_ACCESS_TEAM):
+    with pytest.raises(PermissionDenied, match=error_messages.RESOURCE_DENIED_ERROR):
         team_services.disband_team(user, team.name)
 
 
 @pytest.mark.django_db
 def test_disband_team_user_cannot_disband(team_member):
-    with pytest.raises(PermissionDenied, match=error_messages.CANNOT_DISBAND_TEAM):
+    with pytest.raises(PermissionDenied, match=error_messages.ACTION_DENIED_ERROR):
         team_services.disband_team(team_member.user, team_member.team.name)
+
+
+@pytest.mark.django_db
+def test_create_team_name_exists_in_team(user):
+    Team.objects.create(name="existing_team")
+
+    with pytest.raises(ValidationError, match=error_messages.RESOURCE_EXISTS_ERROR):
+        team_services.create_team(user, "existing_team")
+
+
+@pytest.mark.django_db
+def test_create_team_name_exists_in_namespace(user):
+    Namespace.objects.create(name="existing_namespace")
+
+    with pytest.raises(ValidationError, match=error_messages.RESOURCE_EXISTS_ERROR):
+        team_services.create_team(user, "existing_namespace")
+
+
+@pytest.mark.django_db
+def test_create_team_user_is_service_account(service_account):
+    service_account_user = service_account.user
+
+    with pytest.raises(ValidationError, match=error_messages.ACTION_DENIED_ERROR):
+        team_services.create_team(service_account_user, "new_team")
+
+
+@pytest.mark.django_db
+def test_create_team_success(user):
+    team_name = "new_team"
+    team = team_services.create_team(user, team_name)
+
+    assert Team.objects.filter(name=team_name).exists()
+    assert team.name == team_name
+    assert team.members.filter(user=user, role=TeamMemberRole.owner).exists()

--- a/django/thunderstore/api/cyberstorm/tests/test_create_team.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_create_team.py
@@ -3,6 +3,7 @@ import json
 import pytest
 from rest_framework.test import APIClient
 
+from thunderstore.api import error_messages
 from thunderstore.core.types import UserType
 from thunderstore.repository.factories import NamespaceFactory
 from thunderstore.repository.models.team import Team
@@ -55,8 +56,7 @@ def test_create_team__fail_because_team_with_provided_name_exists(
     response = make_request(api_client, team.name)
 
     assert response.status_code == 400
-    error_message = "A team with the provided name already exists"
-    assert error_message in response.json()["name"]
+    assert response.json() == [error_messages.RESOURCE_EXISTS_ERROR]
 
 
 @pytest.mark.django_db
@@ -69,8 +69,7 @@ def test_create_team__fail_because_team_with_provided_namespace_exists(
     response = make_request(api_client, "CoolestTeamNameEver")
 
     assert response.status_code == 400
-    error_message = "A namespace with the provided name already exists"
-    assert error_message in response.json()["name"]
+    assert response.json() == [error_messages.RESOURCE_EXISTS_ERROR]
 
 
 @pytest.mark.django_db
@@ -137,6 +136,5 @@ def test_create_team_with_service_account(api_client: APIClient, service_account
     response = make_request(api_client, "CoolestTeamNameEver")
 
     assert response.status_code == 400
-    error_message = "Service accounts cannot create teams"
-    assert error_message in response.json()["non_field_errors"]
+    assert response.json() == [error_messages.ACTION_DENIED_ERROR]
     assert Team.objects.filter(name="CoolestTeamNameEver").count() == 0

--- a/django/thunderstore/api/cyberstorm/tests/test_create_team.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_create_team.py
@@ -3,7 +3,6 @@ import json
 import pytest
 from rest_framework.test import APIClient
 
-from thunderstore.api import error_messages
 from thunderstore.core.types import UserType
 from thunderstore.repository.factories import NamespaceFactory
 from thunderstore.repository.models.team import Team
@@ -54,9 +53,12 @@ def test_create_team__fail_because_team_with_provided_name_exists(
 ):
     api_client.force_authenticate(user)
     response = make_request(api_client, team.name)
+    expected_response = {
+        "non_field_errors": ["A team with the provided name already exists"]
+    }
 
     assert response.status_code == 400
-    assert response.json() == [error_messages.RESOURCE_EXISTS_ERROR]
+    assert response.json() == expected_response
 
 
 @pytest.mark.django_db
@@ -67,9 +69,12 @@ def test_create_team__fail_because_team_with_provided_namespace_exists(
     api_client.force_authenticate(user)
     NamespaceFactory(name="CoolestTeamNameEver")
     response = make_request(api_client, "CoolestTeamNameEver")
+    expected_response = {
+        "non_field_errors": ["A namespace with the provided name already exists"]
+    }
 
     assert response.status_code == 400
-    assert response.json() == [error_messages.RESOURCE_EXISTS_ERROR]
+    assert response.json() == expected_response
 
 
 @pytest.mark.django_db
@@ -134,7 +139,8 @@ def test_create_team_with_service_account(api_client: APIClient, service_account
     api_client.force_authenticate(service_account.user)
     assert Team.objects.filter(name="CoolestTeamNameEver").count() == 0
     response = make_request(api_client, "CoolestTeamNameEver")
+    expected_response = {"non_field_errors": ["Service accounts cannot create teams"]}
 
     assert response.status_code == 400
-    assert response.json() == [error_messages.ACTION_DENIED_ERROR]
+    assert response.json() == expected_response
     assert Team.objects.filter(name="CoolestTeamNameEver").count() == 0

--- a/django/thunderstore/api/cyberstorm/tests/test_create_team.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_create_team.py
@@ -9,7 +9,7 @@ from thunderstore.repository.models.team import Team
 
 
 def get_create_team_url() -> str:
-    return "/api/cyberstorm/team/new/"
+    return "/api/cyberstorm/team/create/"
 
 
 def make_request(api_client: APIClient, team_name: str):

--- a/django/thunderstore/api/cyberstorm/tests/test_disband_team.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_disband_team.py
@@ -1,7 +1,6 @@
 import pytest
 from rest_framework.test import APIClient
 
-from thunderstore.api import error_messages
 from thunderstore.core.types import UserType
 from thunderstore.repository.factories import TeamMemberFactory
 from thunderstore.repository.models.team import Team
@@ -61,8 +60,8 @@ def test_disband_team_fail_because_user_is_not_owner(
     TeamMemberFactory(team=team, user=user, role="member")
     api_client.force_authenticate(user)
     response = make_request(api_client, team.name)
-    expected_response = {"detail": error_messages.ACTION_DENIED_ERROR}
-    assert response.status_code == 403
+    expected_response = {"non_field_errors": ["Must be an owner to disband team"]}
+    assert response.status_code == 400
     assert response.json() == expected_response
 
 
@@ -74,6 +73,6 @@ def test_disband_team_fail_because_user_cannot_access_team(
 ):
     api_client.force_authenticate(user)
     response = make_request(api_client, team.name)
-    expected_response = {"detail": error_messages.RESOURCE_DENIED_ERROR}
-    assert response.status_code == 403
+    expected_response = {"non_field_errors": ["Must be a member to access team"]}
+    assert response.status_code == 400
     assert response.json() == expected_response

--- a/django/thunderstore/api/cyberstorm/tests/test_disband_team.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_disband_team.py
@@ -1,6 +1,7 @@
 import pytest
 from rest_framework.test import APIClient
 
+from thunderstore.api import error_messages
 from thunderstore.core.types import UserType
 from thunderstore.repository.factories import TeamMemberFactory
 from thunderstore.repository.models.team import Team
@@ -39,7 +40,7 @@ def test_disband_team_fail_because_team_doesnt_exist(
 
 
 @pytest.mark.django_db
-def test_disband_team__fails_because_user_is_not_authenticated(
+def test_disband_team_fail_because_user_is_not_authenticated(
     api_client: APIClient,
     team: Team,
 ):
@@ -60,7 +61,7 @@ def test_disband_team_fail_because_user_is_not_owner(
     TeamMemberFactory(team=team, user=user, role="member")
     api_client.force_authenticate(user)
     response = make_request(api_client, team.name)
-    expected_response = {"detail": "You do not have permission to disband this team."}
+    expected_response = {"detail": error_messages.ACTION_DENIED_ERROR}
     assert response.status_code == 403
     assert response.json() == expected_response
 
@@ -73,6 +74,6 @@ def test_disband_team_fail_because_user_cannot_access_team(
 ):
     api_client.force_authenticate(user)
     response = make_request(api_client, team.name)
-    expected_response = {"detail": "You do not have permission to access this team."}
+    expected_response = {"detail": error_messages.RESOURCE_DENIED_ERROR}
     assert response.status_code == 403
     assert response.json() == expected_response

--- a/django/thunderstore/api/cyberstorm/tests/test_team.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_team.py
@@ -33,14 +33,16 @@ def test_team_api_view__for_nonexisting_team__returns_404(api_client: APIClient)
 
 
 @pytest.mark.django_db
-def test_team_api_view__when_fetching_team__is_case_insensitive(
+def test_team_api_view__when_fetching_team__is_case_sensitive(
     api_client: APIClient,
 ):
     TeamFactory(name="RaDTeAm")
 
-    response = api_client.get("/api/cyberstorm/team/radteam/")
-
+    response = api_client.get("/api/cyberstorm/team/RaDTeAm/")
     assert response.status_code == 200
+
+    response = api_client.get("/api/cyberstorm/team/radteam/")
+    assert response.status_code == 404
 
 
 @pytest.mark.django_db
@@ -121,7 +123,7 @@ def test_team_membership_permission__for_member__returns_200(
 
 
 @pytest.mark.django_db
-def test_team_membership_permission__when_fetching_team__is_case_insensitive(
+def test_team_membership_permission__when_fetching_team__is_case_sensitive(
     api_client: APIClient,
     user: UserType,
 ):
@@ -129,9 +131,11 @@ def test_team_membership_permission__when_fetching_team__is_case_insensitive(
     TeamMemberFactory(team=team, user=user)
     api_client.force_authenticate(user)
 
-    response = api_client.get("/api/cyberstorm/team/thundergods/member/")
-
+    response = api_client.get("/api/cyberstorm/team/ThunderGods/member/")
     assert response.status_code == 200
+
+    response = api_client.get("/api/cyberstorm/team/thundergods/member/")
+    assert response.status_code == 404
 
 
 @pytest.mark.django_db

--- a/django/thunderstore/api/cyberstorm/views/team.py
+++ b/django/thunderstore/api/cyberstorm/views/team.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db.models import Q, QuerySet
 from rest_framework import status
 from rest_framework.exceptions import PermissionDenied, ValidationError
@@ -64,11 +65,9 @@ class TeamCreateAPIView(APIView):
     def post(self, request, *args, **kwargs):
         serializer = CyberstormCreateTeamSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-
         team_name = serializer.validated_data["name"]
         team = team_services.create_team(user=request.user, team_name=team_name)
         return_data = CyberstormTeamSerializer(team).data
-
         return Response(return_data, status=status.HTTP_201_CREATED)
 
 

--- a/django/thunderstore/api/error_messages.py
+++ b/django/thunderstore/api/error_messages.py
@@ -1,3 +1,0 @@
-RESOURCE_DENIED_ERROR = "Cannot access resource."
-RESOURCE_EXISTS_ERROR = "Resource already exists."
-ACTION_DENIED_ERROR = "Cannot perform this action."

--- a/django/thunderstore/api/error_messages.py
+++ b/django/thunderstore/api/error_messages.py
@@ -1,2 +1,3 @@
 RESOURCE_DENIED_ERROR = "Cannot access resource."
+RESOURCE_EXISTS_ERROR = "Resource already exists."
 ACTION_DENIED_ERROR = "Cannot perform this action."

--- a/django/thunderstore/api/error_messages.py
+++ b/django/thunderstore/api/error_messages.py
@@ -1,0 +1,2 @@
+RESOURCE_DENIED_ERROR = "Cannot access resource."
+ACTION_DENIED_ERROR = "Cannot perform this action."

--- a/django/thunderstore/api/urls.py
+++ b/django/thunderstore/api/urls.py
@@ -107,7 +107,7 @@ cyberstorm_urls = [
         name="cyberstorm.package.rate",
     ),
     path(
-        "team/new/",
+        "team/create/",
         TeamCreateAPIView.as_view(),
         name="cyberstorm.team.create",
     ),


### PR DESCRIPTION
@Roffenlund I was reviewing the diff between the last tag and current master and spotted a few things I'd like to see changed. Changed a few smaller portions myself already (but did not test nor update tests in case those broke with them), but left a slightly larger change for you.

There's a code comment in the team API views explaining the situation, but the gist of it is we should consolidate all business logic actions to a single channel and avoid double-implementation. This primarily applies to the Team management API views, but I did consider how applicable it's to package listing API views also. In the latter case the situation could be better (we already have similar implementations in the code base), but given that a lot of the actual business logic is already handled elsewhere (in the model classes, including permission checks etc), the main goal of avoiding duplicate business logic implementations for the same actions is met.

Created a PR primarily because it's not possible to comment on diffs that aren't linked to any PR as far as I know