### PR TITLE
Slow cyberstorm api endpoints (TS-2516)

### DIFF
--- a/django/thunderstore/api/cyberstorm/views/markdown.py
+++ b/django/thunderstore/api/cyberstorm/views/markdown.py
@@ -29,12 +29,8 @@ class PackageVersionReadmeAPIView(CyberstormAutoSchemaMixin, RetrieveAPIView):
             version_number=self.kwargs.get("version_number"),
         )
 
-        readme = package_version.readme
-        if readme is None:
-            raise Http404("README not found for this package version.")
-
         return render_markdown_service(
-            markdown=readme,
+            markdown=package_version.readme,
             key="readme",
             object_id=package_version.id,
         )

--- a/django/thunderstore/core/settings.py
+++ b/django/thunderstore/core/settings.py
@@ -109,6 +109,7 @@ env = environ.Env(
     REDIS_URL_LEGACY=(str, None),
     REDIS_URL_PROFILES=(str, None),
     REDIS_URL_DOWNLOADS=(str, None),
+    REDIS_MARKDOWN_RENDER=(str, None),
     DB_CERT_DIR=(str, ""),
     DB_CLIENT_CERT=(str, ""),
     DB_CLIENT_KEY=(str, ""),
@@ -390,6 +391,7 @@ class CeleryQueues:
     BackgroundCache = "background.cache"
     BackgroundTask = "background.task"
     BackgroundLongRunning = "background.long_running"
+    BackgroundMarkdownRender = "background.markdown_render"
 
 
 CELERY_BROKER_URL = env.str("CELERY_BROKER_URL")
@@ -507,6 +509,10 @@ CACHES = {
     },
     "downloads": {
         **get_redis_cache("REDIS_URL_DOWNLOADS", "REDIS_URL"),
+        "TIMEOUT": None,
+    },
+    "markdown_render": {
+        **get_redis_cache("REDIS_MARKDOWN_RENDER", "REDIS_URL"),
         "TIMEOUT": None,
     },
 }

--- a/django/thunderstore/core/tests/test_celery.py
+++ b/django/thunderstore/core/tests/test_celery.py
@@ -40,6 +40,7 @@ KNOWN_CELERY_IDS = (
     "thunderstore.repository.tasks.process_package_submission",
     "thunderstore.repository.tasks.cleanup_package_submissions",
     "thunderstore.repository.tasks.log_version_download",
+    "thunderstore.repository.tasks.render_markdown",
     "thunderstore.webhooks.tasks.process_audit_event",
 )
 

--- a/django/thunderstore/repository/services/markdown.py
+++ b/django/thunderstore/repository/services/markdown.py
@@ -1,0 +1,34 @@
+import time
+
+from thunderstore.cache.utils import get_cache
+from thunderstore.repository.tasks.markdown import render_markdown_to_html
+
+cache = get_cache("markdown_render")
+
+
+def render_markdown_service(markdown: str, key: str, object_id: int) -> dict:
+    if markdown.strip() == "":
+        return {"html": ""}
+
+    cache_key = f"rendered_html:{key}:{object_id}"
+    status_key = f"rendering_status:{key}:{object_id}"
+
+    html = cache.get(cache_key)
+    if html is not None:
+        return {"html": html}
+
+    if cache.get(status_key) is None:
+        cache.set(status_key, "in_progress", timeout=300)
+        render_markdown_to_html.delay(
+            markdown=markdown,
+            cache_key=cache_key,
+            status_key=status_key,
+        )
+
+    for _ in range(5):  # wait up to 5s total
+        html = cache.get(cache_key)
+        if html is not None:
+            return {"html": html}
+        time.sleep(1)
+
+    return {"html": "<em>Loading...</em>"}

--- a/django/thunderstore/repository/tasks/markdown.py
+++ b/django/thunderstore/repository/tasks/markdown.py
@@ -14,7 +14,6 @@ cache = get_cache("markdown_render")
 def render_markdown_to_html(
     markdown: str,
     cache_key: str,
-    status_key: str,
 ) -> str:
     cached_html = cache.get(cache_key)
     if cached_html is not None:
