### PR TITLE
Implement query parameter for CommunityAPIView (TS-2470)

### DIFF
--- a/django/thunderstore/api/cyberstorm/serializers/community.py
+++ b/django/thunderstore/api/cyberstorm/serializers/community.py
@@ -17,6 +17,7 @@ class CyberstormCommunitySerializer(serializers.Serializer):
     total_download_count = serializers.SerializerMethodField()
     total_package_count = serializers.SerializerMethodField()
     has_mod_manager_support = serializers.BooleanField()
+    is_listed = serializers.BooleanField()
 
     def get_total_download_count(self, obj) -> int:
         return obj.aggregated.download_count

--- a/django/thunderstore/api/cyberstorm/tests/test_community_list.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_community_list.py
@@ -200,3 +200,20 @@ def test_api_cyberstorm_community_search_with_keywords(
     else:
         assert data["count"] == 0
         assert data["results"] == []
+
+
+@pytest.mark.django_db
+def test_api_cyberstorm_community_list_get_include_unlisted(
+    api_client: APIClient,
+) -> None:
+    unlisted_community = CommunityFactory(is_listed=False)
+
+    data = __query_api(api_client, "include_unlisted=true")
+    assert data["count"] == 2
+    assert unlisted_community.identifier in [c["identifier"] for c in data["results"]]
+
+    data = __query_api(api_client)
+    assert data["count"] == 1
+    assert unlisted_community.identifier not in [
+        c["identifier"] for c in data["results"]
+    ]

--- a/django/thunderstore/api/cyberstorm/views/community_list.py
+++ b/django/thunderstore/api/cyberstorm/views/community_list.py
@@ -27,3 +27,9 @@ class CommunityListAPIView(CyberstormAutoSchemaMixin, ListAPIView):
         "name",
     ]
     ordering = ["identifier"]
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        if self.request.query_params.get("include_unlisted", "false").lower() == "true":
+            queryset = Community.objects.all()
+        return queryset


### PR DESCRIPTION
Use the DRF `get_queryset` function to fetch the Community queryset with or without unlisted communities depending on a query parameter passed to the endpoint.

Refs. TS-2470