### PR TITLE
Service layer to existing cyberstorm views (TS-2429)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,22 +21,22 @@ repos:
     hooks:
       - id: prettier
         exclude: "^(django/|builder/src/[a-z]+/vendor/)"
-  - repo: https://github.com/PyCQA/flake8
-    rev: "3.8.4"
-    hooks:
-      - id: flake8
-        exclude: "migrations/"
-        args:
-          - "--exit-zero"
-        verbose: true
-        additional_dependencies:
-          - "flake8-2020==1.6.0"
-          - "flake8-broken-line==0.3.0"
-          - "flake8-bugbear==20.11.1"
-          - "flake8-builtins==1.5.3"
-          - "flake8-commas==2.0.0"
-          - "flake8-comprehensions==3.3.1"
-          - "flake8-pie==0.6.1"
-          - "flake8-printf-formatting==1.1.0"
-          - "flake8-pytest-style==1.3.0"
-          - "pep8-naming==0.11.1"
+#  - repo: https://github.com/PyCQA/flake8
+#    rev: "3.8.4"
+#    hooks:
+#      - id: flake8
+#        exclude: "migrations/"
+#        args:
+#          - "--exit-zero"
+#        verbose: true
+#        additional_dependencies:
+#          - "flake8-2020==1.6.0"
+#          - "flake8-broken-line==0.3.0"
+#          - "flake8-bugbear==20.11.1"
+#          - "flake8-builtins==1.5.3"
+#          - "flake8-commas==2.0.0"
+#          - "flake8-comprehensions==3.3.1"
+#          - "flake8-pie==0.6.1"
+#          - "flake8-printf-formatting==1.1.0"
+#          - "flake8-pytest-style==1.3.0"
+#          - "pep8-naming==0.11.1"

--- a/django/thunderstore/api/cyberstorm/services/package.py
+++ b/django/thunderstore/api/cyberstorm/services/package.py
@@ -1,31 +1,21 @@
 from typing import Literal, Tuple, Union
 
-from django.core.exceptions import ValidationError
 from django.db import transaction
 
-from thunderstore.core.exceptions import PermissionValidationError
 from thunderstore.core.types import UserType
 from thunderstore.repository.models import Package, PackageRating
 
 
 @transaction.atomic
 def deprecate_package(agent: UserType, package: Package) -> Package:
-    try:
-        package.ensure_user_can_manage_deprecation(agent)
-    except ValidationError as e:
-        raise PermissionValidationError(e.message)
-
+    package.ensure_user_can_manage_deprecation(agent)
     package.deprecate()
     return package
 
 
 @transaction.atomic
 def undeprecate_package(agent: UserType, package: Package) -> Package:
-    try:
-        package.ensure_user_can_manage_deprecation(agent)
-    except ValidationError as e:
-        raise PermissionValidationError(e.message)
-
+    package.ensure_user_can_manage_deprecation(agent)
     package.undeprecate()
     return package
 

--- a/django/thunderstore/api/cyberstorm/services/package.py
+++ b/django/thunderstore/api/cyberstorm/services/package.py
@@ -1,3 +1,5 @@
+from typing import Literal, Tuple, Union
+
 from django.core.exceptions import ValidationError
 from django.db import transaction
 
@@ -28,8 +30,13 @@ def undeprecate_package(agent: UserType, package: Package) -> Package:
     return package
 
 
+RATING_STATE = Union[Literal["rated"], Literal["unrated"]]
+
+
 @transaction.atomic
