### PR TITLE
Pre release fixes

### DIFF
--- a/django/thunderstore/api/cyberstorm/tests/test_create_team.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_create_team.py
@@ -9,7 +9,7 @@ from thunderstore.repository.models.team import Team
 
 
 def get_create_team_url() -> str:
-    return "/api/cyberstorm/team/new/"
+    return "/api/cyberstorm/team/create/"
 
 
 def make_request(api_client: APIClient, team_name: str):

--- a/django/thunderstore/api/cyberstorm/tests/test_disband_team.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_disband_team.py
@@ -60,8 +60,8 @@ def test_disband_team_fail_because_user_is_not_owner(
     TeamMemberFactory(team=team, user=user, role="member")
     api_client.force_authenticate(user)
     response = make_request(api_client, team.name)
-    expected_response = {"detail": "You do not have permission to disband this team."}
-    assert response.status_code == 403
+    expected_response = {"non_field_errors": ["User cannot disband this team"]}
+    assert response.status_code == 400
     assert response.json() == expected_response
 
 

--- a/django/thunderstore/api/cyberstorm/tests/test_team.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_team.py
@@ -33,14 +33,16 @@ def test_team_api_view__for_nonexisting_team__returns_404(api_client: APIClient)
 
 
 @pytest.mark.django_db
-def test_team_api_view__when_fetching_team__is_case_insensitive(
+def test_team_api_view__when_fetching_team__is_case_sensitive(
     api_client: APIClient,
 ):
     TeamFactory(name="RaDTeAm")
 
-    response = api_client.get("/api/cyberstorm/team/radteam/")
-
+    response = api_client.get("/api/cyberstorm/team/RaDTeAm/")
     assert response.status_code == 200
+
+    response = api_client.get("/api/cyberstorm/team/radteam/")
+    assert response.status_code == 404
 
 
 @pytest.mark.django_db
@@ -121,7 +123,7 @@ def test_team_membership_permission__for_member__returns_200(
 
 
 @pytest.mark.django_db
-def test_team_membership_permission__when_fetching_team__is_case_insensitive(
+def test_team_membership_permission__when_fetching_team__is_case_sensitive(
     api_client: APIClient,
     user: UserType,
 ):
@@ -129,9 +131,11 @@ def test_team_membership_permission__when_fetching_team__is_case_insensitive(
     TeamMemberFactory(team=team, user=user)
     api_client.force_authenticate(user)
 
-    response = api_client.get("/api/cyberstorm/team/thundergods/member/")
-
+    response = api_client.get("/api/cyberstorm/team/ThunderGods/member/")
     assert response.status_code == 200
+
+    response = api_client.get("/api/cyberstorm/team/thundergods/member/")
+    assert response.status_code == 404
 
 
 @pytest.mark.django_db

--- a/django/thunderstore/api/urls.py
+++ b/django/thunderstore/api/urls.py
@@ -107,7 +107,7 @@ cyberstorm_urls = [
         name="cyberstorm.package.rate",
     ),
     path(
-        "team/new/",
+        "team/create/",
         TeamCreateAPIView.as_view(),
         name="cyberstorm.team.create",
     ),

--- a/django/thunderstore/repository/models/team.py
+++ b/django/thunderstore/repository/models/team.py
@@ -357,3 +357,8 @@ class Team(models.Model):
 
     def can_user_edit_info(self, user: Optional[UserType]) -> bool:
         return check_validity(lambda: self.ensure_user_can_edit_info(user))
+
+    def disband(self, user: Optional[UserType]) -> None:
+        if not self.can_user_disband(user):
+            raise ValidationError("User cannot disband this team")
+        self.delete()


### PR DESCRIPTION
Update the URL for creating new from "/new" -> "/create". Update tests accordingly.

Fetch team with only name instead of name__iexact in several Team views.

Update DisbandTeamAPIView to use APIView instead of DestroyAPIView. Add a function called disband() to Team model which takes care of the actual removing of the Team, as well as checks the permissions. This change in order to move the deletion logic out of the view and in to the model where it can be reused.

Update tests accordingly.

Refs. None