### PR TITLE
Refactor version_count in package_listing view (TS-2447)

### DIFF
--- a/django/thunderstore/api/cyberstorm/tests/test_package_listing.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_package_listing.py
@@ -238,7 +238,7 @@ def test_package_listing_view__returns_info(api_client: APIClient) -> None:
     assert actual["team"]["name"] == listing.package.owner.name
     assert len(actual["team"]["members"]) == 0
     assert actual["website_url"] == latest.website_url
-    assert actual["version_count"] == listing.package.version_count
+    assert actual["version_count"] == 1
 
 
 @pytest.mark.django_db

--- a/django/thunderstore/api/cyberstorm/views/package_listing.py
+++ b/django/thunderstore/api/cyberstorm/views/package_listing.py
@@ -106,7 +106,7 @@ class ResponseSerializer(serializers.Serializer):
     latest_version_number = serializers.CharField(
         source="package.latest.version_number",
     )
-    version_count = serializers.IntegerField(source="package.version_count")
+    version_count = serializers.IntegerField()
     name = serializers.CharField(source="package.name")
     namespace = serializers.CharField(source="package.namespace.name")
     rating_count = serializers.IntegerField(min_value=0)
@@ -172,6 +172,9 @@ def get_custom_package_listing(
             has_changelog=ExpressionWrapper(
                 Q(package__latest__changelog__isnull=False),
                 output_field=BooleanField(),
+            ),
+            version_count=Count(
+                "package__versions", filter=Q(package__versions__is_active=True)
             ),
         )
     )

--- a/django/thunderstore/repository/models/package.py
+++ b/django/thunderstore/repository/models/package.py
@@ -183,10 +183,6 @@ class Package(AdminLinkMixin, models.Model):
         )
 
     @cached_property
-    def version_count(self):
-        return self.versions.filter(is_active=True).count()
-
-    @cached_property
     def downloads(self):
         # TODO: Caching
         return self.versions.aggregate(downloads=Sum("downloads"))["downloads"]


### PR DESCRIPTION
Add the version_count to the get_custom_package_listing queryset as an annotation instead of fetching the version_count from the model's property function.

Remove the version_count property function from the package model.

Update tests accordingly.

Refs. TS-2447