### PR TITLE
Add cached moderated_communities to user

### DIFF
--- a/django/thunderstore/account/models/__init__.py
+++ b/django/thunderstore/account/models/__init__.py
@@ -1,3 +1,4 @@
 from .service_account import *
+from .user import *
 from .user_flag import *
 from .user_settings import *

--- a/django/thunderstore/account/models/user.py
+++ b/django/thunderstore/account/models/user.py
@@ -1,0 +1,20 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+
+User = get_user_model()
+
+if not hasattr(User, "moderated_communities"):
+
+    def moderated_communities(self):
+        if not hasattr(self, "_moderated_communities"):
+            from thunderstore.repository.views.package._utils import (
+                get_moderated_communities,
+            )
+
+            print("Should run once ever")
+            self._moderated_communities = get_moderated_communities(self)
+        return self._moderated_communities
+
+    User.moderated_communities = property(moderated_communities)
+
+AnonymousUser.moderated_communities = []

--- a/django/thunderstore/account/tests/test_user.py
+++ b/django/thunderstore/account/tests/test_user.py
@@ -1,0 +1,39 @@
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_user_moderated_communities_only_called_once():
+    user = User.objects.create_user(username="tester", password="pass")
+
+    with patch(
+        "thunderstore.repository.views.package._utils.get_moderated_communities",
+        return_value=["1", "2", "3"],
+    ) as mock_get_moderated_communities:
+
+        result1 = user.moderated_communities
+        assert result1 == ["1", "2", "3"]
+        assert mock_get_moderated_communities.call_count == 1
+
+        result2 = user.moderated_communities
+        assert result2 == ["1", "2", "3"]
+        assert mock_get_moderated_communities.call_count == 1
+
+
+@pytest.mark.django_db
+def test_user_has_moderated_communities_property():
+    user = User()
+    assert hasattr(user, "moderated_communities")
+    assert callable(getattr(User, "moderated_communities").fget)
+
+
+@pytest.mark.django_db
+def test_anonymous_user_moderated_communities_is_empty_list():
+    anon = AnonymousUser()
+    assert hasattr(anon, "moderated_communities")
+    assert anon.moderated_communities == []

--- a/django/thunderstore/repository/models/package.py
+++ b/django/thunderstore/repository/models/package.py
@@ -313,10 +313,10 @@ class Package(VisibilityMixin, AdminLinkMixin):
             return
 
         from thunderstore.repository.views.package._utils import (
-            get_moderatable_communities,
+            get_moderated_communities,
         )
 
-        moderatable_community_ids = get_moderatable_communities(user)
+        moderatable_community_ids = get_moderated_communities(user)
 
         community_ids = [
             listing.community.id

--- a/django/thunderstore/repository/models/package.py
+++ b/django/thunderstore/repository/models/package.py
@@ -312,21 +312,18 @@ class Package(VisibilityMixin, AdminLinkMixin):
         ):
             return
 
-        from thunderstore.repository.views.package._utils import (
-            get_moderated_communities,
-        )
+        moderated_community_ids = user.moderated_communities
 
-        moderatable_community_ids = get_moderated_communities(user)
+        if moderated_community_ids:
+            community_ids = [
+                listing.community.id
+                for listing in self.community_listings.select_related("community")
+            ]
 
-        community_ids = [
-            listing.community.id
-            for listing in self.community_listings.select_related("community")
-        ]
-
-        if community_ids and all(
-            str(cid) in moderatable_community_ids for cid in community_ids
-        ):
-            return
+            if community_ids and all(
+                str(cid) in moderated_community_ids for cid in community_ids
+            ):
+                return
 
         self.owner.ensure_user_can_manage_packages(user)
 

--- a/django/thunderstore/repository/views/package/_utils.py
+++ b/django/thunderstore/repository/views/package/_utils.py
@@ -54,7 +54,7 @@ def can_view_package_admin(user: UserType, obj: Package):
     return user.is_staff and user.has_perm("repository.view_package")
 
 
