### PR TITLE
Deactivate visibility system update logic

### DIFF
--- a/django/thunderstore/community/models/package_listing.py
+++ b/django/thunderstore/community/models/package_listing.py
@@ -424,11 +424,13 @@ class PackageListing(TimestampMixin, AdminLinkMixin, VisibilityMixin):
 
     @transaction.atomic
     def update_visibility(self):
-        self.visibility.copy_from(self.package.visibility)
-
-        self.set_visibility_from_review_status()
-
-        self.visibility.save()
+        return
+        # TODO: Re-enable once visibility system fixed
+        # self.visibility.copy_from(self.package.visibility)
+        #
+        # self.set_visibility_from_review_status()
+        #
+        # self.visibility.save()
 
 
 signals.post_save.connect(PackageListing.post_save, sender=PackageListing)

--- a/django/thunderstore/repository/models/package.py
+++ b/django/thunderstore/repository/models/package.py
@@ -406,26 +406,28 @@ class Package(VisibilityMixin, AdminLinkMixin):
 
     @transaction.atomic
     def update_visibility(self):
-        original = self.visibility.as_tuple()
-
-        self.set_default_visibility()
-
-        self.set_visibility_from_active_status()
-
-        if self.visibility.as_tuple() != original:
-            for version in self.versions.all():
-                version.update_visibility()
-
-        # package visibility levels can't be higher than the union of version visibility levels
-        self.set_visibility_from_versions()
-
-        if self.visibility.as_tuple() != original:
-            self.visibility.save()
-            for listing in self.community_listings.all():
-                listing.update_visibility()
-
-            self.recache_latest()  # latest available version could potentially change if visibility changes
-            # TODO: Available versions should be affected by visibility
+        return
+        # TODO: Re-enable once visibility system fixed
+        # original = self.visibility.as_tuple()
+        #
+        # self.set_default_visibility()
+        #
+        # self.set_visibility_from_active_status()
+        #
+        # if self.visibility.as_tuple() != original:
+        #     for version in self.versions.all():
+        #         version.update_visibility()
+        #
+        # # package visibility levels can't be higher than the union of version visibility levels
+        # self.set_visibility_from_versions()
+        #
+        # if self.visibility.as_tuple() != original:
+        #     self.visibility.save()
+        #     for listing in self.community_listings.all():
+        #         listing.update_visibility()
+        #
+        #     self.recache_latest()  # latest available version could potentially change if visibility changes
+        #     # TODO: Available versions should be affected by visibility
 
     @staticmethod
     def post_save(sender, instance, created, **kwargs):

--- a/django/thunderstore/repository/models/package_version.py
+++ b/django/thunderstore/repository/models/package_version.py
@@ -460,17 +460,19 @@ class PackageVersion(VisibilityMixin, AdminLinkMixin):
 
     @transaction.atomic
     def update_visibility(self):
-        original = self.visibility.as_tuple()
-
-        self.set_default_visibility()
-
-        self.set_visibility_from_active_status()
-
-        self.set_visibility_from_review_status()
-
-        if self.visibility.as_tuple() != original:
-            self.visibility.save()
-            self.package.update_visibility()  # package's visibility may change because of its versions
+        return
+        # TODO: Re-enable once visibility system fixed
+        # original = self.visibility.as_tuple()
+        #
+        # self.set_default_visibility()
+        #
+        # self.set_visibility_from_active_status()
+        #
+        # self.set_visibility_from_review_status()
+        #
+        # if self.visibility.as_tuple() != original:
+        #     self.visibility.save()
+        #     self.package.update_visibility()  # package's visibility may change because of its versions
 
 
 signals.post_save.connect(PackageVersion.post_save, sender=PackageVersion)

