### PR TITLE
Replace Mythic#0001 contact info

### DIFF
--- a/django/thunderstore/core/urls.py
+++ b/django/thunderstore/core/urls.py
@@ -63,9 +63,7 @@ schema_view = get_schema_view(
         title=f"{settings.SITE_NAME} API",
         default_version="v1",
         description=("Schema is automatically generated and not completely accurate."),
-        contact=openapi.Contact(
-            name="Mythic#0001", url="https://discord.gg/UWpWhjZken"
-        ),
+        contact=openapi.Contact(name="Discord", url="https://discord.thunderstore.io/"),
     ),
     public=True,
     permission_classes=(permissions.AllowAny,),

--- a/django/thunderstore/repository/templates/settings/team_disband.html
+++ b/django/thunderstore/repository/templates/settings/team_disband.html
@@ -8,8 +8,8 @@
 </p>
 <p>
     Be aware you can currently only disband teams with no packages. If you need
-    to archive a team with existing packages, contact Mythic#0001 on the
-    <a href="https://discord.gg/UWpWhjZken">Thunderstore Discord</a>
+    to archive a team with existing packages, contact #support in the
+    <a href="https://discord.thunderstore.io/">Thunderstore Discord</a>
 </p>
 <p>
     As a precaution, to disband your team, please input <kbd class="text-info">{{ team.name }}</kbd>


### PR DESCRIPTION
Replace Mythic#0001 contact info from API docs and the disband team page with just a Discord link.