@@ -23,10 +22,7 @@ def render_markdown_to_html(
     try:
         html = render_markdown(markdown)
     except Exception as error:
-        cache.delete(status_key)
         raise error
 
     cache.set(cache_key, html)
-    cache.delete(status_key)
-
     return html

--- a/django/thunderstore/repository/tasks/markdown.py
+++ b/django/thunderstore/repository/tasks/markdown.py
@@ -1,0 +1,32 @@
+from celery import shared_task
+
+from thunderstore.cache.utils import get_cache
+from thunderstore.core.settings import CeleryQueues
+from thunderstore.markdown.templatetags.markdownify import render_markdown
+
+cache = get_cache("markdown_render")
+
+
+@shared_task(
+    queue=CeleryQueues.BackgroundMarkdownRender,
+    name="thunderstore.repository.tasks.render_markdown",
+)
+def render_markdown_to_html(
+    markdown: str,
+    cache_key: str,
+    status_key: str,
+) -> str:
+    cached_html = cache.get(cache_key)
+    if cached_html is not None:
+        return cached_html
+
+    try:
+        html = render_markdown(markdown)
+    except Exception as error:
+        cache.delete(status_key)
+        raise error
+
+    cache.set(cache_key, html)
+    cache.delete(status_key)
+
+    return html

--- a/django/thunderstore/repository/tasks/tests/test_markdown.py
+++ b/django/thunderstore/repository/tasks/tests/test_markdown.py
@@ -13,28 +13,24 @@ def test_markdown_cache_hit_returns_html():
     cache_key = "rendered_html:test_key:1"
     cache.set(cache_key, "<p>Cached HTML</p>")
 
-    result = render_markdown_to_html("", cache_key, "status_key")
+    result = render_markdown_to_html("", cache_key)
     assert result == "<p>Cached HTML</p>"
 
 
 def test_markdown_cache_miss_triggers_rendering_task():
     cache = get_cache("markdown_render")
     cache_key = "rendered_html:test_key:1"
-    status_key = "rendering_status:test_key:1"
 
-    result = render_markdown_to_html("test markdown", cache_key, status_key)
+    result = render_markdown_to_html("test markdown", cache_key)
     assert result == "<p>test markdown</p>\n"
     assert cache.get(cache_key) == "<p>test markdown</p>\n"
-    assert cache.get(status_key) is None
 
 
 def test_markdown_rendering_exception():
     cache = get_cache("markdown_render")
     cache_key = "rendered_html:test_key:1"
-    status_key = "rendering_status:test_key:1"
 
     with pytest.raises(Exception):
-        render_markdown_to_html(None, cache_key, status_key)
+        render_markdown_to_html(None, cache_key)
 
     assert cache.get(cache_key) is None
-    assert cache.get(status_key) is None

--- a/django/thunderstore/repository/tasks/tests/test_markdown.py
+++ b/django/thunderstore/repository/tasks/tests/test_markdown.py
@@ -1,0 +1,40 @@
+from unittest.mock import patch
+
+import pytest
+
+from thunderstore.cache.utils import get_cache
+from thunderstore.repository.tasks.markdown import render_markdown_to_html
+
+RENDER_MARKDOWN_PATH = "thunderstore.markdown.templatetags.markdownify.render_markdown"
+
+
+def test_markdown_cache_hit_returns_html():
+    cache = get_cache("markdown_render")
+    cache_key = "rendered_html:test_key:1"
+    cache.set(cache_key, "<p>Cached HTML</p>")
+
+    result = render_markdown_to_html("", cache_key, "status_key")
+    assert result == "<p>Cached HTML</p>"
+
+
+def test_markdown_cache_miss_triggers_rendering_task():
+    cache = get_cache("markdown_render")
+    cache_key = "rendered_html:test_key:1"
+    status_key = "rendering_status:test_key:1"
+
+    result = render_markdown_to_html("test markdown", cache_key, status_key)
+    assert result == "<p>test markdown</p>\n"
+    assert cache.get(cache_key) == "<p>test markdown</p>\n"
+    assert cache.get(status_key) is None
+
+
+def test_markdown_rendering_exception():
+    cache = get_cache("markdown_render")
+    cache_key = "rendered_html:test_key:1"
+    status_key = "rendering_status:test_key:1"
+
+    with pytest.raises(Exception):
+        render_markdown_to_html(None, cache_key, status_key)
+
+    assert cache.get(cache_key) is None
+    assert cache.get(status_key) is None

--- a/django/thunderstore/repository/tests/test_markdown_service.py
+++ b/django/thunderstore/repository/tests/test_markdown_service.py
@@ -38,7 +38,16 @@ def test_render_markdown_no_cached_html(package_version):
 
 
 @pytest.mark.django_db
-def test_render_markdown_timeout(package_version):
+@pytest.mark.parametrize(
+    "side_effect,expected_exception,exception_message",
+    [
+        (TimeoutError, TimeoutError, "Markdown rendering task timed out."),
+        (Exception, Exception, None),
+    ],
+)
+def test_render_markdown_exceptions(
+    package_version, side_effect, expected_exception, exception_message
+):
     cache = get_cache("markdown_render")
     status_key = f"rendering_status:changelog:{package_version.id}"
     task_id = "mock-task-id"
@@ -46,24 +55,9 @@ def test_render_markdown_timeout(package_version):
 
     get_path = "celery.result.AsyncResult.get"
     id_path = "celery.result.AsyncResult.id"
-    with patch(get_path, side_effect=TimeoutError), patch(
-        id_path, return_value=task_id
-    ):
-        with pytest.raises(TimeoutError, match="Markdown rendering task timed out."):
+    with patch(get_path, side_effect=side_effect), patch(id_path, return_value=task_id):
+        with pytest.raises(expected_exception, match=exception_message):
             render_markdown_service(
                 package_version.changelog, "changelog", package_version.id
             )
-
-
-@pytest.mark.django_db
-def test_render_markdown_error(package_version):
-    cache = get_cache("markdown_render")
-    status_key = f"rendering_status:changelog:{package_version.id}"
-    task_id = "mock-task-id"
-    cache.set(status_key, task_id)
-
-    get_path = "celery.result.AsyncResult.get"
-    id_path = "celery.result.AsyncResult.id"
-    with patch(get_path, side_effect=Exception), patch(id_path, return_value=task_id):
-        with pytest.raises(Exception) as e:
-            render_markdown_service(None, "changelog", package_version.id)
+        assert cache.get(status_key) is None

--- a/django/thunderstore/repository/tests/test_markdown_service.py
+++ b/django/thunderstore/repository/tests/test_markdown_service.py
@@ -1,0 +1,87 @@
+from unittest.mock import patch
+
+import pytest
+
+from thunderstore.cache.utils import get_cache
+from thunderstore.repository.services.markdown import render_markdown_service
+
+
+@pytest.mark.django_db
+def test_render_markdown_empty_input():
+    result = render_markdown_service("", "changelog", 1)
+    assert result == {"html": ""}
+
+    result = render_markdown_service("    ", "changelog", 1)
+    assert result == {"html": ""}
+
+
+@pytest.mark.django_db
+def test_render_markdown_cached_html(package_version):
+    cache = get_cache("markdown_render")
+    cache_key = f"rendered_html:changelog:{package_version.id}"
+    cache.set(cache_key, "<p>Cached HTML</p>")
+
+    result = render_markdown_service(
+        package_version.changelog, "changelog", package_version.id
+    )
+    assert result == {"html": "<p>Cached HTML</p>"}
+
+
+@pytest.mark.django_db
+def test_render_markdown_no_cached_html(package_version):
+    cache = get_cache("markdown_render")
+    cache_key = f"rendered_html:changelog:{package_version.id}"
+    cache.delete(cache_key)
+
+    result = render_markdown_service(
+        package_version.changelog, "changelog", package_version.id
+    )
+    assert result == {"html": "<h1>This is an example changelog</h1>\n"}
+
+
+@pytest.mark.django_db
+def test_render_markdown_in_progress(package_version):
+    cache = get_cache("markdown_render")
+    status_key = f"rendering_status:changelog:{package_version.id}"
+    cache.set(status_key, "in_progress")
+
+    with patch("time.sleep") as sleep_mock:
+        result = render_markdown_service(
+            package_version.changelog, "changelog", package_version.id
+        )
+        assert result == {"html": "<em>Loading...</em>"}
+        sleep_mock.assert_called()
+
+
+@pytest.mark.django_db
+def test_render_markdown_html_available_after_wait(package_version):
+    cache = get_cache("markdown_render")
+    status_key = f"rendering_status:changelog:{package_version.id}"
+    cache_key = f"rendered_html:changelog:{package_version.id}"
+
+    cache.set(status_key, "in_progress")
+
+    def mock_cache_get(key):
+        if key == cache_key:
+            return "<p>Rendered HTML</p>"
+        return None
+
+    with patch("time.sleep"), patch.object(cache, "get", side_effect=mock_cache_get):
+        result = render_markdown_service(
+            package_version.changelog, "changelog", package_version.id
+        )
+        assert result == {"html": "<p>Rendered HTML</p>"}
+
+
+@pytest.mark.django_db
+def test_render_markdown_html_unavailable_after_wait(package_version):
+    cache = get_cache("markdown_render")
+    status_key = f"rendering_status:changelog:{package_version.id}"
+
+    cache.set(status_key, "in_progress")
+
+    with patch("time.sleep"), patch.object(cache, "get", return_value=None):
+        result = render_markdown_service(
+            package_version.changelog, "changelog", package_version.id
+        )
+        assert result == {"html": "<em>Loading...</em>"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,12 +8,13 @@ x-django-service: &django-service
       BUILD_INSTALL_EXTRAS: ${BUILD_INSTALL_EXTRAS}
   environment:
     CELERY_BROKER_URL: "pyamqp://django:django@rabbitmq/django"
-    CELERY_QUEUES: "celery,background.cache,background.task,background.long_running,log.downloads"
+    CELERY_QUEUES: "celery,background.cache,background.task,background.long_running,log.downloads,background.markdown_render"
     DATABASE_URL: "psql://django:django@dbpool/django"
     REDIS_URL: "redis://redis:6379/0"
     REDIS_URL_LEGACY: "redis://redis:6379/1"
     REDIS_URL_PROFILES: "redis://redis:6379/2"
     REDIS_URL_DOWNLOADS: "redis://redis:6379/3"
+    REDIS_MARKDOWN_RENDER: "redis://redis:6379/4"
     PROTOCOL: "http://"
 
     AWS_ACCESS_KEY_ID: "thunderstore"


### PR DESCRIPTION
Implement a celery task and caching mechanism for rendering markdown to HTML. This removes the CPU overhead caused by rendering the HTML on every request.

* Add new celery queue
* Add new redis cache
* Implement celery task for handling the markdown render
* Refactor the API views for readme and changelog to use the celery task