--- a/django/thunderstore/repository/tests/test_package.py
+++ b/django/thunderstore/repository/tests/test_package.py
@@ -268,151 +268,152 @@ def test_package_is_removed(
     assert package.is_removed == expected_is_removed
 
 
-@pytest.mark.django_db
-def test_set_default_visibility():
-    package = PackageFactory()
-    package.set_default_visibility()
-    package.visibility.save()
-
-    assert_visibility_is_public(
-        package.visibility
-    )  # this will change when default visibility changes
-
-
-@pytest.mark.django_db
-def test_set_visibility_from_active_status_inactive_package():
-    package = PackageFactory()
-    package.is_active = False
-    package.set_visibility_from_active_status()
-    package.visibility.save()
-
-    assert_visibility_is_not_visible(package.visibility)
-
-
-@pytest.mark.django_db
-def test_set_visibility_from_versions():
-    version = PackageVersionFactory()
-    package = version.package
-
-    assert_default_visibility(package.visibility)
-
-    version.set_zero_visibility()
-    version.visibility.save()
-
-    package.set_visibility_from_versions()
-    package.visibility.save()
-
-    assert_visibility_is_not_visible(package.visibility)
-
-
-@pytest.mark.django_db
-def test_visibility_changes_update_version_and_listing_visibility():
-    listing = PackageListingFactory()
-    package = listing.package
-    version = package.latest
-
-    assert_default_visibility(listing.visibility)
-    assert_default_visibility(package.visibility)
-    assert_default_visibility(version.visibility)
-
-    package.is_active = False
-    package.save()
-
-    listing.refresh_from_db()
-    package.refresh_from_db()
-    version.refresh_from_db()
-    assert_visibility_is_not_visible(listing.visibility)
-    assert_visibility_is_not_visible(package.visibility)
-    assert_visibility_is_not_visible(version.visibility)
-
-
-@pytest.mark.django_db
-def test_is_visible_to_user():
-    version = PackageVersionFactory()
-    package = version.package
-    listing = PackageListingFactory(package=package)
-
-    user = UserFactory.create()
-
-    owner = UserFactory.create()
-    TeamMember.objects.create(
-        user=owner,
-        team=version.package.owner,
-        role=TeamMemberRole.owner,
-    )
-
-    moderator = UserFactory.create()
-    CommunityMembership.objects.create(
-        user=moderator,
-        community=listing.community,
-        role=CommunityMemberRole.moderator,
-    )
-
-    admin = UserFactory.create(is_superuser=True)
-
-    agents = {
-        "anonymous": None,
-        "user": user,
-        "owner": owner,
-        "moderator": moderator,
-        "admin": admin,
-    }
-
-    flags = [
-        "public_detail",
-        "owner_detail",
-        "moderator_detail",
-        "admin_detail",
-    ]
-
-    # Admins are also moderators but not owners
-    expected = {
-        "public_detail": {
-            "anonymous": True,
-            "user": True,
-            "owner": True,
-            "moderator": True,
-            "admin": True,
-        },
-        "owner_detail": {
-            "anonymous": False,
-            "user": False,
-            "owner": True,
-            "moderator": False,
-            "admin": False,
-        },
-        "moderator_detail": {
-            "anonymous": False,
-            "user": False,
-            "owner": False,
-            "moderator": True,
-            "admin": True,
-        },
-        "admin_detail": {
-            "anonymous": False,
-            "user": False,
-            "owner": False,
-            "moderator": False,
-            "admin": True,
-        },
-    }
-
-    for flag in flags:
-        package.visibility.public_detail = False
-        package.visibility.owner_detail = False
-        package.visibility.moderator_detail = False
-        package.visibility.admin_detail = False
-
-        setattr(package.visibility, flag, True)
-        package.visibility.save()
-
-        for role, subject in agents.items():
-            result = package.is_visible_to_user(subject)
-            assert result == expected[flag][role], (
-                f"Expected {flag} visibility for {role} to be "
-                f"{expected[flag][role]}, got {result}"
-            )
-
-    package.visibility = None
-
-    assert not package.is_visible_to_user(admin)
+# TODO: Re-enable once visibility system fixed
+# @pytest.mark.django_db
+# def test_set_default_visibility():
+#     package = PackageFactory()
+#     package.set_default_visibility()
+#     package.visibility.save()
+#
+#     assert_visibility_is_public(
+#         package.visibility
+#     )  # this will change when default visibility changes
+#
+#
+# @pytest.mark.django_db
+# def test_set_visibility_from_active_status_inactive_package():
+#     package = PackageFactory()
+#     package.is_active = False
+#     package.set_visibility_from_active_status()
+#     package.visibility.save()
+#
+#     assert_visibility_is_not_visible(package.visibility)
+#
+#
+# @pytest.mark.django_db
+# def test_set_visibility_from_versions():
+#     version = PackageVersionFactory()
+#     package = version.package
+#
+#     assert_default_visibility(package.visibility)
+#
+#     version.set_zero_visibility()
+#     version.visibility.save()
+#
+#     package.set_visibility_from_versions()
+#     package.visibility.save()
+#
+#     assert_visibility_is_not_visible(package.visibility)
+#
+#
+# @pytest.mark.django_db
+# def test_visibility_changes_update_version_and_listing_visibility():
+#     listing = PackageListingFactory()
+#     package = listing.package
+#     version = package.latest
+#
+#     assert_default_visibility(listing.visibility)
+#     assert_default_visibility(package.visibility)
+#     assert_default_visibility(version.visibility)
+#
+#     package.is_active = False
+#     package.save()
+#
+#     listing.refresh_from_db()
+#     package.refresh_from_db()
+#     version.refresh_from_db()
+#     assert_visibility_is_not_visible(listing.visibility)
+#     assert_visibility_is_not_visible(package.visibility)
+#     assert_visibility_is_not_visible(version.visibility)
+#
+#
+# @pytest.mark.django_db
+# def test_is_visible_to_user():
+#     version = PackageVersionFactory()
+#     package = version.package
+#     listing = PackageListingFactory(package=package)
+#
+#     user = UserFactory.create()
+#
+#     owner = UserFactory.create()
+#     TeamMember.objects.create(
+#         user=owner,
+#         team=version.package.owner,
+#         role=TeamMemberRole.owner,
+#     )
+#
+#     moderator = UserFactory.create()
+#     CommunityMembership.objects.create(
+#         user=moderator,
+#         community=listing.community,
+#         role=CommunityMemberRole.moderator,
+#     )
+#
+#     admin = UserFactory.create(is_superuser=True)
+#
+#     agents = {
+#         "anonymous": None,
+#         "user": user,
+#         "owner": owner,
+#         "moderator": moderator,
+#         "admin": admin,
+#     }
+#
+#     flags = [
+#         "public_detail",
+#         "owner_detail",
+#         "moderator_detail",
+#         "admin_detail",
+#     ]
+#
+#     # Admins are also moderators but not owners
+#     expected = {
+#         "public_detail": {
+#             "anonymous": True,
+#             "user": True,
+#             "owner": True,
+#             "moderator": True,
+#             "admin": True,
+#         },
+#         "owner_detail": {
+#             "anonymous": False,
+#             "user": False,
+#             "owner": True,
+#             "moderator": False,
+#             "admin": False,
+#         },
+#         "moderator_detail": {
+#             "anonymous": False,
+#             "user": False,
+#             "owner": False,
+#             "moderator": True,
+#             "admin": True,
+#         },
+#         "admin_detail": {
+#             "anonymous": False,
+#             "user": False,
+#             "owner": False,
+#             "moderator": False,
+#             "admin": True,
+#         },
+#     }
+#
+#     for flag in flags:
+#         package.visibility.public_detail = False
+#         package.visibility.owner_detail = False
+#         package.visibility.moderator_detail = False
+#         package.visibility.admin_detail = False
+#
+#         setattr(package.visibility, flag, True)
+#         package.visibility.save()
+#
+#         for role, subject in agents.items():
+#             result = package.is_visible_to_user(subject)
+#             assert result == expected[flag][role], (
+#                 f"Expected {flag} visibility for {role} to be "
+#                 f"{expected[flag][role]}, got {result}"
+#             )
+#
+#     package.visibility = None
+#
+#     assert not package.is_visible_to_user(admin)

--- a/django/thunderstore/repository/tests/test_package_version.py
+++ b/django/thunderstore/repository/tests/test_package_version.py
@@ -264,92 +264,93 @@ def test_can_user_manage_approval_status_false_if_unauthenticated():
     assert not version.can_user_manage_approval_status(None)
 
 
-@pytest.mark.django_db
-def test_is_visible_to_user():
-    version = PackageVersionFactory()
-    listing = PackageListingFactory(package=version.package)
-
-    user = UserFactory.create()
-
-    owner = UserFactory.create()
-    TeamMember.objects.create(
-        user=owner,
-        team=version.package.owner,
-        role=TeamMemberRole.owner,
-    )
-
-    moderator = UserFactory.create()
-    CommunityMembership.objects.create(
-        user=moderator,
-        community=listing.community,
-        role=CommunityMemberRole.moderator,
-    )
-
-    admin = UserFactory.create(is_superuser=True)
-
-    agents = {
-        "anonymous": None,
-        "user": user,
-        "owner": owner,
-        "moderator": moderator,
-        "admin": admin,
-    }
-
-    flags = [
-        "public_detail",
-        "owner_detail",
-        "moderator_detail",
-        "admin_detail",
-    ]
-
-    # Admins are also moderators but not owners
-    expected = {
-        "public_detail": {
-            "anonymous": True,
-            "user": True,
-            "owner": True,
-            "moderator": True,
-            "admin": True,
-        },
-        "owner_detail": {
-            "anonymous": False,
-            "user": False,
-            "owner": True,
-            "moderator": False,
-            "admin": False,
-        },
-        "moderator_detail": {
-            "anonymous": False,
-            "user": False,
-            "owner": False,
-            "moderator": True,
-            "admin": True,
-        },
-        "admin_detail": {
-            "anonymous": False,
-            "user": False,
-            "owner": False,
-            "moderator": False,
-            "admin": True,
-        },
-    }
-
-    for flag in flags:
-        version.visibility.public_detail = False
-        version.visibility.owner_detail = False
-        version.visibility.moderator_detail = False
-        version.visibility.admin_detail = False
-
-        setattr(version.visibility, flag, True)
-        version.visibility.save()
-
-        for role, subject in agents.items():
-            result = version.is_visible_to_user(subject)
-            assert result == expected[flag][role], (
-                f"Expected {flag} visibility for {role} to be "
-                f"{expected[flag][role]}, got {result}"
-            )
-
-    version.visibility = None
-
-    assert not version.is_visible_to_user(admin)
+# TODO: Re-enable once visibility system fixed
+# @pytest.mark.django_db
+# def test_is_visible_to_user():
+#     version = PackageVersionFactory()
+#     listing = PackageListingFactory(package=version.package)
+#
+#     user = UserFactory.create()
+#
+#     owner = UserFactory.create()
+#     TeamMember.objects.create(
+#         user=owner,
+#         team=version.package.owner,
+#         role=TeamMemberRole.owner,
+#     )
+#
+#     moderator = UserFactory.create()
+#     CommunityMembership.objects.create(
+#         user=moderator,
+#         community=listing.community,
+#         role=CommunityMemberRole.moderator,
+#     )
+#
+#     admin = UserFactory.create(is_superuser=True)
+#
+#     agents = {
+#         "anonymous": None,
+#         "user": user,
+#         "owner": owner,
+#         "moderator": moderator,
+#         "admin": admin,
+#     }
+#
+#     flags = [
+#         "public_detail",
+#         "owner_detail",
+#         "moderator_detail",
+#         "admin_detail",
+#     ]
+#
+#     # Admins are also moderators but not owners
+#     expected = {
+#         "public_detail": {
+#             "anonymous": True,
+#             "user": True,
+#             "owner": True,
+#             "moderator": True,
+#             "admin": True,
+#         },
+#         "owner_detail": {
+#             "anonymous": False,
+#             "user": False,
+#             "owner": True,
+#             "moderator": False,
+#             "admin": False,
+#         },
+#         "moderator_detail": {
+#             "anonymous": False,
+#             "user": False,
+#             "owner": False,
+#             "moderator": True,
+#             "admin": True,
+#         },
+#         "admin_detail": {
+#             "anonymous": False,
+#             "user": False,
+#             "owner": False,
+#             "moderator": False,
+#             "admin": True,
+#         },
+#     }
+#
+#     for flag in flags:
+#         version.visibility.public_detail = False
+#         version.visibility.owner_detail = False
+#         version.visibility.moderator_detail = False
+#         version.visibility.admin_detail = False
+#
+#         setattr(version.visibility, flag, True)
+#         version.visibility.save()
+#
+#         for role, subject in agents.items():
+#             result = version.is_visible_to_user(subject)
+#             assert result == expected[flag][role], (
+#                 f"Expected {flag} visibility for {role} to be "
+#                 f"{expected[flag][role]}, got {result}"
+#             )
+#
+#     version.visibility = None
+#
+#     assert not version.is_visible_to_user(admin)


### PR DESCRIPTION
Deactivate the visibility system's update logic, as it's currently not used for anything but ran into crashes in production.