### PR TITLE
Add PackageVersionAPIView

### DIFF
--- a/django/thunderstore/api/cyberstorm/serializers/__init__.py
+++ b/django/thunderstore/api/cyberstorm/serializers/__init__.py
@@ -6,6 +6,7 @@ from .community import (
 from .package import (
     CyberstormPackageDependencySerializer,
     CyberstormPackagePreviewSerializer,
+    CyberstormPackageTeamSerializer,
     PackagePermissionsSerializer,
 )
 from .package_listing import PackageListingStatusResponseSerializer
@@ -19,8 +20,10 @@ from .team import (
     CyberstormTeamSerializer,
     CyberstormTeamUpdateSerializer,
 )
+from .utils import EmptyStringAsNoneField
 
 __all__ = [
+    "EmptyStringAsNoneField",
     "CyberstormTeamAddMemberRequestSerializer",
     "CyberstormTeamAddMemberResponseSerializer",
     "CyberstormCreateTeamSerializer",
@@ -29,6 +32,7 @@ __all__ = [
     "CyberstormPackageCategorySerializer",
     "CyberstormPackageListingSectionSerializer",
     "CyberstormPackagePreviewSerializer",
+    "CyberstormPackageTeamSerializer",
     "CyberstormServiceAccountSerializer",
     "CyberstormTeamMemberSerializer",
     "CyberstormTeamSerializer",

--- a/django/thunderstore/api/cyberstorm/serializers/__init__.py
+++ b/django/thunderstore/api/cyberstorm/serializers/__init__.py
@@ -10,6 +10,7 @@ from .package import (
     PackagePermissionsSerializer,
 )
 from .package_listing import PackageListingStatusResponseSerializer
+from .package_version import PackageVersionResponseSerializer
 from .team import (
     CyberstormCreateServiceAccountSerializer,
     CyberstormCreateTeamSerializer,
@@ -40,4 +41,5 @@ __all__ = [
     "CyberstormTeamUpdateSerializer",
     "CyberstormPackageDependencySerializer",
     "PackageListingStatusResponseSerializer",
+    "PackageVersionResponseSerializer",
 ]

--- a/django/thunderstore/api/cyberstorm/serializers/package.py
+++ b/django/thunderstore/api/cyberstorm/serializers/package.py
@@ -5,6 +5,7 @@ from rest_framework import serializers
 from thunderstore.api.cyberstorm.serializers.community import (
     CyberstormPackageCategorySerializer,
 )
+from thunderstore.api.cyberstorm.serializers.team import CyberstormTeamMemberSerializer
 from thunderstore.community.models import Community
 from thunderstore.repository.models import Namespace, Package, PackageVersion
 
@@ -77,3 +78,12 @@ class CyberstormPackageDependencySerializer(serializers.Serializer):
 
     def get_icon_url(self, obj: PackageVersion) -> Optional[str]:
         return obj.icon.url if obj.is_effectively_active else None
+
+
+class CyberstormPackageTeamSerializer(serializers.Serializer):
+    """
+    Minimal information to present the team on package detail view.
+    """
+
+    name = serializers.CharField()
+    members = CyberstormTeamMemberSerializer(many=True, source="public_members")

--- a/django/thunderstore/api/cyberstorm/serializers/package_version.py
+++ b/django/thunderstore/api/cyberstorm/serializers/package_version.py
@@ -1,0 +1,29 @@
+from rest_framework import serializers
+
+from thunderstore.api.cyberstorm.serializers.package import (
+    CyberstormPackageTeamSerializer,
+)
+from thunderstore.api.cyberstorm.serializers.utils import EmptyStringAsNoneField
+
+
+class PackageVersionResponseSerializer(serializers.Serializer):
+    """
+    Data shown on package version detail view.
+
+    Expects an annotated and customized CustomListing object.
+    """
+
+    datetime_created = serializers.DateTimeField(source="date_created")
+    dependency_count = serializers.IntegerField(min_value=0)
+    description = serializers.CharField()
+    download_count = serializers.IntegerField(source="downloads", min_value=0)
+    download_url = serializers.CharField(source="full_download_url")
+    full_version_name = serializers.CharField()
+    icon_url = serializers.CharField(source="icon.url")
+    install_url = serializers.CharField()
+    name = serializers.CharField()
+    version_number = serializers.CharField()
+    namespace = serializers.CharField(source="package.namespace.name")
+    size = serializers.IntegerField(min_value=0, source="file_size")
+    team = CyberstormPackageTeamSerializer(source="owner")
+    website_url = EmptyStringAsNoneField()

--- a/django/thunderstore/api/cyberstorm/serializers/utils.py
+++ b/django/thunderstore/api/cyberstorm/serializers/utils.py
@@ -1,0 +1,18 @@
+from rest_framework import serializers
+
+
+class EmptyStringAsNoneField(serializers.Field):
+    """
+    Serialize empty string to None and deserialize vice versa.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.allow_null = True
+        self.allow_blank = True
+
+    def to_representation(self, value):
+        return None if value == "" else value
+
+    def to_internal_value(self, data):
+        return "" if data is None else data

--- a/django/thunderstore/api/cyberstorm/tests/endpoint_data.py
+++ b/django/thunderstore/api/cyberstorm/tests/endpoint_data.py
@@ -11,6 +11,7 @@ ENDPOINTS = {
         "/api/cyberstorm/package/{community_id}/{namespace_id}/{package_name}/permissions/",
         "/api/cyberstorm/package/{namespace_id}/{package_name}/latest/changelog/",
         "/api/cyberstorm/package/{namespace_id}/{package_name}/latest/readme/",
+        "/api/cyberstorm/package/{namespace_id}/{package_name}/v/{version_number}/",
         "/api/cyberstorm/package/{namespace_id}/{package_name}/v/{version_number}/changelog/",
         "/api/cyberstorm/package/{namespace_id}/{package_name}/v/{version_number}/readme/",
         "/api/cyberstorm/package/{namespace_id}/{package_name}/v/{version_number}/dependencies/",

--- a/django/thunderstore/api/cyberstorm/tests/test_package_version.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_package_version.py
@@ -1,0 +1,87 @@
+from datetime import datetime
+
+import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from rest_framework.test import APIClient
+
+from thunderstore.repository.factories import PackageVersionFactory, TeamMemberFactory
+from thunderstore.repository.models.package_version import PackageVersion
+
+
+def _date_to_z(value: datetime) -> str:
+    return value.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def _get_version_url(pv: PackageVersion) -> str:
+    return f"/api/cyberstorm/package/{pv.package.namespace.name}/{pv.name}/v/{pv.version_number}/"
+
+
+# ---------------------------------------------------------------------------
+# API view tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_package_version_view__returns_info(api_client: APIClient) -> None:
+    pv1 = PackageVersionFactory(
+        downloads=12,
+        website_url="https://thunderstore.io/",
+        changelog="some changelog",
+    )
+    pv2 = PackageVersionFactory()
+    pv3 = PackageVersionFactory()
+    pv4 = PackageVersionFactory()
+
+    # Set multiple dependencies to ensure only direct dependencies are counted
+    pv1.dependencies.set([pv2, pv3])
+    # Set a dependency that is not direct
+    pv2.dependencies.set([pv4])
+
+    TeamMemberFactory(team=pv1.package.owner, role="owner")
+    TeamMemberFactory(team=pv1.package.owner, role="member")
+
+    url = _get_version_url(pv1)
+    response = api_client.get(url)
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["datetime_created"] == _date_to_z(pv1.date_created)
+    assert data["dependency_count"] == 2
+    assert data["description"] == pv1.description
+    assert data["download_count"] == pv1.downloads
+    assert data["download_url"] == pv1.full_download_url
+    assert data["full_version_name"] == pv1.full_version_name
+    assert data["icon_url"].startswith("http")
+    assert data["name"] == pv1.name
+    assert data["namespace"] == pv1.package.namespace.name
+    assert data["size"] == pv1.file_size
+    assert data["team"]["name"] == pv1.package.owner.name
+    assert "members" in data["team"]
+    assert data["website_url"] == "https://thunderstore.io/"
+
+
+@pytest.mark.django_db
+def test_package_version_view__serializes_url_correctly(api_client: APIClient) -> None:
+    pv = PackageVersionFactory(website_url="https://thunderstore.io/")
+    url = _get_version_url(pv)
+    assert api_client.get(url).json()["website_url"] == "https://thunderstore.io/"
+
+    pv.website_url = ""
+    pv.save(update_fields=("website_url",))
+    assert api_client.get(url).json()["website_url"] is None
+
+
+@pytest.mark.django_db
+def test_package_version_view__query_count(api_client: APIClient) -> None:
+    pv = PackageVersionFactory()
+    deps = [PackageVersionFactory() for _ in range(10)]
+    pv.dependencies.set(deps)
+    url = _get_version_url(pv)
+
+    with CaptureQueriesContext(connection) as ctx:
+        response = api_client.get(url)
+
+    assert response.status_code == 200
+    # Allow some overhead but ensure it's not exploding
+    assert len(ctx.captured_queries) < 20

--- a/django/thunderstore/api/cyberstorm/views/__init__.py
+++ b/django/thunderstore/api/cyberstorm/views/__init__.py
@@ -16,6 +16,7 @@ from .package_listing_list import (
 )
 from .package_permissions import PackagePermissionsAPIView
 from .package_rating import RatePackageAPIView
+from .package_version import PackageVersionAPIView
 from .package_version_list import (
     PackageVersionDependenciesListAPIView,
     PackageVersionListAPIView,
@@ -47,6 +48,7 @@ __all__ = [
     "PackageListingByDependencyListAPIView",
     "PackageListingByNamespaceListAPIView",
     "PackagePermissionsAPIView",
+    "PackageVersionAPIView",
     "PackageVersionChangelogAPIView",
     "PackageVersionDependenciesListAPIView",
     "PackageVersionListAPIView",

--- a/django/thunderstore/api/cyberstorm/views/package_listing.py
+++ b/django/thunderstore/api/cyberstorm/views/package_listing.py
@@ -22,7 +22,8 @@ from rest_framework.views import APIView
 
 from thunderstore.api.cyberstorm.serializers import (
     CyberstormPackageCategorySerializer,
-    CyberstormTeamMemberSerializer,
+    CyberstormPackageTeamSerializer,
+    EmptyStringAsNoneField,
     PackageListingStatusResponseSerializer,
 )
 from thunderstore.api.cyberstorm.views.package_listing_actions import (
@@ -73,32 +74,6 @@ class DependencySerializer(serializers.Serializer):
         return obj.version_is_unavailable
 
 
-class TeamSerializer(serializers.Serializer):
-    """
-    Minimal information to present the team on package detail view.
-    """
-
-    name = serializers.CharField()
-    members = CyberstormTeamMemberSerializer(many=True, source="public_members")
-
-
-class EmptyStringAsNoneField(serializers.Field):
-    """
-    Serialize empty string to None and deserialize vice versa.
-    """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.allow_null = True
-        self.allow_blank = True
-
-    def to_representation(self, value):
-        return None if value == "" else value
-
-    def to_internal_value(self, data):
-        return "" if data is None else data
-
-
 class ResponseSerializer(serializers.Serializer):
     """
     Data shown on package detail view.
@@ -132,7 +107,7 @@ class ResponseSerializer(serializers.Serializer):
     namespace = serializers.CharField(source="package.namespace.name")
     rating_count = serializers.IntegerField(min_value=0)
     size = serializers.IntegerField(min_value=0, source="package.latest.file_size")
-    team = TeamSerializer(source="package.owner")
+    team = CyberstormPackageTeamSerializer(source="package.owner")
     website_url = EmptyStringAsNoneField(source="package.latest.website_url")
 
 

--- a/django/thunderstore/api/cyberstorm/views/package_version.py
+++ b/django/thunderstore/api/cyberstorm/views/package_version.py
@@ -1,0 +1,51 @@
+from django.db.models import Count
+from django.http import HttpRequest
+from rest_framework import status
+from rest_framework.generics import get_object_or_404
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from thunderstore.api.cyberstorm.serializers.package_version import (
+    PackageVersionResponseSerializer,
+)
+from thunderstore.api.utils import (
+    CyberstormAutoSchemaMixin,
+    conditional_swagger_auto_schema,
+)
+from thunderstore.repository.models.package_version import PackageVersion
+
+
+class PackageVersionAPIView(CyberstormAutoSchemaMixin, APIView):
+    @conditional_swagger_auto_schema(
+        responses={200: PackageVersionResponseSerializer},
+        operation_id="cyberstorm.package_version",
+        tags=["cyberstorm"],
+    )
+    def get(
+        self,
+        request: HttpRequest,
+        namespace_id: str,
+        package_name: str,
+        version_number: str,
+    ) -> Response:
+        instance = get_object_or_404(
+            PackageVersion.objects.filter(is_active=True)
+            .select_related(
+                "package",
+                "package__namespace",
+            )
+            .prefetch_related(
+                "package__owner__members",
+            )
+            .annotate(
+                dependency_count=Count(
+                    "dependencies",
+                )
+            ),
+            package__namespace__name=namespace_id,
+            name=package_name,
+            version_number=version_number,
+        )
+
+        response_serializer = PackageVersionResponseSerializer(instance=instance)
+        return Response(response_serializer.data, status=status.HTTP_200_OK)

--- a/django/thunderstore/api/urls.py
+++ b/django/thunderstore/api/urls.py
@@ -15,6 +15,7 @@ from thunderstore.api.cyberstorm.views import (
     PackageListingByNamespaceListAPIView,
     PackageListingStatusAPIView,
     PackagePermissionsAPIView,
+    PackageVersionAPIView,
     PackageVersionChangelogAPIView,
     PackageVersionDependenciesListAPIView,
     PackageVersionListAPIView,
@@ -96,6 +97,11 @@ cyberstorm_urls = [
         "package/<str:namespace_id>/<str:package_name>/latest/readme/",
         PackageVersionReadmeAPIView.as_view(),
         name="cyberstorm.package.latest.readme",
+    ),
+    path(
+        "package/<str:namespace_id>/<str:package_name>/v/<str:version_number>/",
+        PackageVersionAPIView.as_view(),
+        name="cyberstorm.package.version",
     ),
     path(
         "package/<str:namespace_id>/<str:package_name>/v/<str:version_number>/changelog/",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - New API endpoint returning detailed package version metadata (created date, dependency count, downloads, download URL, icon URL, size, team, website URL).

- **Bug Fixes**
  - Empty website URLs now serialize as null instead of empty strings.
  - Package responses now include exposed team info with member lists.

- **Breaking Changes**
  - Team field in package listing responses changed to a unified structure including member details.

- **Performance**
  - Package version detail retrieval optimized to reduce DB queries.

- **Tests**
  - Added tests for package version response structure, serialization, and query performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->