### PR TITLE
Consolidate team creation logic

### DIFF
--- a/django/thunderstore/api/cyberstorm/services/team.py
+++ b/django/thunderstore/api/cyberstorm/services/team.py
@@ -28,6 +28,6 @@ def create_team(user: UserType, team_name: str) -> Team:
     if Namespace.objects.filter(name=team_name).exists():
         raise ValidationError("A namespace with the provided name already exists")
 
-    team = Team.objects.create(name=team_name)
+    team = Team.create(name=team_name)
     team.add_member(user=user, role=TeamMemberRole.owner)
     return team

--- a/django/thunderstore/api/cyberstorm/tests/test_package_listing_list.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_package_listing_list.py
@@ -744,7 +744,7 @@ def test_listing_by_namespace_view__returns_only_packages_listed_in_community_be
     community: Community,
     team: Team,
 ) -> None:
-    namespace = team.namespaces.get()
+    namespace = team.get_namespace()
     expected = PackageListingFactory(
         community_=community,
         package_kwargs={"namespace": namespace},

--- a/django/thunderstore/repository/models/team.py
+++ b/django/thunderstore/repository/models/team.py
@@ -185,13 +185,8 @@ class Team(models.Model):
     @classmethod
     @transaction.atomic
     def create(cls, name, **kwargs):
-        existing_ns = Namespace.objects.filter(name__iexact=name).first()
-        if existing_ns:
-            raise ValidationError("Namespace with the Teams name exists")
-        else:
-            team = cls.objects.create(name=name, **kwargs)
-            Namespace.objects.create(name=name, team=team)
-            return team
+        team = cls.objects.create(name=name, **kwargs)
+        return team
 
     @classmethod
     @transaction.atomic

--- a/django/thunderstore/repository/tests/test_team.py
+++ b/django/thunderstore/repository/tests/test_team.py
@@ -68,17 +68,6 @@ def test_team_create(name: str, should_fail: bool) -> None:
 
 
 @pytest.mark.django_db
-def test_team_create_namespace_creation() -> None:
-    team = Team.create(name="Test_Team")
-    assert len(Namespace.objects.filter(name="Test_Team")) == 1
-    ns = Namespace(name="taken_namespace", team=team)
-    ns.save()
-    with pytest.raises(ValidationError) as e:
-        Team.create(name="taken_namespace")
-    assert "Namespace with the Teams name exists" in str(e.value)
-
-
-@pytest.mark.django_db
 @pytest.mark.parametrize(
     ("username", "expected_name"),
     (
@@ -671,14 +660,6 @@ def test_team_ensure_can_create_service_account(
             assert "Must be an owner to create a service account" in str(e.value)
         if role == TeamMemberRole.owner:
             assert team.ensure_can_create_service_account(user) is None
-
-
-@pytest.mark.django_db
-def test_team_save():
-    team = Team.create(name="TestTeam")
-    team.save()
-    assert team.namespaces is not None
-    assert team.namespaces.first().name == team.name
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Consolidate team creation logic by calling Team.create() from the team creation service
Remove the namespace creation logic from Team.create()