### PR TITLE
Refactor team disband and create views(TS-2426)

### DIFF
--- a/django/thunderstore/repository/forms/team.py
+++ b/django/thunderstore/repository/forms/team.py
@@ -5,13 +5,7 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 
 from thunderstore.core.types import UserType
-from thunderstore.repository.models import (
-    Namespace,
-    Team,
-    TeamMember,
-    TeamMemberRole,
-    transaction,
-)
+from thunderstore.repository.models import Team, TeamMember, TeamMemberRole, transaction
 from thunderstore.repository.validators import PackageReferenceComponentValidator
 
 User = get_user_model()
@@ -29,27 +23,6 @@ class CreateTeamForm(forms.ModelForm):
     def __init__(self, user: UserType, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.user = user
-
-    def clean_name(self):
-        name = self.cleaned_data["name"]
-        if Team.objects.filter(name__iexact=name.lower()).exists():
-            raise ValidationError(f"A team with the provided name already exists")
-        if Namespace.objects.filter(name__iexact=name.lower()).exists():
-            raise ValidationError("A namespace with the provided name already exists")
-        return name
-
-    def clean(self):
-        if not self.user or not self.user.is_authenticated or not self.user.is_active:
-            raise ValidationError("Must be authenticated to create teams")
-        if getattr(self.user, "service_account", None) is not None:
-            raise ValidationError("Service accounts cannot create teams")
-        return super().clean()
-
-    @transaction.atomic
-    def save(self, *args, **kwargs) -> Team:
-        instance = super().save()
-        instance.add_member(user=self.user, role=TeamMemberRole.owner)
-        return instance
 
 
 class AddTeamMemberForm(forms.ModelForm):
@@ -151,21 +124,15 @@ class DisbandTeamForm(forms.ModelForm):
         self.user = user
 
     def clean_verification(self):
-        data = self.cleaned_data["verification"]
-        if data != self.instance.name:
+        verification = self.cleaned_data["verification"]
+        if verification != self.instance.name:
             raise forms.ValidationError("Invalid verification")
-        return data
+        return verification
 
     def clean(self):
         if not self.instance.pk:
             raise ValidationError("Missing team instance")
-        self.instance.ensure_user_can_disband(self.user)
         return super().clean()
-
-    @transaction.atomic
-    def save(self, **kwargs):
-        self.instance.ensure_user_can_disband(self.user)
-        self.instance.delete()
 
 
 class DonationLinkTeamForm(forms.ModelForm):

--- a/django/thunderstore/repository/views/team_settings.py
+++ b/django/thunderstore/repository/views/team_settings.py
@@ -16,6 +16,7 @@ from thunderstore.account.forms import (
     CreateServiceAccountForm,
     DeleteServiceAccountForm,
 )
+from thunderstore.api.cyberstorm.services import team as team_service
 from thunderstore.core.mixins import RequireAuthenticationMixin
 from thunderstore.core.utils import capture_exception
 from thunderstore.frontend.views import SettingsViewMixin
@@ -26,7 +27,6 @@ from thunderstore.repository.forms import (
     DonationLinkTeamForm,
     EditTeamMemberForm,
     RemoveTeamMemberForm,
-    TeamMemberRole,
 )
 from thunderstore.repository.models import Team, TeamMember, reverse
 
@@ -152,8 +152,13 @@ class SettingsTeamCreateView(
 
     @transaction.atomic
     def form_valid(self, form):
-        instance = form.save()
-        return redirect(instance.settings_url)
+        try:
+            team_name = form.cleaned_data["name"]
+            team_service.create_team(self.request.user, team_name)
+        except ValidationError as e:
+            form.add_error(None, e)
+            return self.form_invalid(form)
+        return redirect(reverse("settings.teams"))
 
 
 class SettingsTeamDisbandView(TeamDetailView, UserFormKwargs, FormView):
@@ -174,7 +179,11 @@ class SettingsTeamDisbandView(TeamDetailView, UserFormKwargs, FormView):
 
     @transaction.atomic
     def form_valid(self, form):
-        form.save()
+        try:
+            team_service.disband_team(self.request.user, self.object.name)
+        except ValidationError as e:
+            form.add_error(None, e)
+            return self.form_invalid(form)
         return redirect(reverse("settings.teams"))
 
 


### PR DESCRIPTION
Use the team services create_team and disband_team in the form views responsible for creating and disbanding teams. Catch the errors manually which are raised in the services and add them to the form.

Remove redunant functionality from the forms, such as validations that are handled in the services and remove the save functions from the forms since this is handled by the services.

Refs. TS-2426