### PR TITLE
Add wiki link to Upload page

### DIFF
--- a/django/thunderstore/repository/templates/repository/package_create.html
+++ b/django/thunderstore/repository/templates/repository/package_create.html
@@ -12,8 +12,8 @@
 
 <div class="mb-3 mt-3 alert alert-info" role="alert">
     <p class="mb-0">
-        Looking for package format documentation?
-        <a href="{% community_url 'packages.create.docs' %}">You can find it here</a>
+        Need help formatting your package?
+        <a href="https://wiki.thunderstore.io/creating-a-package">Check out the Thunderstore wiki</a>
     </p>
 </div>
 <div class="mb-3 mt-3 alert alert-info" role="alert">

--- a/django/thunderstore/repository/templates/repository/package_create_old.html
+++ b/django/thunderstore/repository/templates/repository/package_create_old.html
@@ -11,8 +11,8 @@
 
 <div class="mb-3 mt-3 alert alert-info" role="alert">
     <p class="mb-0">
-        Looking for package format documentation?
-        <a href="{% community_url 'packages.create.docs' %}">You can find it here</a>
+        Need help formatting your package?
+        <a href="https://wiki.thunderstore.io/creating-a-package">Check out the Thunderstore wiki</a>
     </p>
 </div>
 <div class="mb-3 mt-3 alert alert-info" role="alert">


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3490ea2f-7151-42f0-97d5-3b14106c0c12)
is now
![image](https://github.com/user-attachments/assets/66cd8256-5360-47b6-8d00-9aaadce4e2fe)

which leads to https://wiki.thunderstore.io/ instead of http://thunderstore.io/package/create/docs/