-def get_moderatable_communities(user: Optional[UserType]) -> List[str]:
+def get_moderated_communities(user: Optional[UserType]) -> List[str]:
     if not user or not user.is_authenticated:
         return []
 

--- a/django/thunderstore/repository/views/package/list.py
+++ b/django/thunderstore/repository/views/package/list.py
@@ -21,7 +21,7 @@ from thunderstore.community.models import (
 from thunderstore.frontend.url_reverse import get_community_url_reverse_args
 from thunderstore.repository.mixins import CommunityMixin
 from thunderstore.repository.models import Team, get_package_dependants
-from thunderstore.repository.views.package._utils import get_moderatable_communities
+from thunderstore.repository.views.package._utils import get_moderated_communities
 
 # Should be divisible by 4 and 3
 MODS_PER_PAGE = 24
@@ -453,7 +453,7 @@ class PackageReviewListView(PackageListSearchView):
         return f"review-queue"
 
     def dispatch(self, *args, **kwargs):
-        self.community_ids = get_moderatable_communities(self.request.user)
+        self.community_ids = get_moderated_communities(self.request.user)
         if not self.community_ids:
             raise PermissionDenied()
         return super().dispatch(*args, **kwargs)

--- a/django/thunderstore/repository/views/package/tests/test_utils.py
+++ b/django/thunderstore/repository/views/package/tests/test_utils.py
@@ -8,37 +8,37 @@ from thunderstore.community.models import (
     CommunityMembership,
 )
 from thunderstore.core.types import UserType
-from thunderstore.repository.views.package._utils import get_moderatable_communities
+from thunderstore.repository.views.package._utils import get_moderated_communities
 
 User = get_user_model()
 
 
 @pytest.mark.django_db
-def test_utils_get_moderatable_communities_no_user(
+def test_utils_get_moderated_communities_no_user(
     community: Community,
 ):
-    assert get_moderatable_communities(None) == []
-    assert get_moderatable_communities(AnonymousUser()) == []
+    assert get_moderated_communities(None) == []
+    assert get_moderated_communities(AnonymousUser()) == []
 
 
 @pytest.mark.django_db
-def test_utils_get_moderatable_communities_superuser(
+def test_utils_get_moderated_communities_superuser(
     community: Community,
     user: UserType,
 ):
     user.is_superuser = True
     user.save()
-    assert get_moderatable_communities(user) == [str(community.pk)]
+    assert get_moderated_communities(user) == [str(community.pk)]
 
 
 @pytest.mark.django_db
-def test_utils_get_moderatable_communities_staff(
+def test_utils_get_moderated_communities_staff(
     community: Community,
     user: UserType,
 ):
     user.is_staff = True
     user.save()
-    assert get_moderatable_communities(user) == []
+    assert get_moderated_communities(user) == []
 
     perm = Permission.objects.get(
         content_type__app_label="community",
@@ -46,17 +46,17 @@ def test_utils_get_moderatable_communities_staff(
     )
     user.user_permissions.add(perm)
     user = User.objects.get(pk=user.pk)
-    assert get_moderatable_communities(user) == [str(community.pk)]
+    assert get_moderated_communities(user) == [str(community.pk)]
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("role", CommunityMemberRole.options())
-def test_utils_get_moderatable_communities_community_member(
+def test_utils_get_moderated_communities_community_member(
     community: Community,
     user: UserType,
     role: str,
 ):
-    assert get_moderatable_communities(user) == []
+    assert get_moderated_communities(user) == []
 
     membership = CommunityMembership.objects.create(
         user=user,
@@ -70,4 +70,4 @@ def test_utils_get_moderatable_communities_community_member(
         else []
     )
 
-    assert get_moderatable_communities(user) == expected
+    assert get_moderated_communities(user) == expected


### PR DESCRIPTION
Add cached moderated_communities to user to potentially improve performance of https://github.com/thunderstore-io/Thunderstore/pull/1150