### PR TITLE
Increase Community list api view page size (TS-2403)

### DIFF
--- a/django/thunderstore/api/cyberstorm/views/community_list.py
+++ b/django/thunderstore/api/cyberstorm/views/community_list.py
@@ -9,7 +9,7 @@ from thunderstore.community.models import Community
 
 
 class CommunityPaginator(PageNumberPagination):
-    page_size = 150
+    page_size = 300
 
 
 class CommunityListAPIView(CyberstormAutoSchemaMixin, ListAPIView):


### PR DESCRIPTION
Increase page size from 150 to 300 since we have a total of 150 communities in thunderstore at the moment.