### PR TITLE
Query count tests (TS-2584)

### DIFF
--- a/django/thunderstore/api/cyberstorm/tests/endpoint_data.py
+++ b/django/thunderstore/api/cyberstorm/tests/endpoint_data.py
@@ -1,0 +1,70 @@
+ENDPOINTS = {
+    "GET": [
+        "/api/cyberstorm/community/",
+        "/api/cyberstorm/community/{community_id}/",
+        "/api/cyberstorm/community/{community_id}/filters/",
+        "/api/cyberstorm/listing/{community_id}/",
+        "/api/cyberstorm/listing/{community_id}/{namespace_id}/",
+        "/api/cyberstorm/listing/{community_id}/{namespace_id}/{package_name}/",
+        "/api/cyberstorm/listing/{community_id}/{namespace_id}/{package_name}/dependants/",
+        "/api/cyberstorm/package/{community_id}/{namespace_id}/{package_name}/permissions/",
+        "/api/cyberstorm/package/{namespace_id}/{package_name}/latest/changelog/",
+        "/api/cyberstorm/package/{namespace_id}/{package_name}/latest/readme/",
+        "/api/cyberstorm/package/{namespace_id}/{package_name}/v/{version_number}/changelog/",
+        "/api/cyberstorm/package/{namespace_id}/{package_name}/v/{version_number}/readme/",
+        "/api/cyberstorm/package/{namespace_id}/{package_name}/versions/",
+        "/api/cyberstorm/team/{team_id}/",
+        "/api/cyberstorm/team/{team_id}/member/",
+        "/api/cyberstorm/team/{team_id}/service-account/",
+    ],
+    "POST": {
+        "/api/cyberstorm/listing/{community_id}/{namespace_id}/{package_name}/approve/": {
+            "internal_notes": "This is an example internal note",
+        },
+        "/api/cyberstorm/listing/{community_id}/{namespace_id}/{package_name}/reject/": {
+            "rejection_reason": "This is an example rejection reason",
+        },
+        "/api/cyberstorm/listing/{community_id}/{namespace_id}/{package_name}/update/": {
+            "categories": ["test"],
+        },
+        "/api/cyberstorm/package/{namespace_id}/{package_name}/deprecate/": {
+            "deprecate": True,
+        },
+        "/api/cyberstorm/package/{namespace_id}/{package_name}/rate/": {
+            "target_state": "rated",
+        },
+        "/api/cyberstorm/team/create/": {
+            "name": "TestTeam",
+        },
+        "/api/cyberstorm/team/{team_name}/member/add/": {
+            "username": "TestUser",
+            "role": "member",
+        },
+    },
+    "PATCH": {
+        "/api/cyberstorm/team/{team_name}/update/": {
+            "donation_link": "https://example.com/donate",
+        },
+    },
+    "DELETE": [
+        "/api/cyberstorm/team/{team_name}/disband/",
+    ],
+}
+
+
+GET_TEST_CASES = [{"path": path} for path in ENDPOINTS["GET"]]
+
+
+POST_TEST_CASES = [
+    {"path": path, "payload": payload}
+    for path, payload in ENDPOINTS["POST"].items()
+]
+
+
+PATCH_TEST_CASES = [
+    {"path": path, "payload": payload}
+    for path, payload in ENDPOINTS["PATCH"].items()
+]
+
+
+DELETE_TEST_CASES = [{"path": path} for path in ENDPOINTS["DELETE"]]

--- a/django/thunderstore/api/cyberstorm/tests/endpoint_data.py
+++ b/django/thunderstore/api/cyberstorm/tests/endpoint_data.py
@@ -56,14 +56,12 @@ GET_TEST_CASES = [{"path": path} for path in ENDPOINTS["GET"]]
 
 
 POST_TEST_CASES = [
-    {"path": path, "payload": payload}
-    for path, payload in ENDPOINTS["POST"].items()
+    {"path": path, "payload": payload} for path, payload in ENDPOINTS["POST"].items()
 ]
 
 
 PATCH_TEST_CASES = [
-    {"path": path, "payload": payload}
-    for path, payload in ENDPOINTS["PATCH"].items()
+    {"path": path, "payload": payload} for path, payload in ENDPOINTS["PATCH"].items()
 ]
 
 

