### PR TITLE
Fix how queryset is fetched in CommunityListAPI

### DIFF
--- a/django/thunderstore/api/cyberstorm/views/community_list.py
+++ b/django/thunderstore/api/cyberstorm/views/community_list.py
@@ -1,4 +1,3 @@
-from drf_yasg.utils import swagger_auto_schema
 from rest_framework import serializers
 from rest_framework.filters import SearchFilter
 from rest_framework.generics import ListAPIView
@@ -6,7 +5,10 @@ from rest_framework.pagination import PageNumberPagination
 
 from thunderstore.api.cyberstorm.serializers import CyberstormCommunitySerializer
 from thunderstore.api.ordering import StrictOrderingFilter
-from thunderstore.api.utils import CyberstormAutoSchemaMixin
+from thunderstore.api.utils import (
+    CyberstormAutoSchemaMixin,
+    conditional_swagger_auto_schema,
+)
 from thunderstore.community.models import Community
 
 
@@ -33,7 +35,6 @@ class CommunityListAPIView(CyberstormAutoSchemaMixin, ListAPIView):
     ]
     ordering = ["identifier"]
 
-    @swagger_auto_schema(query_serializer=CommunityListAPIQueryParams())
     def get_queryset(self):
         query_params = CommunityListAPIQueryParams(data=self.request.query_params)
         query_params.is_valid(raise_exception=True)
@@ -42,3 +43,10 @@ class CommunityListAPIView(CyberstormAutoSchemaMixin, ListAPIView):
             return Community.objects.all()
         else:
             return Community.objects.listed()
+
+    @conditional_swagger_auto_schema(
+        tags=["cyberstorm"],
+        query_serializer=CommunityListAPIQueryParams(),
+    )
+    def get(self, *args, **kwargs):
+        return super().get(*args, **kwargs)

--- a/django/thunderstore/api/cyberstorm/views/community_list.py
+++ b/django/thunderstore/api/cyberstorm/views/community_list.py
@@ -29,7 +29,7 @@ class CommunityListAPIView(CyberstormAutoSchemaMixin, ListAPIView):
     ordering = ["identifier"]
 
     def get_queryset(self):
-        queryset = super().get_queryset()
-        if self.request.query_params.get("include_unlisted", "false").lower() == "true":
-            queryset = Community.objects.all()
-        return queryset
+        include_unlisted = self.request.query_params.get("include_unlisted", "false")
+        if include_unlisted.lower() == "true":
+            return Community.objects.all()
+        return self.queryset


### PR DESCRIPTION
Preserve filtering/search when include_unlisted=true in CommunityListAPIView.

Refs. None