### PR TITLE
Fix donation link form silent error

### DIFF
--- a/django/thunderstore/repository/forms/team.py
+++ b/django/thunderstore/repository/forms/team.py
@@ -199,5 +199,6 @@ class DonationLinkTeamForm(forms.ModelForm):
             )
         except ValidationError as e:
             self.add_error(None, e)
+            raise ValidationError(self.errors)
 
         return self.instance

--- a/django/thunderstore/repository/tests/test_team_forms.py
+++ b/django/thunderstore/repository/tests/test_team_forms.py
@@ -553,7 +553,8 @@ def test_form_donation_link_team_form_permissions(
         team.refresh_from_db()
         assert team.donation_link == link
     else:
-        form.save()
+        with pytest.raises(ValidationError):
+            form.save()
         assert form.is_valid() is False
         assert form.errors
         team.refresh_from_db()

--- a/django/thunderstore/repository/views/team_settings.py
+++ b/django/thunderstore/repository/views/team_settings.py
@@ -276,8 +276,10 @@ class SettingsTeamDonationLinkView(TeamDetailView, UserFormKwargs, UpdateView):
         return self.object.donation_link_url
 
     def form_valid(self, form: DonationLinkTeamForm):
-        self.object = form.save()
-        if form.errors:  # Check if service layer raised an error
+        try:
+            self.object = form.save()
+        except ValidationError:
             return super().form_invalid(form)
+
         messages.success(self.request, "Donation link saved")
-        return redirect(self.get_success_url())
+        return super().form_valid(form)


### PR DESCRIPTION
Update how the `DonationLinkTeamForm` handles the errors upon saving the donation link. The previous implementation did not raise an error upon saving the form, only added the error to the form's error list and the error was raised in the view.

Refs. None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Team donation link updates now fail gracefully with clear validation errors and no partial changes saved.
  * Successful updates redirect consistently and show the expected success message.
  * Improved form handling ensures errors are surfaced correctly and transactions are rolled back on failure.

* **Tests**
  * Updated tests to reflect new error-handling behavior, ensuring validation errors are raised and no unintended updates occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->