### PR TITLE
DRF unhandled exceptions (TS-2459)

### DIFF
--- a/django/thunderstore/core/exception_handler.py
+++ b/django/thunderstore/core/exception_handler.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ValidationError as DjangoValidationError
 from drf_yasg.openapi import Response
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.exceptions import ValidationError as DRFValidationError
+from rest_framework.response import Response as DRFResponse
 from rest_framework.serializers import as_serializer_error
 from rest_framework.views import exception_handler as drf_exception_handler
 
@@ -34,4 +35,5 @@ def exception_handler(exc: Exception, context: Any) -> Optional[Response]:
     response = drf_exception_handler(exc, context)
     if response:
         return response
-    return None
+
+    return DRFResponse(data={"detail": "Internal server error"}, status=500)

--- a/django/thunderstore/core/tests/test_api_exceptions.py
+++ b/django/thunderstore/core/tests/test_api_exceptions.py
@@ -1,0 +1,94 @@
+import pytest
+from django.contrib import admin
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.urls import path
+from rest_framework.views import APIView
+
+from thunderstore.core.exceptions import PermissionValidationError
+
+
+class PermissionValidationErrorPublicView(APIView):
+    def get(self, request):
+        raise PermissionValidationError(
+            "Public PermissionValidationError", is_public=True
+        )
+
+
+class PermissionValidationErrorNonPublicView(APIView):
+    def get(self, request):
+        raise PermissionValidationError(
+            "Non-public PermissionValidationError", is_public=False
+        )
+
+
+class DjangoValidationErrorView(APIView):
+    def get(self, request):
+        raise DjangoValidationError("DjangoValidationError")
+
+
+class PermissionErrorView(APIView):
+    def get(self, request):
+        raise PermissionError("PermissionError")
+
+
+class UnhandledErrorView(APIView):
+    def get(self, request):
+        raise RuntimeError("RuntimeError")
+
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+    path(
+        "error/permission-validation-public/",
+        PermissionValidationErrorPublicView.as_view(),
+    ),
+    path(
+        "error/permission-validation-nonpublic/",
+        PermissionValidationErrorNonPublicView.as_view(),
+    ),
+    path("error/django-validation/", DjangoValidationErrorView.as_view()),
+    path("error/permission/", PermissionErrorView.as_view()),
+    path("error/unhandled-runtime/", UnhandledErrorView.as_view()),
+]
+
+
+@pytest.mark.urls("thunderstore.core.tests.test_api_exceptions")
+@pytest.mark.django_db
+def test_permission_validation_error_public(api_client):
+    resp = api_client.get("/error/permission-validation-public/")
+    assert resp.status_code == 403
+    assert resp.json() == {"non_field_errors": ["Public PermissionValidationError"]}
+
+
+@pytest.mark.urls("thunderstore.core.tests.test_api_exceptions")
+@pytest.mark.django_db
+def test_permission_validation_error_nonpublic(api_client):
+    resp = api_client.get("/error/permission-validation-nonpublic/")
+    assert resp.status_code == 403
+    assert resp.json() == {
+        "detail": "You do not have permission to perform this action."
+    }
+
+
+@pytest.mark.urls("thunderstore.core.tests.test_api_exceptions")
+@pytest.mark.django_db
+def test_django_validation_error(api_client):
+    resp = api_client.get("/error/django-validation/")
+    assert resp.status_code == 400
+    assert resp.json() == {"non_field_errors": ["DjangoValidationError"]}
+
+
+@pytest.mark.urls("thunderstore.core.tests.test_api_exceptions")
+@pytest.mark.django_db
+def test_permission_error(api_client):
+    resp = api_client.get("/error/permission/")
+    assert resp.status_code == 403
+    assert resp.json() == {"detail": "PermissionError"}
+
+
+@pytest.mark.urls("thunderstore.core.tests.test_api_exceptions")
+@pytest.mark.django_db
+def test_unhandled_exception(api_client):
+    resp = api_client.get("/error/unhandled-runtime/")
+    assert resp.status_code == 500
+    assert resp.json() == {"detail": "Internal server error"}


### PR DESCRIPTION
Add a standard DRF response with a 500 status code when we encounter an unexpected error in out custom exception handler. Implement tests for the expected errors in the exception handler.