--- a/django/thunderstore/api/cyberstorm/tests/test_endpoints.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_endpoints.py
@@ -10,6 +10,7 @@ from thunderstore.api.cyberstorm.tests.utils import (
     convert_path_to_schema_style,
     extract_paths,
     fill_path_params,
+    get_parameter_values,
     get_resolver,
     get_schema,
     setup_superuser_with_package,
@@ -17,21 +18,6 @@ from thunderstore.api.cyberstorm.tests.utils import (
     validate_response_against_schema,
 )
 from thunderstore.api.urls import cyberstorm_urls
-from thunderstore.repository.models import PackageListing
-
-
-def get_parameter_values(package_listing: PackageListing) -> dict:
-    service_account = package_listing.package.owner.service_accounts.first()
-
-    return {
-        "community_id": package_listing.community.identifier,
-        "namespace_id": package_listing.package.owner.get_namespace().name,
-        "package_name": package_listing.package.name,
-        "version_number": package_listing.package.latest.version_number,
-        "team_id": package_listing.package.owner.name,
-        "team_name": package_listing.package.owner.name,
-        "uuid": service_account.uuid if service_account else "",
-    }
 
 
 @pytest.mark.django_db

--- a/django/thunderstore/api/cyberstorm/tests/test_endpoints.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_endpoints.py
@@ -1,62 +1,28 @@
 import pytest
 
+from thunderstore.api.cyberstorm.tests.endpoint_data import (
+    DELETE_TEST_CASES,
+    GET_TEST_CASES,
+    PATCH_TEST_CASES,
+    POST_TEST_CASES,
+)
 from thunderstore.api.cyberstorm.tests.utils import (
     convert_path_to_schema_style,
     extract_paths,
     fill_path_params,
     get_resolver,
     get_schema,
+    setup_superuser_with_package,
     validate_request_body_against_schema,
     validate_response_against_schema,
 )
 from thunderstore.api.urls import cyberstorm_urls
-from thunderstore.core.factories import UserFactory
-from thunderstore.repository.models import PackageListing, TeamMemberRole
-
-post_payload_map = {
-    "/api/cyberstorm/listing/{community_id}/{namespace_id}/{package_name}/approve/": {
-        "internal_notes": "This is an example internal note",
-    },
-    "/api/cyberstorm/listing/{community_id}/{namespace_id}/{package_name}/reject/": {
-        "rejection_reason": "This is an example rejection reason",
-    },
-    "/api/cyberstorm/listing/{community_id}/{namespace_id}/{package_name}/update/": {
-        "categories": ["test"],
-    },
-    "/api/cyberstorm/package/{namespace_id}/{package_name}/deprecate/": {
-        "deprecate": True,
-    },
-    "/api/cyberstorm/package/{namespace_id}/{package_name}/rate/": {
-        "target_state": "rated"
-    },
-    "/api/cyberstorm/team/create/": {
-        "name": "TestTeam",
-    },
-    "/api/cyberstorm/team/{team_name}/member/add/": {
-        "username": "TestUser",
-        "role": "member",
-    },
-}
-
-
-put_payload_map = {}
-
-
-patch_payload_map = {
-    "/api/cyberstorm/team/{team_name}/update/": {
-        "donation_link": "https://example.com/donate",
-    }
-}
-
-
-payload_mapping = {
-    "post": post_payload_map,
-    "put": put_payload_map,
-    "patch": patch_payload_map,
-}
+from thunderstore.repository.models import PackageListing
 
 
 def get_parameter_values(package_listing: PackageListing) -> dict:
+    service_account = package_listing.package.owner.service_accounts.first()
+
     return {
         "community_id": package_listing.community.identifier,
         "namespace_id": package_listing.package.owner.get_namespace().name,
@@ -64,89 +30,156 @@ def get_parameter_values(package_listing: PackageListing) -> dict:
         "version_number": package_listing.package.latest.version_number,
         "team_id": package_listing.package.owner.name,
         "team_name": package_listing.package.owner.name,
+        "uuid": service_account.uuid if service_account else "",
     }
 
 
-def setup_superuser_with_package(package_listing, package_category=None):
-    user = UserFactory()
-    user.is_superuser = True
-    user.save()
-
-    UserFactory.create(username="TestUser", email="test@user.dev", is_active=True)
-
-    package_listing.package.owner.add_member(
-        user=user,
-        role=TeamMemberRole.owner,
-    )
-
-    if package_category:
-        package_category.community = package_listing.community
-        package_category.save()
-
-    package_listing.package.latest.changelog = "# This is an example changelog"
-    package_listing.package.latest.readme = "# This is an example readme"
-    package_listing.package.latest.save()
-
-    return user
-
-
-def make_request(method: str, url: str, api_client, data: dict = {}):
-    method = method.lower()
-    client_method = getattr(api_client, method)
-
-    if method in ["get", "delete"]:
-        return client_method(url)
-    else:
-        return client_method(url, data=data, format="json")
-
-
 @pytest.mark.django_db
-@pytest.mark.parametrize("http_verb", ["get", "delete", "post", "put", "patch"])
-def test_cyberstorm_endpoint_schemas(
-    api_client, active_package_listing, package_category, http_verb
+@pytest.mark.parametrize("test_case", GET_TEST_CASES)
+def test_cyberstorm_GET_endpoint_schemas(
+    test_case, api_client, active_package_listing, package_category
 ):
+    api_path = test_case["path"]
     user = setup_superuser_with_package(active_package_listing, package_category)
+    api_client.force_authenticate(user)
+
     param_values = get_parameter_values(active_package_listing)
     schema = get_schema(api_client)
     resolver = get_resolver(schema)
-    api_paths = extract_paths(schema, "cyberstorm", http_verb)
-    matched_payload_map = payload_mapping.get(http_verb)
 
-    request_body = {}
+    url = fill_path_params(api_path, param_values)
+    response = api_client.get(url, format="json")
+
+    errors = validate_response_against_schema(
+        response=response,
+        path=api_path,
+        method="get",
+        schema=schema,
+        resolver=resolver,
+    )
+
+    if errors:
+        pytest.fail(f"Validation errors for GET {api_path}:\n" + "\n".join(errors))
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("test_case", DELETE_TEST_CASES)
+def test_cyberstorm_DELETE_endpoint_schemas(
+    test_case, api_client, active_package_listing, package_category, service_account
+):
+    api_path = test_case["path"]
+    user = setup_superuser_with_package(active_package_listing, package_category)
+    api_client.force_authenticate(user)
+
+    service_account.owner = active_package_listing.package.owner
+    service_account.save(update_fields=("owner",))
+
+    param_values = get_parameter_values(active_package_listing)
+    schema = get_schema(api_client)
+    resolver = get_resolver(schema)
+
+    url = fill_path_params(api_path, param_values)
+
+    if "disband" in api_path:
+        user.teams.first().team.owned_packages.all().delete()
+
+    response = api_client.delete(url, format="json")
+
+    errors = validate_response_against_schema(
+        response=response,
+        path=api_path,
+        method="delete",
+        schema=schema,
+        resolver=resolver,
+    )
+
+    if errors:
+        pytest.fail(f"Validation errors for DELETE {api_path}:\n" + "\n".join(errors))
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("test_case", POST_TEST_CASES)
+def test_cyberstorm_POST_endpoint_schemas(
+    test_case, api_client, active_package_listing, package_category
+):
+    api_path = test_case["path"]
+    payload = test_case["payload"]
+    user = setup_superuser_with_package(active_package_listing, package_category)
+    api_client.force_authenticate(user)
+
+    param_values = get_parameter_values(active_package_listing)
+    schema = get_schema(api_client)
+    resolver = get_resolver(schema)
     failures = []
 
-    for path in api_paths:
-        url = fill_path_params(path, param_values)
-        api_client.force_authenticate(user)
+    request_errors = validate_request_body_against_schema(
+        request_body=payload,
+        path=api_path,
+        method="post",
+        schema=schema,
+        resolver=resolver,
+    )
 
-        if matched_payload_map:
-            request_body = matched_payload_map.get(path, {})
-            errors = validate_request_body_against_schema(
-                request_body=request_body,
-                path=path,
-                method=http_verb,
-                schema=schema,
-                resolver=resolver,
-            )
+    if request_errors:
+        failures.extend(request_errors)
 
-            failures.extend(errors)
+    url = fill_path_params(api_path, param_values)
+    response = api_client.post(url, data=payload, format="json")
 
-        if "disband" in path:  # requires special handling in setup
-            user.teams.first().team.owned_packages.all().delete()
+    response_errors = validate_response_against_schema(
+        response=response,
+        path=api_path,
+        method="post",
+        schema=schema,
+        resolver=resolver,
+    )
 
-        response = make_request(
-            method=http_verb, url=url, api_client=api_client, data=request_body
-        )
+    if response_errors:
+        failures.extend(response_errors)
 
-        errors = validate_response_against_schema(
-            response=response,
-            path=path,
-            method=http_verb,
-            schema=schema,
-            resolver=resolver,
-        )
+    if failures:
+        pytest.fail("\n".join(failures))
 
-        failures.extend(errors)
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("test_case", PATCH_TEST_CASES)
+def test_cyberstorm_PATCH_endpoint_schemas(
+    test_case, api_client, active_package_listing, package_category
+):
+    api_path = test_case["path"]
+    payload = test_case["payload"]
+    user = setup_superuser_with_package(active_package_listing, package_category)
+    api_client.force_authenticate(user)
+
+    param_values = get_parameter_values(active_package_listing)
+    schema = get_schema(api_client)
+    resolver = get_resolver(schema)
+    failures = []
+
+    request_errors = validate_request_body_against_schema(
+        request_body=payload,
+        path=api_path,
+        method="patch",
+        schema=schema,
+        resolver=resolver,
+    )
+
+    if request_errors:
+        failures.extend(request_errors)
+
+    url = fill_path_params(api_path, param_values)
+    response = api_client.patch(url, data=payload, format="json")
+
+    response_errors = validate_response_against_schema(
+        response=response,
+        path=api_path,
+        method="patch",
+        schema=schema,
+        resolver=resolver,
+    )
+
+    if response_errors:
+        failures.extend(response_errors)
 
     if failures:
         pytest.fail("\n".join(failures))
@@ -165,16 +198,21 @@ def test_validate_extracted_paths_with_urlpatterns(api_client):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("http_verb", ["put", "patch", "post"])
-def test_find_missing_endpoints(api_client, http_verb):
-    schema = get_schema(api_client)
-    api_paths = extract_paths(schema, "cyberstorm", http_verb)
-    failures = []
+def test_find_missing_endpoints():
+    tested_paths = {
+        convert_path_to_schema_style(path["path"])
+        for path in GET_TEST_CASES
+        + POST_TEST_CASES
+        + PATCH_TEST_CASES
+        + DELETE_TEST_CASES
+    }
 
-    for path in api_paths:
-        url = convert_path_to_schema_style(path)
-        if url not in payload_mapping[http_verb]:
-            failures.append(f"Missing test coverage for: {url}")
+    existing_paths = {
+        convert_path_to_schema_style(f"/api/cyberstorm/{url.pattern}")
+        for url in cyberstorm_urls
+    }
 
-    if failures:
-        pytest.fail("\n".join(failures))
+    missing = existing_paths - tested_paths
+
+    if missing:
+        pytest.fail("Missing test coverage for:\n" + "\n".join(sorted(missing)))

--- a/django/thunderstore/api/cyberstorm/tests/test_query_count.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_query_count.py
@@ -1,0 +1,216 @@
+import factory
+import pytest
+
+from thunderstore.account.forms import CreateServiceAccountForm
+from thunderstore.api.cyberstorm.tests.endpoint_data import GET_TEST_CASES
+from thunderstore.community.models import Community
+from thunderstore.core.factories import UserFactory
+from thunderstore.repository.factories import PackageFactory, PackageVersionFactory
+from thunderstore.repository.models import (
+    PackageListing,
+    Team,
+    TeamMember,
+    TeamMemberRole,
+)
+
+from .utils import (
+    fill_path_params,
+    setup_superuser,
+    setup_superuser_with_package,
+    validate_max_queries,
+)
+
+MAX_QUERIES = 15
+
+
+def get_parameter_values(package_listing: PackageListing) -> dict:
+    service_account = package_listing.package.owner.service_accounts.first()
+
+    return {
+        "community_id": package_listing.community.identifier,
+        "namespace_id": package_listing.package.owner.get_namespace().name,
+        "package_name": package_listing.package.name,
+        "version_number": package_listing.package.latest.version_number,
+        "team_id": package_listing.package.owner.name,
+        "team_name": package_listing.package.owner.name,
+        "uuid": service_account.uuid if service_account else "",
+    }
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("test_case", GET_TEST_CASES)
+def test_cyberstorm_api_GET_query_count(
+    test_case, api_client, active_package_listing, package_category
+):
+    api_path = test_case["path"]
+    user = setup_superuser_with_package(active_package_listing, package_category)
+    api_client.force_authenticate(user)
+    param_values = get_parameter_values(active_package_listing)
+    url = fill_path_params(api_path, param_values)
+
+    validate_max_queries(
+        client=api_client,
+        method="get",
+        path=url,
+        max_queries=MAX_QUERIES,
+    )
+
+
+@pytest.mark.django_db
+def test_cybserstorm_community_list_query_count(api_client):
+    path = "/api/cyberstorm/community/"
+
+    communities = []
+
+    for x in range(20):
+        random_name = f"Community_{x}"
+        random_id = f"community_{x}"
+        communities.append(Community(name=random_name, identifier=random_id))
+
+    Community.objects.bulk_create(communities)
+
+    validate_max_queries(
+        client=api_client,
+        method="get",
+        path=path,
+        max_queries=MAX_QUERIES,
+    )
+
+
+@pytest.mark.django_db
+def test_cyberstorm_package_versions_list_query_count(api_client, active_package):
+    url = "/api/cyberstorm/package/{namespace_id}/{package_name}/versions/"
+
+    PackageVersionFactory.create_batch(
+        20,
+        package=active_package,
+        name=factory.Sequence(lambda n: f"{active_package.name}_2_0_{n+1}"),
+        version_number=factory.Sequence(lambda n: f"2.0.{n+1}"),
+        website_url="https://example.org",
+        description="Example mod",
+        readme="# This is an example mod",
+        changelog="# This is an example changelog",
+    )
+
+    user = setup_superuser()
+    api_client.force_authenticate(user)
+    path_params = {
+        "namespace_id": active_package.owner.get_namespace().name,
+        "package_name": active_package.name,
+    }
+    path = fill_path_params(url, path_params)
+
+    validate_max_queries(
+        client=api_client,
+        method="get",
+        path=path,
+        max_queries=MAX_QUERIES,
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        {"path": "/api/cyberstorm/listing/{community_id}/"},
+        {"path": "/api/cyberstorm/listing/{community_id}/{namespace_id}/"},
+    ],
+)
+def test_cyberstorm_package_listing_list_query_count(test_case, api_client):
+    amount = 20
+    community = Community.objects.create(
+        name="Test_Community", identifier="test_community"
+    )
+    team = Team.create(name="Test_Team")
+    namespace = team.get_namespace()
+
+    packages = PackageFactory.create_batch(
+        amount,
+        is_active=True,
+        is_deprecated=False,
+        owner=team,
+        namespace=namespace,
+        name=factory.Sequence(lambda n: f"Test_Package_{n}"),
+    )
+
+    PackageVersionFactory.create_batch(
+        amount,
+        package=factory.Iterator(packages),
+        name=factory.Iterator([pkg.name for pkg in packages]),
+        is_active=True,
+    )
+
+    PackageListing.objects.bulk_create(
+        [PackageListing(community=community, package=pkg) for pkg in packages]
+    )
+
+    api_path = test_case["path"]
+    user = setup_superuser()
+    api_client.force_authenticate(user)
+    path_params = {
+        "community_id": community.identifier,
+        "namespace_id": namespace.name,
+    }
+    url = fill_path_params(api_path, path_params)
+
+    validate_max_queries(
+        client=api_client,
+        method="get",
+        path=url,
+        max_queries=MAX_QUERIES,
+    )
+
+
+@pytest.mark.django_db
+def test_cyberstorm_team_member_list_query_count(api_client):
+    url = "/api/cyberstorm/team/{team_id}/member/"
+    user = setup_superuser()
+    team = Team.create(name="Test_Team")
+
+    users = UserFactory.create_batch(20)
+    TeamMember.objects.bulk_create(
+        [
+            TeamMember(team=team, user=member_user, role=TeamMemberRole.member)
+            for member_user in users
+        ]
+    )
+
+    api_client.force_authenticate(user)
+    url = fill_path_params(url, {"team_id": team.name})
+
+    validate_max_queries(
+        client=api_client,
+        method="get",
+        path=url,
+        max_queries=MAX_QUERIES,
+    )
+
+
+@pytest.mark.django_db
+def test_cyberstorm_team_service_accounts_list_query_count(api_client):
+    url = "/api/cyberstorm/team/{team_id}/service-account/"
+    user = setup_superuser()
+
+    team = Team.create(name="Test_Team")
+    team.add_member(user=user, role=TeamMemberRole.owner)
+
+    for x in range(20):
+        member_user = UserFactory.create(username=f"TestUser_{x+1}")
+        team.add_member(user=member_user, role=TeamMemberRole.owner)
+        form = CreateServiceAccountForm(
+            user,
+            data={"team": team, "nickname": f"ServiceAccount_{x}"},
+        )
+        form.is_valid()
+        form.save()
+
+    api_client.force_authenticate(user)
+    path_params = {"team_id": team.name}
+    url = fill_path_params(url, path_params)
+
+    validate_max_queries(
+        client=api_client,
+        method="get",
+        path=url,
+        max_queries=MAX_QUERIES,
+    )

--- a/django/thunderstore/api/cyberstorm/tests/utils.py
+++ b/django/thunderstore/api/cyberstorm/tests/utils.py
@@ -7,18 +7,25 @@ from jsonschema import RefResolver, ValidationError, validate
 from rest_framework.test import APIClient
 
 from thunderstore.core.factories import UserFactory
-from thunderstore.repository.models import TeamMemberRole
+from thunderstore.repository.models import PackageListing, TeamMemberRole
 
 
-def setup_superuser():
-    user = UserFactory()
-    user.is_superuser = True
-    user.save()
-    return user
+def get_parameter_values(package_listing: PackageListing) -> dict:
+    service_account = package_listing.package.owner.service_accounts.first()
+
+    return {
+        "community_id": package_listing.community.identifier,
+        "namespace_id": package_listing.package.owner.get_namespace().name,
+        "package_name": package_listing.package.name,
+        "version_number": package_listing.package.latest.version_number,
+        "team_id": package_listing.package.owner.name,
+        "team_name": package_listing.package.owner.name,
+        "uuid": service_account.uuid if service_account else "",
+    }
 
 
 def setup_superuser_with_package(package_listing, package_category=None):
-    user = setup_superuser()
+    user = UserFactory.create(is_superuser=True)
 
     UserFactory.create(username="TestUser", email="test@user.dev", is_active=True)
 


### PR DESCRIPTION
* Implement logic for query count tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added parameterized query-count tests that enforce a MAX_QUERIES limit for CyberStorm GET endpoints and surface SQL when exceeded.
  * Expanded coverage for community, package versions, listings, team members, and service accounts with data-driven GET/POST/PATCH/DELETE suites and per-verb schema validation.
  * Converted combined endpoint tests into separate per-verb test suites and improved missing-endpoint coverage checks.

* **Chores**
  * Introduced shared test-data and helper utilities to simplify authenticated setup, path parameter extraction, and query-count assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->