### PR TITLE
Add attribute to allowed_attributes (TS-2545)

### DIFF
--- a/django/thunderstore/markdown/allowed_tags.py
+++ b/django/thunderstore/markdown/allowed_tags.py
@@ -86,4 +86,5 @@ ALLOWED_ATTRIBUTES = {
     "h5": ["align"],
     "h6": ["align"],
     "p": ["align"],
+    "details": ["open"],
 }


### PR DESCRIPTION
Add the 'open' attribute to the 'details' so it will be recognized by the markdown renderer.

Refs. TS-2545