-def rate_package(agent: UserType, package: Package, target_state: str):
+def rate_package(
+    agent: UserType, package: Package, target_state: RATING_STATE
+) -> Tuple[int, RATING_STATE]:
     result_state = PackageRating.rate_package(
         agent=agent,
         package=package,

--- a/django/thunderstore/api/cyberstorm/services/package.py
+++ b/django/thunderstore/api/cyberstorm/services/package.py
@@ -1,0 +1,40 @@
+from django.core.exceptions import ValidationError
+from django.db import transaction
+
+from thunderstore.core.exceptions import PermissionValidationError
+from thunderstore.core.types import UserType
+from thunderstore.repository.models import Package, PackageRating
+
+
+@transaction.atomic
+def deprecate_package(package: Package, user: UserType) -> Package:
+    try:
+        package.ensure_user_can_manage_deprecation(user)
+    except ValidationError as e:
+        raise PermissionValidationError(e.message)
+
+    package.deprecate()
+    return package
+
+
+@transaction.atomic
+def undeprecate_package(package: Package, user: UserType) -> Package:
+    try:
+        package.ensure_user_can_manage_deprecation(user)
+    except ValidationError as e:
+        raise PermissionValidationError(e.message)
+
+    package.undeprecate()
+    return package
+
+
+@transaction.atomic
+def rate_package(package: Package, agent: UserType, target_state: str):
+    result_state = PackageRating.rate_package(
+        agent=agent,
+        package=package,
+        target_state=target_state,
+    )
+
+    package = Package.objects.get(id=package.id)
+    return package.rating_score, result_state

--- a/django/thunderstore/api/cyberstorm/services/package.py
+++ b/django/thunderstore/api/cyberstorm/services/package.py
@@ -7,9 +7,9 @@ from thunderstore.repository.models import Package, PackageRating
 
 
 @transaction.atomic
-def deprecate_package(package: Package, user: UserType) -> Package:
+def deprecate_package(agent: UserType, package: Package) -> Package:
     try:
-        package.ensure_user_can_manage_deprecation(user)
+        package.ensure_user_can_manage_deprecation(agent)
     except ValidationError as e:
         raise PermissionValidationError(e.message)
 
@@ -18,9 +18,9 @@ def deprecate_package(package: Package, user: UserType) -> Package:
 
 
 @transaction.atomic
-def undeprecate_package(package: Package, user: UserType) -> Package:
+def undeprecate_package(agent: UserType, package: Package) -> Package:
     try:
-        package.ensure_user_can_manage_deprecation(user)
+        package.ensure_user_can_manage_deprecation(agent)
     except ValidationError as e:
         raise PermissionValidationError(e.message)
 
@@ -29,7 +29,7 @@ def undeprecate_package(package: Package, user: UserType) -> Package:
 
 
 @transaction.atomic
-def rate_package(package: Package, agent: UserType, target_state: str):
+def rate_package(agent: UserType, package: Package, target_state: str):
     result_state = PackageRating.rate_package(
         agent=agent,
         package=package,

--- a/django/thunderstore/api/cyberstorm/services/package_listing.py
+++ b/django/thunderstore/api/cyberstorm/services/package_listing.py
@@ -1,7 +1,5 @@
-from django.core.exceptions import ValidationError
 from django.db import transaction
 
-from thunderstore.core.exceptions import PermissionValidationError
 from thunderstore.core.types import UserType
 from thunderstore.repository.models import PackageListing
 from thunderstore.repository.views.package._utils import get_package_listing_or_404
@@ -11,11 +9,8 @@ from thunderstore.repository.views.package._utils import get_package_listing_or_
 def update_categories(
     agent: UserType, categories: list, listing: PackageListing
 ) -> None:
-    try:
-        listing.ensure_update_categories_permission(agent)
-        listing.update_categories(agent=agent, categories=categories)
-    except ValidationError as e:
-        raise PermissionValidationError(e.message)
+    listing.ensure_update_categories_permission(agent)
+    listing.update_categories(agent=agent, categories=categories)
 
     get_package_listing_or_404.clear_cache_with_args(
         namespace=listing.package.namespace.name,
@@ -31,13 +26,9 @@ def reject_package_listing(
     notes: str,
     listing: PackageListing,
 ) -> None:
-    try:
-        listing.community.ensure_user_can_moderate_packages(agent)
-    except ValidationError as e:
-        raise PermissionValidationError(e.message)
+    listing.community.ensure_user_can_moderate_packages(agent)
 
     listing.reject(agent=agent, rejection_reason=reason, internal_notes=notes)
-
     listing.clear_review_request()
 
     get_package_listing_or_404.clear_cache_with_args(
@@ -51,13 +42,9 @@ def reject_package_listing(
 def approve_package_listing(
     agent: UserType, notes: str, listing: PackageListing
 ) -> None:
-    try:
-        listing.community.ensure_user_can_moderate_packages(agent)
-    except ValidationError as e:
-        raise PermissionValidationError(e.message)
+    listing.community.ensure_user_can_moderate_packages(agent)
 
     listing.approve(agent=agent, internal_notes=notes)
-
     listing.clear_review_request()
 
     get_package_listing_or_404.clear_cache_with_args(

--- a/django/thunderstore/api/cyberstorm/services/package_listing.py
+++ b/django/thunderstore/api/cyberstorm/services/package_listing.py
@@ -9,11 +9,11 @@ from thunderstore.repository.views.package._utils import get_package_listing_or_
 
 @transaction.atomic
 def update_categories(
-    categories: list, user: UserType, listing: PackageListing
+    agent: UserType, categories: list, listing: PackageListing
 ) -> None:
     try:
-        listing.ensure_update_categories_permission(user)
-        listing.update_categories(agent=user, categories=categories)
+        listing.ensure_update_categories_permission(agent)
+        listing.update_categories(agent=agent, categories=categories)
     except ValidationError as e:
         raise PermissionValidationError(e.message)
 
@@ -26,9 +26,9 @@ def update_categories(
 
 @transaction.atomic
 def reject_package_listing(
+    agent: UserType,
     reason: str,
     notes: str,
-    agent: UserType,
     listing: PackageListing,
 ) -> None:
     try:
@@ -49,7 +49,7 @@ def reject_package_listing(
 
 @transaction.atomic
 def approve_package_listing(
-    notes: str, agent: UserType, listing: PackageListing
+    agent: UserType, notes: str, listing: PackageListing
 ) -> None:
     try:
         listing.community.ensure_user_can_moderate_packages(agent)

--- a/django/thunderstore/api/cyberstorm/services/package_listing.py
+++ b/django/thunderstore/api/cyberstorm/services/package_listing.py
@@ -1,0 +1,67 @@
+from django.core.exceptions import ValidationError
+from django.db import transaction
+
+from thunderstore.core.exceptions import PermissionValidationError
+from thunderstore.core.types import UserType
+from thunderstore.repository.models import PackageListing
+from thunderstore.repository.views.package._utils import get_package_listing_or_404
+
+
+@transaction.atomic
+def update_categories(
+    categories: list, user: UserType, listing: PackageListing
+) -> None:
+    try:
+        listing.ensure_update_categories_permission(user)
+        listing.update_categories(agent=user, categories=categories)
+    except ValidationError as e:
+        raise PermissionValidationError(e.message)
+
+    get_package_listing_or_404.clear_cache_with_args(
+        namespace=listing.package.namespace.name,
+        name=listing.package.name,
+        community=listing.community,
+    )
+
+
+@transaction.atomic
+def reject_package_listing(
+    reason: str,
+    notes: str,
+    agent: UserType,
+    listing: PackageListing,
+) -> None:
+    try:
+        listing.community.ensure_user_can_moderate_packages(agent)
+    except ValidationError as e:
+        raise PermissionValidationError(e.message)
+
+    listing.reject(agent=agent, rejection_reason=reason, internal_notes=notes)
+
+    listing.clear_review_request()
+
+    get_package_listing_or_404.clear_cache_with_args(
+        namespace=listing.package.namespace.name,
+        name=listing.package.name,
+        community=listing.community,
+    )
+
+
+@transaction.atomic
+def approve_package_listing(
+    notes: str, agent: UserType, listing: PackageListing
+) -> None:
+    try:
+        listing.community.ensure_user_can_moderate_packages(agent)
+    except ValidationError as e:
+        raise PermissionValidationError(e.message)
+
+    listing.approve(agent=agent, internal_notes=notes)
+
+    listing.clear_review_request()
+
+    get_package_listing_or_404.clear_cache_with_args(
+        namespace=listing.package.namespace.name,
+        name=listing.package.name,
+        community=listing.community,
+    )

--- a/django/thunderstore/api/cyberstorm/services/team.py
+++ b/django/thunderstore/api/cyberstorm/services/team.py
@@ -2,6 +2,7 @@ from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.shortcuts import get_object_or_404
 
+from thunderstore.core.exceptions import PermissionValidationError
 from thunderstore.core.types import UserType
 from thunderstore.repository.models import Namespace, Team
 from thunderstore.repository.models.team import TeamMemberRole
@@ -19,9 +20,9 @@ def disband_team(user: UserType, team_name: str) -> None:
 @transaction.atomic
 def create_team(user: UserType, team_name: str) -> Team:
     if not user or not user.is_authenticated or not user.is_active:
-        raise ValidationError("Must be authenticated to create teams")
+        raise PermissionValidationError("Must be authenticated to create teams")
     if getattr(user, "service_account", None) is not None:
-        raise ValidationError("Service accounts cannot create teams")
+        raise PermissionValidationError("Service accounts cannot create teams")
     if Team.objects.filter(name=team_name).exists():
         raise ValidationError("A team with the provided name already exists")
     if Namespace.objects.filter(name=team_name).exists():

--- a/django/thunderstore/api/cyberstorm/tests/services/test_package_listing_services.py
+++ b/django/thunderstore/api/cyberstorm/tests/services/test_package_listing_services.py
@@ -33,11 +33,11 @@ def test_update_categories(
     if not can_moderate:
         with pytest.raises(PermissionValidationError):
             update_categories(
-                categories=categories, user=user, listing=active_package_listing
+                agent=user, categories=categories, listing=active_package_listing
             )
     else:
         update_categories(
-            categories=categories, user=user, listing=active_package_listing
+            agent=user, categories=categories, listing=active_package_listing
         )
         active_package_listing.refresh_from_db()
         assert active_package_listing.categories.count() == 1
@@ -63,16 +63,16 @@ def test_reject_package_listing(active_package_listing, user_role, can_reject):
     if not can_reject:
         with pytest.raises(PermissionValidationError):
             reject_package_listing(
+                agent=agent,
                 reason="Inappropriate content",
                 notes="This package contains inappropriate content.",
-                agent=agent,
                 listing=active_package_listing,
             )
     else:
         reject_package_listing(
+            agent=agent,
             reason="Inappropriate content",
             notes="This package contains inappropriate content.",
-            agent=agent,
             listing=active_package_listing,
         )
         active_package_listing.refresh_from_db()
@@ -98,14 +98,14 @@ def test_approve_package_listing(active_package_listing, user_role, can_approve)
     if not can_approve:
         with pytest.raises(PermissionValidationError):
             approve_package_listing(
-                notes="This package is approved.",
                 agent=agent,
+                notes="This package is approved.",
                 listing=active_package_listing,
             )
     else:
         approve_package_listing(
-            notes="This package is approved.",
             agent=agent,
+            notes="This package is approved.",
             listing=active_package_listing,
         )
         active_package_listing.refresh_from_db()
@@ -118,8 +118,8 @@ def test_approve_package_listing(active_package_listing, user_role, can_approve)
 def test_approve_package_listing_no_community_membership(active_package_listing, user):
     with pytest.raises(PermissionValidationError):
         approve_package_listing(
-            notes="This package is approved.",
             agent=user,
+            notes="This package is approved.",
             listing=active_package_listing,
         )
 
@@ -132,7 +132,7 @@ def test_update_categories_no_community_membership(
 
     with pytest.raises(PermissionValidationError):
         update_categories(
-            categories=categories, user=user, listing=active_package_listing
+            agent=user, categories=categories, listing=active_package_listing
         )
 
 
@@ -140,8 +140,8 @@ def test_update_categories_no_community_membership(
 def test_reject_package_listing_no_community_membership(active_package_listing, user):
     with pytest.raises(PermissionValidationError):
         reject_package_listing(
+            agent=user,
             reason="Inappropriate content",
             notes="This package contains inappropriate content.",
-            agent=user,
             listing=active_package_listing,
         )

--- a/django/thunderstore/api/cyberstorm/tests/services/test_package_listing_services.py
+++ b/django/thunderstore/api/cyberstorm/tests/services/test_package_listing_services.py
@@ -1,0 +1,148 @@
+import pytest
+from thunderstore.core.exceptions import PermissionValidationError
+
+from thunderstore.api.cyberstorm.services.package_listing import (
+    approve_package_listing,
+    reject_package_listing,
+    update_categories,
+)
+from thunderstore.community.consts import PackageListingReviewStatus
+
+from conftest import TestUserTypes
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "user_role, can_moderate",
+    [
+        (TestUserTypes.no_user, False),
+        (TestUserTypes.unauthenticated, False),
+        (TestUserTypes.regular_user, False),
+        (TestUserTypes.deactivated_user, False),
+        (TestUserTypes.service_account, False),
+        (TestUserTypes.site_admin, True),
+        (TestUserTypes.superuser, True),
+    ],
+)
+def test_update_categories(
+    user, active_package_listing, package_category, user_role, can_moderate
+):
+
+    categories = [package_category]
+    user = TestUserTypes.get_user_by_type(user_role)
+
+    if not can_moderate:
+        with pytest.raises(PermissionValidationError):
+            update_categories(
+                categories=categories, user=user, listing=active_package_listing
+            )
+    else:
+        update_categories(
+            categories=categories, user=user, listing=active_package_listing
+        )
+        active_package_listing.refresh_from_db()
+        assert active_package_listing.categories.count() == 1
+        assert package_category in active_package_listing.categories.all()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "user_role, can_reject",
+    [
+        (TestUserTypes.no_user, False),
+        (TestUserTypes.unauthenticated, False),
+        (TestUserTypes.regular_user, False),
+        (TestUserTypes.deactivated_user, False),
+        (TestUserTypes.service_account, False),
+        (TestUserTypes.site_admin, True),
+        (TestUserTypes.superuser, True),
+    ],
+)
+def test_reject_package_listing(active_package_listing, user_role, can_reject):
+    agent = TestUserTypes.get_user_by_type(user_role)
+
+    if not can_reject:
+        with pytest.raises(PermissionValidationError):
+            reject_package_listing(
+                reason="Inappropriate content",
+                notes="This package contains inappropriate content.",
+                agent=agent,
+                listing=active_package_listing,
+            )
+    else:
+        reject_package_listing(
+            reason="Inappropriate content",
+            notes="This package contains inappropriate content.",
+            agent=agent,
+            listing=active_package_listing,
+        )
+        active_package_listing.refresh_from_db()
+        assert active_package_listing.is_rejected is True
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "user_role, can_approve",
+    [
+        (TestUserTypes.no_user, False),
+        (TestUserTypes.unauthenticated, False),
+        (TestUserTypes.regular_user, False),
+        (TestUserTypes.deactivated_user, False),
+        (TestUserTypes.service_account, False),
+        (TestUserTypes.site_admin, True),
+        (TestUserTypes.superuser, True),
+    ],
+)
+def test_approve_package_listing(active_package_listing, user_role, can_approve):
+    agent = TestUserTypes.get_user_by_type(user_role)
+
+    if not can_approve:
+        with pytest.raises(PermissionValidationError):
+            approve_package_listing(
+                notes="This package is approved.",
+                agent=agent,
+                listing=active_package_listing,
+            )
+    else:
+        approve_package_listing(
+            notes="This package is approved.",
+            agent=agent,
+            listing=active_package_listing,
+        )
+        active_package_listing.refresh_from_db()
+        assert active_package_listing.review_status == (
+            PackageListingReviewStatus.approved
+        )
+
+
+@pytest.mark.django_db
+def test_approve_package_listing_no_community_membership(active_package_listing, user):
+    with pytest.raises(PermissionValidationError):
+        approve_package_listing(
+            notes="This package is approved.",
+            agent=user,
+            listing=active_package_listing,
+        )
+
+
+@pytest.mark.django_db
+def test_update_categories_no_community_membership(
+    user, active_package_listing, package_category
+):
+    categories = [package_category]
+
+    with pytest.raises(PermissionValidationError):
+        update_categories(
+            categories=categories, user=user, listing=active_package_listing
+        )
+
+
+@pytest.mark.django_db
+def test_reject_package_listing_no_community_membership(active_package_listing, user):
+    with pytest.raises(PermissionValidationError):
+        reject_package_listing(
+            reason="Inappropriate content",
+            notes="This package contains inappropriate content.",
+            agent=user,
+            listing=active_package_listing,
+        )

--- a/django/thunderstore/api/cyberstorm/tests/services/test_package_listing_services.py
+++ b/django/thunderstore/api/cyberstorm/tests/services/test_package_listing_services.py
@@ -1,14 +1,13 @@
 import pytest
-from thunderstore.core.exceptions import PermissionValidationError
 
+from conftest import TestUserTypes
 from thunderstore.api.cyberstorm.services.package_listing import (
     approve_package_listing,
     reject_package_listing,
     update_categories,
 )
 from thunderstore.community.consts import PackageListingReviewStatus
-
-from conftest import TestUserTypes
+from thunderstore.core.exceptions import PermissionValidationError
 
 
 @pytest.mark.django_db

--- a/django/thunderstore/api/cyberstorm/tests/services/test_package_services.py
+++ b/django/thunderstore/api/cyberstorm/tests/services/test_package_services.py
@@ -1,0 +1,125 @@
+import pytest
+from thunderstore.core.exceptions import PermissionValidationError
+from rest_framework.exceptions import PermissionDenied
+from django.core.exceptions import ValidationError
+
+from thunderstore.api.cyberstorm.services.package import (
+    deprecate_package,
+    rate_package,
+    undeprecate_package,
+)
+from thunderstore.repository.models import TeamMember, TeamMemberRole
+from conftest import TestUserTypes
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "user_role, can_deprecate",
+    [
+        (TestUserTypes.no_user, False),
+        (TestUserTypes.unauthenticated, False),
+        (TestUserTypes.regular_user, False),
+        (TestUserTypes.deactivated_user, False),
+        (TestUserTypes.service_account, False),
+        (TestUserTypes.site_admin, True),
+        (TestUserTypes.superuser, True),
+    ],
+)
+def test_deprecate_package_user_roles(active_package, user_role, can_deprecate):
+    active_package.is_deprecated = False
+    active_package.save()
+    user = TestUserTypes.get_user_by_type(user_role)
+    if not can_deprecate:
+        with pytest.raises(PermissionValidationError):
+            deprecate_package(active_package, user)
+    else:
+        deprecate_package(active_package, user)
+        active_package.refresh_from_db()
+        assert active_package.is_deprecated is True
+
+
+@pytest.mark.django_db
+def test_deprecate_package_not_team_member(package, user):
+    error_msg = "Must be a member of team to manage package"
+    with pytest.raises(PermissionValidationError, match=error_msg):
+        deprecate_package(package, user)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "user_role, can_undeprecate",
+    [
+        (TestUserTypes.no_user, False),
+        (TestUserTypes.unauthenticated, False),
+        (TestUserTypes.regular_user, False),
+        (TestUserTypes.deactivated_user, False),
+        (TestUserTypes.service_account, False),
+        (TestUserTypes.site_admin, True),
+        (TestUserTypes.superuser, True),
+    ],
+)
+def test_undeprecate_package_user_roles(active_package, user_role, can_undeprecate):
+    active_package.is_deprecated = True
+    active_package.save()
+    user = TestUserTypes.get_user_by_type(user_role)
+    if not can_undeprecate:
+        with pytest.raises(PermissionValidationError):
+            undeprecate_package(active_package, user)
+    else:
+        undeprecate_package(active_package, user)
+        active_package.refresh_from_db()
+        assert active_package.is_deprecated is False
+
+
+@pytest.mark.django_db
+def test_undeprecate_package(package, user):
+    TeamMember.objects.create(
+        user=user,
+        team=package.owner,
+        role=TeamMemberRole.owner,
+    )
+
+    package.is_deprecated = True
+    package.save()
+
+    assert package.is_deprecated is True
+    package = undeprecate_package(package, user)
+    assert package.is_deprecated is False
+
+
+@pytest.mark.django_db
+def test_undeprecate_package_not_team_member(package, user):
+    error_msg = "Must be a member of team to manage package"
+    with pytest.raises(PermissionValidationError, match=error_msg):
+        undeprecate_package(package, user)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "user_role, can_rate",
+    [
+        (TestUserTypes.no_user, False),
+        (TestUserTypes.unauthenticated, False),
+        (TestUserTypes.regular_user, True),
+        (TestUserTypes.deactivated_user, False),
+        (TestUserTypes.service_account, False),
+        (TestUserTypes.site_admin, True),
+        (TestUserTypes.superuser, True),
+    ],
+)
+def test_rate_package_user_roles(active_package, user_role, can_rate):
+    agent = TestUserTypes.get_user_by_type(user_role)
+    if not can_rate:
+        with pytest.raises(PermissionDenied):
+            rate_package(active_package, agent, "rated")
+    else:
+        rating_score, result_state = rate_package(active_package, agent, "rated")
+        assert rating_score == 1
+        assert result_state == "rated"
+
+
+@pytest.mark.django_db
+def test_rate_package_invalid_target_state(active_package, user):
+    error_msg = "Invalid target_state"
+    with pytest.raises(ValidationError, match=error_msg):
+        rate_package(active_package, user, "invalid_state")

--- a/django/thunderstore/api/cyberstorm/tests/services/test_package_services.py
+++ b/django/thunderstore/api/cyberstorm/tests/services/test_package_services.py
@@ -1,15 +1,15 @@
 import pytest
-from thunderstore.core.exceptions import PermissionValidationError
-from rest_framework.exceptions import PermissionDenied
 from django.core.exceptions import ValidationError
+from rest_framework.exceptions import PermissionDenied
 
+from conftest import TestUserTypes
 from thunderstore.api.cyberstorm.services.package import (
     deprecate_package,
     rate_package,
     undeprecate_package,
 )
+from thunderstore.core.exceptions import PermissionValidationError
 from thunderstore.repository.models import TeamMember, TeamMemberRole
-from conftest import TestUserTypes
 
 
 @pytest.mark.django_db

--- a/django/thunderstore/api/cyberstorm/tests/services/test_package_services.py
+++ b/django/thunderstore/api/cyberstorm/tests/services/test_package_services.py
@@ -28,12 +28,12 @@ from thunderstore.repository.models import TeamMember, TeamMemberRole
 def test_deprecate_package_user_roles(active_package, user_role, can_deprecate):
     active_package.is_deprecated = False
     active_package.save()
-    user = TestUserTypes.get_user_by_type(user_role)
+    agent = TestUserTypes.get_user_by_type(user_role)
     if not can_deprecate:
         with pytest.raises(PermissionValidationError):
-            deprecate_package(active_package, user)
+            deprecate_package(agent, active_package)
     else:
-        deprecate_package(active_package, user)
+        deprecate_package(agent, active_package)
         active_package.refresh_from_db()
         assert active_package.is_deprecated is True
 
@@ -42,7 +42,7 @@ def test_deprecate_package_user_roles(active_package, user_role, can_deprecate):
 def test_deprecate_package_not_team_member(package, user):
     error_msg = "Must be a member of team to manage package"
     with pytest.raises(PermissionValidationError, match=error_msg):
-        deprecate_package(package, user)
+        deprecate_package(user, package)
 
 
 @pytest.mark.django_db
@@ -61,12 +61,12 @@ def test_deprecate_package_not_team_member(package, user):
 def test_undeprecate_package_user_roles(active_package, user_role, can_undeprecate):
     active_package.is_deprecated = True
     active_package.save()
-    user = TestUserTypes.get_user_by_type(user_role)
+    agent = TestUserTypes.get_user_by_type(user_role)
     if not can_undeprecate:
         with pytest.raises(PermissionValidationError):
-            undeprecate_package(active_package, user)
+            undeprecate_package(agent, active_package)
     else:
-        undeprecate_package(active_package, user)
+        undeprecate_package(agent, active_package)
         active_package.refresh_from_db()
         assert active_package.is_deprecated is False
 
@@ -83,7 +83,7 @@ def test_undeprecate_package(package, user):
     package.save()
 
     assert package.is_deprecated is True
-    package = undeprecate_package(package, user)
+    package = undeprecate_package(user, package)
     assert package.is_deprecated is False
 
 
@@ -91,7 +91,7 @@ def test_undeprecate_package(package, user):
 def test_undeprecate_package_not_team_member(package, user):
     error_msg = "Must be a member of team to manage package"
     with pytest.raises(PermissionValidationError, match=error_msg):
-        undeprecate_package(package, user)
+        undeprecate_package(user, package)
 
 
 @pytest.mark.django_db
@@ -111,9 +111,9 @@ def test_rate_package_user_roles(active_package, user_role, can_rate):
     agent = TestUserTypes.get_user_by_type(user_role)
     if not can_rate:
         with pytest.raises(PermissionDenied):
-            rate_package(active_package, agent, "rated")
+            rate_package(agent, active_package, "rated")
     else:
-        rating_score, result_state = rate_package(active_package, agent, "rated")
+        rating_score, result_state = rate_package(agent, active_package, "rated")
         assert rating_score == 1
         assert result_state == "rated"
 
@@ -122,4 +122,4 @@ def test_rate_package_user_roles(active_package, user_role, can_rate):
 def test_rate_package_invalid_target_state(active_package, user):
     error_msg = "Invalid target_state"
     with pytest.raises(ValidationError, match=error_msg):
-        rate_package(active_package, user, "invalid_state")
+        rate_package(user, active_package, "invalid_state")

--- a/django/thunderstore/api/cyberstorm/tests/test_create_team.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_create_team.py
@@ -141,6 +141,6 @@ def test_create_team_with_service_account(api_client: APIClient, service_account
     response = make_request(api_client, "CoolestTeamNameEver")
     expected_response = {"non_field_errors": ["Service accounts cannot create teams"]}
 
-    assert response.status_code == 400
+    assert response.status_code == 403
     assert response.json() == expected_response
     assert Team.objects.filter(name="CoolestTeamNameEver").count() == 0

--- a/django/thunderstore/api/cyberstorm/tests/test_disband_team.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_disband_team.py
@@ -60,7 +60,7 @@ def test_disband_team_fail_because_user_is_not_owner(
     TeamMemberFactory(team=team, user=user, role="member")
     api_client.force_authenticate(user)
     response = make_request(api_client, team.name)
-    expected_response = {"non_field_errors": ["Must be an owner to disband team"]}
+    expected_response = {"detail": ["Must be an owner to disband team"]}
     assert response.status_code == 403
     assert response.json() == expected_response
 
@@ -73,6 +73,6 @@ def test_disband_team_fail_because_user_cannot_access_team(
 ):
     api_client.force_authenticate(user)
     response = make_request(api_client, team.name)
-    expected_response = {"non_field_errors": ["Must be a member to access team"]}
+    expected_response = {"detail": ["Must be a member to access team"]}
     assert response.status_code == 403
     assert response.json() == expected_response

--- a/django/thunderstore/api/cyberstorm/tests/test_disband_team.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_disband_team.py
@@ -61,7 +61,7 @@ def test_disband_team_fail_because_user_is_not_owner(
     api_client.force_authenticate(user)
     response = make_request(api_client, team.name)
     expected_response = {"non_field_errors": ["Must be an owner to disband team"]}
-    assert response.status_code == 400
+    assert response.status_code == 403
     assert response.json() == expected_response
 
 
@@ -74,5 +74,5 @@ def test_disband_team_fail_because_user_cannot_access_team(
     api_client.force_authenticate(user)
     response = make_request(api_client, team.name)
     expected_response = {"non_field_errors": ["Must be a member to access team"]}
-    assert response.status_code == 400
+    assert response.status_code == 403
     assert response.json() == expected_response

--- a/django/thunderstore/api/cyberstorm/tests/test_disband_team.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_disband_team.py
@@ -60,7 +60,7 @@ def test_disband_team_fail_because_user_is_not_owner(
     TeamMemberFactory(team=team, user=user, role="member")
     api_client.force_authenticate(user)
     response = make_request(api_client, team.name)
-    expected_response = {"detail": ["Must be an owner to disband team"]}
+    expected_response = {"non_field_errors": ["Must be an owner to disband team"]}
     assert response.status_code == 403
     assert response.json() == expected_response
 
@@ -73,6 +73,6 @@ def test_disband_team_fail_because_user_cannot_access_team(
 ):
     api_client.force_authenticate(user)
     response = make_request(api_client, team.name)
-    expected_response = {"detail": ["Must be a member to access team"]}
+    expected_response = {"non_field_errors": ["Must be a member to access team"]}
     assert response.status_code == 403
     assert response.json() == expected_response

--- a/django/thunderstore/api/cyberstorm/tests/test_package_listing_actions.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_package_listing_actions.py
@@ -4,8 +4,7 @@ from unittest.mock import patch
 import pytest
 from rest_framework.test import APIClient
 
-from conftest import UserType
-from thunderstore.community.consts import PackageListingReviewStatus
+from conftest import TestUserTypes, UserType
 from thunderstore.community.models import PackageCategory, PackageListing
 
 
@@ -28,147 +27,126 @@ def get_reject_url(package_listing):
     return f"{get_base_url(package_listing)}/reject/"
 
 
-@pytest.mark.django_db
-@patch(
-    "thunderstore.community.models.package_listing.PackageListing.check_update_categories_permission"
-)
-@patch(
-    "thunderstore.community.models.package_listing.PackageListing.can_be_moderated_by_user"
-)
-def test_update_categories_success(
-    mock_can_be_moderated_by_user,
-    mock_check_update_categories_permission,
-    active_package_listing: PackageListing,
+def perform_404_test(
     api_client: APIClient,
+    active_package_listing: PackageListing,
     user: UserType,
-    package_category: PackageCategory,
+    url: str,
 ):
-    mock_check_update_categories_permission.return_value = True
-    mock_can_be_moderated_by_user.return_value = True
+    active_package_listing.package.owner.add_member(user, role="owner")
     api_client.force_authenticate(user=user)
 
-    url = get_update_categories_url(active_package_listing)
-    data = json.dumps({"categories": [package_category.slug]})
+    data = json.dumps(
+        {
+            "rejection_reason": "Invalid content",
+            "internal_notes": "Some internal notes",
+        }
+    )
 
-    expected_response = {
-        "categories": [{"name": package_category.name, "slug": package_category.slug}]
+    response = api_client.post(url, data=data, content_type="application/json")
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Not found."}
+
+
+def perform_package_listing_action_test(
+    api_client: APIClient,
+    package_listing: PackageListing,
+    user_type: str,
+    url: str,
+    data: dict,
+):
+    user = TestUserTypes.get_user_by_type(user_type)
+
+    is_fake_user = user in TestUserTypes.fake_users()
+    is_unauthenticated = user_type == TestUserTypes.unauthenticated
+
+    if not is_fake_user and not is_unauthenticated:
+        api_client.force_authenticate(user=user)
+
+    data = json.dumps(data)
+    response = api_client.post(url, data=data, content_type="application/json")
+
+    package_listing.refresh_from_db()
+
+    expected_status_code = {
+        TestUserTypes.no_user: 401,
+        TestUserTypes.unauthenticated: 401,
+        TestUserTypes.regular_user: 403,
+        TestUserTypes.deactivated_user: 403,
+        TestUserTypes.service_account: 403,
+        TestUserTypes.site_admin: 200,
+        TestUserTypes.superuser: 200,
     }
 
-    assert active_package_listing.categories.count() == 0
-
-    response = api_client.post(url, data=data, content_type="application/json")
-
-    assert response.status_code == 200
-    assert response.json() == expected_response
-    assert active_package_listing.categories.count() == 1
-    assert package_category in active_package_listing.categories.all()
+    assert response.status_code == expected_status_code[user_type]
 
 
 @pytest.mark.django_db
-def test_update_categories_permission_denied(
+@pytest.mark.parametrize("user_type", TestUserTypes.options())
+def test_update_categories_success(
     active_package_listing: PackageListing,
     api_client: APIClient,
     package_category: PackageCategory,
+    user_type: str,
 ):
-    url = get_update_categories_url(active_package_listing)
-    data = json.dumps({"categories": [package_category.slug]})
 
-    expected_response = {"detail": "You do not have permission to perform this action."}
-    response = api_client.post(url, data=data, content_type="application/json")
-
-    assert response.status_code == 403
-    assert response.json() == expected_response
-
-
-@patch(
-    "thunderstore.community.models.package_listing.PackageListing.can_user_manage_approval_status"
-)
-@pytest.mark.django_db
-def test_reject_package_listing_success(
-    mock_can_user_manage_approval_status,
-    api_client: APIClient,
-    user: UserType,
-    active_package_listing: PackageListing,
-):
-    mock_can_user_manage_approval_status.return_value = True
-    api_client.force_authenticate(user=user)
-    data = json.dumps(
-        {
-            "rejection_reason": "Invalid content",
-            "internal_notes": "Some internal notes",
-        }
+    perform_package_listing_action_test(
+        api_client=api_client,
+        package_listing=active_package_listing,
+        user_type=user_type,
+        url=get_update_categories_url(active_package_listing),
+        data={"categories": [package_category.slug]},
     )
 
-    assert active_package_listing.rejection_reason != "Invalid content"
-    assert active_package_listing.notes != "Some internal notes"
-    assert active_package_listing.review_status != PackageListingReviewStatus.rejected
-
-    url = get_reject_url(active_package_listing)
-    response = api_client.post(url, data, content_type="application/json")
-
-    active_package_listing.refresh_from_db()
-
-    assert response.status_code == 200
-    assert response.json() == {"message": "Success"}
-    assert active_package_listing.rejection_reason == "Invalid content"
-    assert active_package_listing.notes == "Some internal notes"
-    assert active_package_listing.review_status == PackageListingReviewStatus.rejected
-
 
 @pytest.mark.django_db
-def test_reject_package_listing_permission_denied(
+@pytest.mark.parametrize("user_type", TestUserTypes.options())
+def test_reject_package_listing(
     api_client: APIClient,
     active_package_listing: PackageListing,
+    user_type: str,
 ):
-    data = json.dumps(
-        {
-            "rejection_reason": "Invalid content",
-            "internal_notes": "Some internal notes",
-        }
+
+    perform_package_listing_action_test(
+        api_client=api_client,
+        package_listing=active_package_listing,
+        user_type=user_type,
+        url=get_reject_url(active_package_listing),
+        data={"rejection_reason": "Invalid content"},
     )
-    url = get_reject_url(active_package_listing)
-    response = api_client.post(url, data, content_type="application/json")
-    assert response.status_code == 403
 
 
 @pytest.mark.django_db
-@patch(
-    "thunderstore.community.models.package_listing.PackageListing.can_user_manage_approval_status"
-)
-def test_approve_package_listing_success(
-    mock_can_user_manage_approval_status,
+def test_reject_package_listing_required_fields(
     api_client: APIClient,
-    user: UserType,
     active_package_listing: PackageListing,
 ):
-    mock_can_user_manage_approval_status.return_value = True
+    user = TestUserTypes.get_user_by_type(TestUserTypes.site_admin)
     api_client.force_authenticate(user=user)
-    url = get_approve_url(active_package_listing)
 
-    assert active_package_listing.notes != "Some internal notes"
-    assert active_package_listing.review_status != PackageListingReviewStatus.approved
+    url = get_reject_url(active_package_listing)
+    response = api_client.post(
+        url, data=json.dumps({}), content_type="application/json"
+    )
 
-    data = json.dumps({"internal_notes": "Some internal notes"})
-    response = api_client.post(url, data=data, content_type="application/json")
-
-    active_package_listing.refresh_from_db()
-
-    assert response.status_code == 200
-    assert response.json() == {"message": "Success"}
-    assert active_package_listing.notes == "Some internal notes"
-    assert active_package_listing.review_status == PackageListingReviewStatus.approved
+    assert response.status_code == 400
+    assert response.json() == {"rejection_reason": ["This field is required."]}
 
 
 @pytest.mark.django_db
-def test_approve_package_listing_permission_denied(
+@pytest.mark.parametrize("user_type", TestUserTypes.options())
+def test_approve_package_listing(
     api_client: APIClient,
     active_package_listing: PackageListing,
+    user_type: str,
 ):
-    url = get_approve_url(active_package_listing)
-    data = json.dumps({"internal_notes": "Some internal notes"})
-    response = api_client.post(url, data=data, content_type="application/json")
-    active_package_listing.refresh_from_db()
-    assert response.status_code == 403
+    perform_package_listing_action_test(
+        api_client=api_client,
+        package_listing=active_package_listing,
+        user_type=user_type,
+        url=get_approve_url(active_package_listing),
+        data={},
+    )
 
 
 @pytest.mark.django_db
@@ -177,19 +155,67 @@ def test_get_community_404(
     url_action: str,
     api_client: APIClient,
     active_package_listing: PackageListing,
+    user: UserType,
 ):
-    namespace_id = active_package_listing.package.namespace.name
-    package_name = active_package_listing.package.name
     url = (
         f"/api/cyberstorm/listing/invalid_community_id/"
-        f"{namespace_id}/{package_name}/{url_action}/"
+        f"{active_package_listing.package.namespace.name}/"
+        f"{active_package_listing.package.name}/{url_action}/"
     )
+
+    perform_404_test(
+        api_client=api_client,
+        active_package_listing=active_package_listing,
+        user=user,
+        url=url,
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("url_action", ["update", "approve", "reject"])
+def test_get_package_404(
+    url_action: str,
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+    user: UserType,
+):
+    url = (
+        f"/api/cyberstorm/listing/{active_package_listing.community.identifier}/"
+        f"{active_package_listing.package.namespace.name}/"
+        f"invalid_package_name/{url_action}/"
+    )
+
+    perform_404_test(
+        api_client=api_client,
+        active_package_listing=active_package_listing,
+        user=user,
+        url=url,
+    )
+
+
+@pytest.mark.django_db
+@patch(
+    "thunderstore.community.models.package_listing.PackageListing.can_user_manage_approval_status"
+)
+def test_reject_package_listing_permission_error(
+    mock_can_user_manage_approval_status,
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+):
+    """Test that PermissionError is re-raised as PermissionDenied"""
+
+    mock_can_user_manage_approval_status.return_value = False
+
+    user = TestUserTypes.get_user_by_type(TestUserTypes.site_admin)
+    api_client.force_authenticate(user=user)
+
+    url = get_reject_url(active_package_listing)
     data = json.dumps(
         {
             "rejection_reason": "Invalid content",
             "internal_notes": "Some internal notes",
         }
     )
+
     response = api_client.post(url, data=data, content_type="application/json")
-    assert response.status_code == 404
-    assert response.json() == {"detail": "Not found."}
+    assert response.status_code == 403

--- a/django/thunderstore/api/cyberstorm/views/package_deprecate.py
+++ b/django/thunderstore/api/cyberstorm/views/package_deprecate.py
@@ -39,8 +39,8 @@ class DeprecatePackageAPIView(APIView):
         package = self.get_package(namespace_id, package_name)
 
         if should_deprecate:
-            deprecate_package(package, request.user)
+            deprecate_package(agent=request.user, package=package)
         else:
-            undeprecate_package(package, request.user)
+            undeprecate_package(agent=request.user, package=package)
 
-        return Response(status=status.HTTP_200_OK)
+        return Response("message: Success", status=status.HTTP_200_OK)

--- a/django/thunderstore/api/cyberstorm/views/package_listing_actions.py
+++ b/django/thunderstore/api/cyberstorm/views/package_listing_actions.py
@@ -1,8 +1,9 @@
+from django.shortcuts import get_object_or_404
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
-from rest_framework.exceptions import PermissionDenied
-from rest_framework.generics import GenericAPIView, get_object_or_404
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from thunderstore.api.cyberstorm.serializers.package_listing import (
     PackageListingApproveSerializer,
@@ -10,117 +11,108 @@ from thunderstore.api.cyberstorm.serializers.package_listing import (
     PackageListingRejectSerializer,
     PackageListingUpdateSerializer,
 )
-from thunderstore.community.models import Community, PackageListing
+from thunderstore.api.cyberstorm.services.package_listing import (
+    approve_package_listing,
+    reject_package_listing,
+    update_categories,
+)
+from thunderstore.repository.models import Community, PackageListing
 from thunderstore.repository.views.package._utils import get_package_listing_or_404
 
 
-class BasePackageListingActionView(GenericAPIView):
-    def get_community(self) -> Community:
-        community_id = self.kwargs.get("community_id")
-        community = get_object_or_404(Community, identifier=community_id)
-        return community
-
-    def get_object(self) -> PackageListing:
-        return get_package_listing_or_404(
-            namespace=self.kwargs["namespace_id"],
-            name=self.kwargs["package_name"],
-            community=self.get_community(),
-        )
-
-    def clear_package_listing_cache_with_args(self, listing: PackageListing) -> None:
-        get_package_listing_or_404.clear_cache_with_args(
-            namespace=listing.package.namespace.name,
-            name=listing.package.name,
-            community=listing.community,
-        )
-
-
-class UpdatePackageListingCategoriesAPIView(BasePackageListingActionView):
-    queryset = PackageListing.objects.active().select_related(
-        "community",
-        "package",
+def get_package_listing(
+    namespace_id: str, package_name: str, community_id: str
+) -> PackageListing:
+    community = get_object_or_404(Community, identifier=community_id)
+    return get_package_listing_or_404(
+        namespace=namespace_id,
+        name=package_name,
+        community=community,
     )
-    serializer_class = PackageListingUpdateSerializer
 
-    def _update_categories(self, listing: PackageListing, categories: list) -> None:
-        listing.update_categories(agent=self.request.user, categories=categories)
-        self.clear_package_listing_cache_with_args(listing)
+
+class UpdatePackageListingCategoriesAPIView(APIView):
+    permission_classes = [IsAuthenticated]
+    serializer_class = PackageListingUpdateSerializer
 
     @swagger_auto_schema(
         operation_id="cyberstorm.package_listing.update",
-        request_body=PackageListingUpdateSerializer,
-        responses={200: serializer_class()},
+        request_body=serializer_class,
+        responses={200: serializer_class},
         tags=["cyberstorm"],
     )
     def post(self, request, *args, **kwargs) -> Response:
-        listing = self.get_object()
-        if not listing.check_update_categories_permission(self.request.user):
-            raise PermissionDenied()
+        listing = get_package_listing(
+            namespace_id=kwargs["namespace_id"],
+            package_name=kwargs["package_name"],
+            community_id=kwargs["community_id"],
+        )
 
         ctx = {"community": listing.community}
         serializer = self.serializer_class(data=request.data, context=ctx)
         serializer.is_valid(raise_exception=True)
 
         categories = serializer.validated_data["categories"]
-        self._update_categories(listing, categories)
+        update_categories(categories=categories, user=request.user, listing=listing)
 
         response_serializer = PackageListingCategoriesSerializer(instance=listing)
         return Response(response_serializer.data, status=status.HTTP_200_OK)
 
 
-class RejectPackageListingAPIView(BasePackageListingActionView):
-    queryset = PackageListing.objects.select_related("community", "package")
+class RejectPackageListingAPIView(APIView):
+    permission_classes = [IsAuthenticated]
     serializer_class = PackageListingRejectSerializer
-
-    def _reject(self, listing: PackageListing, params: dict) -> None:
-        reason = params["rejection_reason"]
-        notes = params.get("internal_notes")
-        user = self.request.user
-        listing.reject(agent=user, rejection_reason=reason, internal_notes=notes)
-        listing.clear_review_request()
-        self.clear_package_listing_cache_with_args(listing)
 
     @swagger_auto_schema(
         operation_id="cyberstorm.package_listing.reject",
-        request_body=PackageListingRejectSerializer,
+        request_body=serializer_class,
         responses={200: "Success"},
         tags=["cyberstorm"],
     )
     def post(self, request, *args, **kwargs) -> Response:
-        listing = self.get_object()
+        listing = get_package_listing(
+            namespace_id=kwargs["namespace_id"],
+            package_name=kwargs["package_name"],
+            community_id=kwargs["community_id"],
+        )
+
         serializer = self.serializer_class(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        try:
-            self._reject(listing, serializer.validated_data)
-            return Response({"message": "Success"}, status=200)
-        except PermissionError:
-            raise PermissionDenied()
+        reject_package_listing(
+            reason=serializer.validated_data["rejection_reason"],
+            notes=serializer.validated_data.get("internal_notes"),
+            agent=request.user,
+            listing=listing,
+        )
+
+        return Response({"message": "Success"}, status=status.HTTP_200_OK)
 
 
-class ApprovePackageListingAPIView(BasePackageListingActionView):
-    queryset = PackageListing.objects.select_related("community", "package")
+class ApprovePackageListingAPIView(APIView):
+    permission_classes = [IsAuthenticated]
     serializer_class = PackageListingApproveSerializer
-
-    def _approve(self, listing: PackageListing, params: dict) -> None:
-        notes = params.get("internal_notes")
-        listing.approve(agent=self.request.user, internal_notes=notes)
-        listing.clear_review_request()
-        self.clear_package_listing_cache_with_args(listing)
 
     @swagger_auto_schema(
         operation_id="cyberstorm.package_listing.approve",
-        request_body=PackageListingApproveSerializer,
+        request_body=serializer_class,
         responses={200: "Success"},
         tags=["cyberstorm"],
     )
     def post(self, request, *args, **kwargs) -> Response:
-        listing = self.get_object()
+        listing = get_package_listing(
+            namespace_id=kwargs["namespace_id"],
+            package_name=kwargs["package_name"],
+            community_id=kwargs["community_id"],
+        )
+
         serializer = self.serializer_class(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        try:
-            self._approve(listing, serializer.validated_data)
-            return Response({"message": "Success"}, status=200)
-        except PermissionError:
-            raise PermissionDenied()
+        approve_package_listing(
+            notes=serializer.validated_data.get("internal_notes"),
+            agent=request.user,
+            listing=listing,
+        )
+
+        return Response({"message": "Success"}, status=status.HTTP_200_OK)

--- a/django/thunderstore/api/cyberstorm/views/package_listing_actions.py
+++ b/django/thunderstore/api/cyberstorm/views/package_listing_actions.py
@@ -16,18 +16,25 @@ from thunderstore.api.cyberstorm.services.package_listing import (
     reject_package_listing,
     update_categories,
 )
-from thunderstore.repository.models import Community, PackageListing
-from thunderstore.repository.views.package._utils import get_package_listing_or_404
+from thunderstore.repository.models import PackageListing
 
 
 def get_package_listing(
     namespace_id: str, package_name: str, community_id: str
 ) -> PackageListing:
-    community = get_object_or_404(Community, identifier=community_id)
-    return get_package_listing_or_404(
-        namespace=namespace_id,
-        name=package_name,
-        community=community,
+    return get_object_or_404(
+        PackageListing.objects.active()
+        .select_related(
+            "package",
+            "package__owner",
+            "package__latest",
+        )
+        .prefetch_related(
+            "categories",
+        ),
+        package__namespace__name=namespace_id,
+        package__name=package_name,
+        community__identifier=community_id,
     )
 
 

--- a/django/thunderstore/api/cyberstorm/views/package_listing_actions.py
+++ b/django/thunderstore/api/cyberstorm/views/package_listing_actions.py
@@ -53,7 +53,7 @@ class UpdatePackageListingCategoriesAPIView(APIView):
         serializer.is_valid(raise_exception=True)
 
         categories = serializer.validated_data["categories"]
-        update_categories(categories=categories, user=request.user, listing=listing)
+        update_categories(agent=request.user, categories=categories, listing=listing)
 
         response_serializer = PackageListingCategoriesSerializer(instance=listing)
         return Response(response_serializer.data, status=status.HTTP_200_OK)
@@ -80,9 +80,9 @@ class RejectPackageListingAPIView(APIView):
         serializer.is_valid(raise_exception=True)
 
         reject_package_listing(
+            agent=request.user,
             reason=serializer.validated_data["rejection_reason"],
             notes=serializer.validated_data.get("internal_notes"),
-            agent=request.user,
             listing=listing,
         )
 
@@ -110,8 +110,8 @@ class ApprovePackageListingAPIView(APIView):
         serializer.is_valid(raise_exception=True)
 
         approve_package_listing(
-            notes=serializer.validated_data.get("internal_notes"),
             agent=request.user,
+            notes=serializer.validated_data.get("internal_notes"),
             listing=listing,
         )
 

--- a/django/thunderstore/api/cyberstorm/views/package_rating.py
+++ b/django/thunderstore/api/cyberstorm/views/package_rating.py
@@ -43,8 +43,8 @@ class RatePackageAPIView(APIView):
         package = self.get_package(namespace_id, package_name)
 
         rating_score, result_state = rate_package(
-            package=package,
             agent=request.user,
+            package=package,
             target_state=target_state,
         )
         response_data = {"state": result_state, "score": rating_score}

--- a/django/thunderstore/api/cyberstorm/views/package_rating.py
+++ b/django/thunderstore/api/cyberstorm/views/package_rating.py
@@ -1,12 +1,13 @@
 from django.http import HttpRequest
-from rest_framework import serializers
-from rest_framework.generics import get_object_or_404
+from django.shortcuts import get_object_or_404
+from rest_framework import serializers, status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from thunderstore.api.cyberstorm.services.package import rate_package
 from thunderstore.api.utils import conditional_swagger_auto_schema
-from thunderstore.repository.models import Package, PackageRating
+from thunderstore.repository.models import Package
 
 
 class CyberstormRatePackageRequestSerializer(serializers.Serializer):
@@ -21,6 +22,14 @@ class CyberstormRatePackageResponseSerializer(serializers.Serializer):
 class RatePackageAPIView(APIView):
     permission_classes = [IsAuthenticated]
 
+    def get_package(self, namespace_name: str, package_name: str) -> Package:
+        package = get_object_or_404(
+            Package.objects.active(),
+            namespace__name=namespace_name,
+            name=package_name,
+        )
+        return package
+
     @conditional_swagger_auto_schema(
         request_body=CyberstormRatePackageRequestSerializer,
         responses={200: CyberstormRatePackageResponseSerializer},
@@ -30,22 +39,17 @@ class RatePackageAPIView(APIView):
     def post(self, request: HttpRequest, namespace_id: str, package_name: str):
         serializer = CyberstormRatePackageRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        package = get_object_or_404(
-            Package.objects.active(),
-            namespace__name=namespace_id,
-            name=package_name,
-        )
-        result_state = PackageRating.rate_package(
-            agent=request.user,
+        target_state = serializer.validated_data["target_state"]
+        package = self.get_package(namespace_id, package_name)
+
+        rating_score, result_state = rate_package(
             package=package,
-            target_state=serializer.validated_data["target_state"],
+            agent=request.user,
+            target_state=target_state,
         )
-        package = Package.objects.get(pk=package.pk)
+        response_data = {"state": result_state, "score": rating_score}
+
         return Response(
-            CyberstormRatePackageResponseSerializer(
-                {
-                    "state": result_state,
-                    "score": package.rating_score,
-                }
-            ).data
+            CyberstormRatePackageResponseSerializer(response_data).data,
+            status=status.HTTP_200_OK,
         )

--- a/django/thunderstore/community/api/experimental/tests/test_api_package_listing.py
+++ b/django/thunderstore/community/api/experimental/tests/test_api_package_listing.py
@@ -34,18 +34,14 @@ def test_api_experimental_package_listing_update_user_types(
         TestUserTypes.site_admin: True,
         TestUserTypes.superuser: True,
     }
+
     should_succeed = expected_results[user_type]
 
-    print(response.content)
     if should_succeed:
         assert response.status_code == 200
         assert response.json()["categories"] == []
     else:
         assert response.status_code == 403
-        assert (
-            response.json()["detail"]
-            == "You do not have permission to perform this action."
-        )
 
 
 @pytest.mark.django_db

--- a/django/thunderstore/community/api/experimental/tests/test_api_package_listing.py
+++ b/django/thunderstore/community/api/experimental/tests/test_api_package_listing.py
@@ -18,8 +18,7 @@ def test_api_experimental_package_listing_update_user_types(
     active_package_listing: PackageListing,
 ):
     user = TestUserTypes.get_user_by_type(user_type)
-    if user_type not in TestUserTypes.fake_users():
-        api_client.force_authenticate(user=user)
+    api_client.force_authenticate(user=user)
 
     response = api_client.post(
         f"/api/experimental/package-listing/{active_package_listing.pk}/update/",
@@ -28,8 +27,8 @@ def test_api_experimental_package_listing_update_user_types(
     )
 
     expected_error_content = {
-        TestUserTypes.no_user: {"detail": PermissionDenied.default_detail},
-        TestUserTypes.unauthenticated: {"detail": PermissionDenied.default_detail},
+        TestUserTypes.no_user: {"non_field_errors": ["Must be authenticated"]},
+        TestUserTypes.unauthenticated: {"non_field_errors": ["Must be authenticated"]},
         TestUserTypes.regular_user: {
             "non_field_errors": ["User is missing necessary roles or permissions"]
         },

--- a/django/thunderstore/community/api/experimental/views/listing.py
+++ b/django/thunderstore/community/api/experimental/views/listing.py
@@ -37,8 +37,8 @@ class PackageListingUpdateApiView(GenericAPIView):
         request_serializer.is_valid(raise_exception=True)
 
         update_categories(
+            agent=request.user,
             categories=request_serializer.validated_data["categories"],
-            user=request.user,
             listing=listing,
         )
 
@@ -70,9 +70,9 @@ class PackageListingRejectApiView(GenericAPIView):
         request_serializer.is_valid(raise_exception=True)
 
         reject_package_listing(
+            agent=request.user,
             reason=request_serializer.validated_data["rejection_reason"],
             notes=request_serializer.validated_data.get("internal_notes"),
-            agent=request.user,
             listing=listing,
         )
 
@@ -103,8 +103,8 @@ class PackageListingApproveApiView(GenericAPIView):
         request_serializer.is_valid(raise_exception=True)
 
         approve_package_listing(
-            notes=request_serializer.validated_data.get("internal_notes"),
             agent=request.user,
+            notes=request_serializer.validated_data.get("internal_notes"),
             listing=listing,
         )
 

--- a/django/thunderstore/community/models/community.py
+++ b/django/thunderstore/community/models/community.py
@@ -16,6 +16,7 @@ from thunderstore.community.models.community_membership import (
     CommunityMembership,
 )
 from thunderstore.core.enums import OptionalBoolChoice
+from thunderstore.core.exceptions import PermissionValidationError
 from thunderstore.core.mixins import TimestampMixin
 from thunderstore.core.types import UserType
 from thunderstore.core.utils import check_validity
@@ -257,7 +258,9 @@ class Community(TimestampMixin, models.Model):
         ) and not (
             user.is_superuser or user.is_staff
         ):  # TODO: Maybe remove
-            raise ValidationError("Must be a moderator or higher to manage packages")
+            raise PermissionValidationError(
+                "Must be a moderator or higher to manage packages"
+            )
 
     def ensure_user_can_manage_categories(self, user: Optional[UserType]) -> None:
         user = validate_user(user)
@@ -272,7 +275,9 @@ class Community(TimestampMixin, models.Model):
         if (not membership or membership.role not in allowed_roles) and not (
             user.is_superuser or user.is_staff
         ):  # TODO: Maybe remove
-            raise ValidationError("Must be a janitor or higher to manage categories")
+            raise PermissionValidationError(
+                "Must be a janitor or higher to manage categories"
+            )
 
     @lru_cache
     def can_user_manage_packages(self, user: Optional[UserType]) -> bool:

--- a/django/thunderstore/core/exception_handler.py
+++ b/django/thunderstore/core/exception_handler.py
@@ -2,22 +2,32 @@ from typing import Any, Optional
 
 from django.core.exceptions import ValidationError as DjangoValidationError
 from drf_yasg.openapi import Response
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.exceptions import ValidationError as DRFValidationError
 from rest_framework.serializers import as_serializer_error
 from rest_framework.views import exception_handler as drf_exception_handler
 
+from thunderstore.core.exceptions import PermissionValidationError
 
-def django_to_drf_error(error: DjangoValidationError) -> DRFValidationError:
+
+def django_validation_to_drf_error(error: DjangoValidationError) -> DRFValidationError:
     return DRFValidationError(detail=as_serializer_error(error))
 
 
 def serialize_validation_error(error: DjangoValidationError):
-    return django_to_drf_error(error).detail
+    return django_validation_to_drf_error(error).detail
 
 
 def exception_handler(exc: Exception, context: Any) -> Optional[Response]:
     if isinstance(exc, DjangoValidationError):
-        exc = django_to_drf_error(exc)
+        exc = django_validation_to_drf_error(exc)
+
+    if isinstance(exc, PermissionValidationError):
+        exc = PermissionDenied(detail=exc)
+
+    if isinstance(exc, PermissionError):
+        exc = PermissionDenied(detail=exc)
+
     response = drf_exception_handler(exc, context)
     if response:
         return response

--- a/django/thunderstore/core/exception_handler.py
+++ b/django/thunderstore/core/exception_handler.py
@@ -20,7 +20,10 @@ def serialize_validation_error(error: DjangoValidationError):
 
 def exception_handler(exc: Exception, context: Any) -> Optional[Response]:
     if isinstance(exc, PermissionValidationError):
-        exc = PermissionDenied(detail=as_serializer_error(exc))
+        if exc.is_public:
+            exc = PermissionDenied(detail=as_serializer_error(exc))
+        else:
+            exc = PermissionDenied()
 
     elif isinstance(exc, DjangoValidationError):
         exc = django_validation_to_drf_error(exc)

--- a/django/thunderstore/core/exception_handler.py
+++ b/django/thunderstore/core/exception_handler.py
@@ -19,13 +19,13 @@ def serialize_validation_error(error: DjangoValidationError):
 
 
 def exception_handler(exc: Exception, context: Any) -> Optional[Response]:
-    if isinstance(exc, DjangoValidationError):
-        exc = django_validation_to_drf_error(exc)
-
     if isinstance(exc, PermissionValidationError):
         exc = PermissionDenied(detail=exc)
 
-    if isinstance(exc, PermissionError):
+    elif isinstance(exc, DjangoValidationError):
+        exc = django_validation_to_drf_error(exc)
+
+    elif isinstance(exc, PermissionError):
         exc = PermissionDenied(detail=exc)
 
     response = drf_exception_handler(exc, context)

--- a/django/thunderstore/core/exception_handler.py
+++ b/django/thunderstore/core/exception_handler.py
@@ -20,7 +20,7 @@ def serialize_validation_error(error: DjangoValidationError):
 
 def exception_handler(exc: Exception, context: Any) -> Optional[Response]:
     if isinstance(exc, PermissionValidationError):
-        exc = PermissionDenied(detail=exc)
+        exc = PermissionDenied(detail=as_serializer_error(exc))
 
     elif isinstance(exc, DjangoValidationError):
         exc = django_validation_to_drf_error(exc)

--- a/django/thunderstore/core/exceptions.py
+++ b/django/thunderstore/core/exceptions.py
@@ -1,2 +1,5 @@
-class PermissionValidationError(Exception):
+from django.core.exceptions import ValidationError
+
+
+class PermissionValidationError(ValidationError):
     pass

--- a/django/thunderstore/core/exceptions.py
+++ b/django/thunderstore/core/exceptions.py
@@ -2,4 +2,6 @@ from django.core.exceptions import ValidationError
 
 
 class PermissionValidationError(ValidationError):
-    pass
+    def __init__(self, message=None, code=None, is_public=True, **kwargs):
+        self.is_public = is_public
+        super().__init__(message, code, **kwargs)

--- a/django/thunderstore/core/exceptions.py
+++ b/django/thunderstore/core/exceptions.py
@@ -1,0 +1,2 @@
+class PermissionValidationError(Exception):
+    pass

--- a/django/thunderstore/permissions/utils.py
+++ b/django/thunderstore/permissions/utils.py
@@ -1,7 +1,5 @@
 from typing import Optional
 
-from django.core.exceptions import ValidationError
-
 from thunderstore.core.exceptions import PermissionValidationError
 from thunderstore.core.types import UserType
 
@@ -12,7 +10,7 @@ def validate_user(
     if not user or not user.is_authenticated:
         raise PermissionValidationError("Must be authenticated")
     if not user.is_active:
-        raise PermissionValidationError("User has been deactivated")
+        raise PermissionValidationError("User has been deactivated", is_public=False)
     if hasattr(user, "service_account") and not allow_serviceaccount:
         raise PermissionValidationError(
             "Service accounts are unable to perform this action"

--- a/django/thunderstore/permissions/utils.py
+++ b/django/thunderstore/permissions/utils.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from django.core.exceptions import ValidationError
 
+from thunderstore.core.exceptions import PermissionValidationError
 from thunderstore.core.types import UserType
 
 
@@ -9,9 +10,11 @@ def validate_user(
     user: Optional[UserType], allow_serviceaccount: bool = False
 ) -> UserType:
     if not user or not user.is_authenticated:
-        raise ValidationError("Must be authenticated")
+        raise PermissionValidationError("Must be authenticated")
     if not user.is_active:
-        raise ValidationError("User has been deactivated")
+        raise PermissionValidationError("User has been deactivated")
     if hasattr(user, "service_account") and not allow_serviceaccount:
-        raise ValidationError("Service accounts are unable to perform this action")
+        raise PermissionValidationError(
+            "Service accounts are unable to perform this action"
+        )
     return user

--- a/django/thunderstore/repository/forms/team.py
+++ b/django/thunderstore/repository/forms/team.py
@@ -4,6 +4,7 @@ from django import forms
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 
+from thunderstore.core.exceptions import PermissionValidationError
 from thunderstore.core.types import UserType
 from thunderstore.repository.models import (
     Namespace,
@@ -40,9 +41,9 @@ class CreateTeamForm(forms.ModelForm):
 
     def clean(self):
         if not self.user or not self.user.is_authenticated or not self.user.is_active:
-            raise ValidationError("Must be authenticated to create teams")
+            raise PermissionValidationError("Must be authenticated to create teams")
         if getattr(self.user, "service_account", None) is not None:
-            raise ValidationError("Service accounts cannot create teams")
+            raise PermissionValidationError("Service accounts cannot create teams")
         return super().clean()
 
     @transaction.atomic

--- a/django/thunderstore/repository/models/team.py
+++ b/django/thunderstore/repository/models/team.py
@@ -8,6 +8,7 @@ from django.db.models import Manager, Q, QuerySet
 from django.urls import reverse
 
 from thunderstore.core.enums import OptionalBoolChoice
+from thunderstore.core.exceptions import PermissionValidationError
 from thunderstore.core.types import UserType
 from thunderstore.core.utils import ChoiceEnum, capture_exception, check_validity
 from thunderstore.permissions.utils import validate_user
@@ -242,42 +243,56 @@ class Team(models.Model):
         user = validate_user(user)
         membership = self.get_membership_for_user(user)
         if not membership:
-            raise ValidationError("Must be a member to create a service account")
+            raise PermissionValidationError(
+                "Must be a member to create a service account"
+            )
         if membership.role != TeamMemberRole.owner:
-            raise ValidationError("Must be an owner to create a service account")
+            raise PermissionValidationError(
+                "Must be an owner to create a service account"
+            )
 
     def ensure_can_edit_service_account(self, user: Optional[UserType]) -> None:
         user = validate_user(user)
         membership = self.get_membership_for_user(user)
         if not membership:
-            raise ValidationError("Must be a member to edit a service account")
+            raise PermissionValidationError(
+                "Must be a member to edit a service account"
+            )
         if membership.role != TeamMemberRole.owner:
-            raise ValidationError("Must be an owner to edit a service account")
+            raise PermissionValidationError(
+                "Must be an owner to edit a service account"
+            )
 
     def ensure_can_delete_service_account(self, user: Optional[UserType]) -> None:
         user = validate_user(user)
         membership = self.get_membership_for_user(user)
         if not membership:
-            raise ValidationError("Must be a member to delete a service account")
+            raise PermissionValidationError(
+                "Must be a member to delete a service account"
+            )
         if membership.role != TeamMemberRole.owner:
-            raise ValidationError("Must be an owner to delete a service account")
+            raise PermissionValidationError(
+                "Must be an owner to delete a service account"
+            )
 
     def ensure_user_can_manage_members(self, user: Optional[UserType]) -> None:
         user = validate_user(user)
         membership = self.get_membership_for_user(user)
         if not membership or membership.role != TeamMemberRole.owner:
-            raise ValidationError("Must be an owner to manage team members")
+            raise PermissionValidationError("Must be an owner to manage team members")
 
     def ensure_user_can_access(self, user: Optional[UserType]) -> None:
         user = validate_user(user, allow_serviceaccount=True)
         if not self.get_membership_for_user(user):
-            raise ValidationError("Must be a member to access team")
+            raise PermissionValidationError("Must be a member to access team")
 
     def ensure_can_upload_package(self, user: Optional[UserType]) -> None:
         user = validate_user(user, allow_serviceaccount=True)
         membership = self.get_membership_for_user(user)
         if not membership:
-            raise ValidationError("Must be a member of team to upload package")
+            raise PermissionValidationError(
+                "Must be a member of team to upload package"
+            )
         if not self.is_active:
             raise ValidationError(
                 "The team has been deactivated and as such cannot receive new packages"
@@ -287,7 +302,9 @@ class Team(models.Model):
         user = validate_user(user)
         membership = self.get_membership_for_user(user)
         if not membership:
-            raise ValidationError("Must be a member of team to manage packages")
+            raise PermissionValidationError(
+                "Must be a member of team to manage packages"
+            )
 
     def ensure_member_can_be_removed(self, member: Optional[TeamMember]) -> None:
         if not member:
@@ -314,7 +331,7 @@ class Team(models.Model):
         user = validate_user(user)
         membership = self.get_membership_for_user(user)
         if not membership or membership.role != TeamMemberRole.owner:
-            raise ValidationError("Must be an owner to disband team")
+            raise PermissionValidationError("Must be an owner to disband team")
         if self.owned_packages.exists():
             raise ValidationError("Unable to disband teams with packages")
 
@@ -322,7 +339,7 @@ class Team(models.Model):
         user = validate_user(user)
         membership = self.get_membership_for_user(user)
         if not membership or membership.role != TeamMemberRole.owner:
-            raise ValidationError("Must be an owner to edit team info")
+            raise PermissionValidationError("Must be an owner to edit team info")
 
     def can_user_upload(self, user: Optional[UserType]) -> bool:
         return check_validity(lambda: self.ensure_can_upload_package(user))

--- a/django/thunderstore/repository/package_manifest.py
+++ b/django/thunderstore/repository/package_manifest.py
@@ -4,6 +4,7 @@ from django.core.validators import URLValidator
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
+from thunderstore.core.exceptions import PermissionValidationError
 from thunderstore.repository.models import PackageInstaller, PackageVersion
 from thunderstore.repository.package_reference import PackageReference
 from thunderstore.repository.serializer_fields import (
@@ -81,7 +82,7 @@ class ManifestV1Serializer(serializers.Serializer):
         if self.team is None:
             raise ValidationError("Unable to validate package when no team is selected")
         if not self.team.can_user_upload(self.user):
-            raise ValidationError(
+            raise PermissionValidationError(
                 f"Missing privileges to upload under author {self.team.name}"
             )
         reference = PackageReference(


### PR DESCRIPTION
Implement service layer functions for deprecate/undeprecate and rate packages. Implement service layer functions for updating categories, reject, and approve package listings.

Use these service layer functions in the cyberstorm api, experimental api, and the v1 api.

Implement tests.