### PR TITLE
Cyberstorm api dependencies endpoint (TS-2639)

### DIFF
--- a/django/thunderstore/api/cyberstorm/serializers/__init__.py
+++ b/django/thunderstore/api/cyberstorm/serializers/__init__.py
@@ -3,7 +3,11 @@ from .community import (
     CyberstormPackageCategorySerializer,
     CyberstormPackageListingSectionSerializer,
 )
-from .package import CyberstormPackagePreviewSerializer, PackagePermissionsSerializer
+from .package import (
+    CyberstormPackageDependencySerializer,
+    CyberstormPackagePreviewSerializer,
+    PackagePermissionsSerializer,
+)
 from .team import (
     CyberstormCreateTeamSerializer,
     CyberstormServiceAccountSerializer,
@@ -27,4 +31,5 @@ __all__ = [
     "CyberstormTeamSerializer",
     "PackagePermissionsSerializer",
     "CyberstormTeamUpdateSerializer",
+    "CyberstormPackageDependencySerializer",
 ]

--- a/django/thunderstore/api/cyberstorm/serializers/package.py
+++ b/django/thunderstore/api/cyberstorm/serializers/package.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from rest_framework import serializers
 
 from thunderstore.api.cyberstorm.serializers.community import (
@@ -55,3 +57,23 @@ class CyberstormPackagePreviewSerializer(serializers.Serializer):
     rating_count = serializers.IntegerField(min_value=0)
     size = serializers.IntegerField(min_value=0)
     datetime_created = serializers.DateTimeField()
+
+
+class CyberstormPackageDependencySerializer(serializers.Serializer):
+    description = serializers.SerializerMethodField()
+    icon_url = serializers.SerializerMethodField()
+    is_active = serializers.BooleanField(source="is_effectively_active")
+    name = serializers.CharField()
+    namespace = serializers.CharField(source="package.namespace.name")
+    version_number = serializers.CharField()
+    is_removed = serializers.BooleanField()
+
+    def get_description(self, obj: PackageVersion) -> str:
+        return (
+            obj.description
+            if obj.is_effectively_active
+            else "This package has been removed."
+        )
+
+    def get_icon_url(self, obj: PackageVersion) -> Optional[str]:
+        return obj.icon.url if obj.is_effectively_active else None

--- a/django/thunderstore/api/cyberstorm/tests/test_package_version_list.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_package_version_list.py
@@ -1,7 +1,11 @@
+from typing import Optional
+
 import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from rest_framework.test import APIClient
 
-from thunderstore.repository.factories import PackageVersionFactory
+from thunderstore.repository.factories import PackageFactory, PackageVersionFactory
 from thunderstore.repository.models import Package
 
 
@@ -48,3 +52,109 @@ def test_package_version_list_api_view__returns_versions(
 
     assert len(actual) == 1
     assert actual[0]["version_number"] == expected.version_number
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "version, should_raise_404",
+    [
+        ("1.0.0", False),
+        ("latest", False),
+        ("hello", True),
+        ("world", True),
+        (None, True),
+        ("", True),
+    ],
+)
+def test_package_version_dependencies_list(
+    api_client: APIClient,
+    version: Optional[str],
+    should_raise_404: bool,
+) -> None:
+    """ "Test the PackageVersionDependenciesListAPIView with different version inputs."""
+
+    dependency_count = 1
+
+    package = PackageFactory(name="TestPackage")
+    PackageVersionFactory(package=package)
+
+    target_dependencies = [PackageVersionFactory() for _ in range(dependency_count)]
+    package.latest.dependencies.set([dep.id for dep in target_dependencies])
+
+    namespace = package.namespace.name
+    package_name = package.name
+
+    url = (
+        f"/api/cyberstorm/package/{namespace}/{package_name}/v/{version}/dependencies/"
+    )
+    response = api_client.get(url)
+
+    if should_raise_404:
+        assert response.status_code == 404
+    else:
+        assert response.status_code == 200
+        assert response.json()["count"] == dependency_count
+
+
+@pytest.mark.django_db
+def test_package_version_dependencies_query_count(api_client: APIClient) -> None:
+    """Ensure that the number of database queries remains low regardless with 100 dependencies."""
+
+    dependency_count = 100
+    query_count = 25
+
+    package = PackageFactory(name="TestPackage")
+    PackageVersionFactory(package=package)
+
+    target_dependencies = [PackageVersionFactory() for _ in range(dependency_count)]
+    package.latest.dependencies.set([dep.id for dep in target_dependencies])
+
+    namespace = package.namespace.name
+    package_name = package.name
+    url = f"/api/cyberstorm/package/{namespace}/{package_name}/v/latest/dependencies/"
+
+    with CaptureQueriesContext(connection) as ctx:
+        response = api_client.get(url)
+
+    assert response.status_code == 200
+    assert len(ctx.captured_queries) <= query_count
+
+
+@pytest.mark.django_db
+def test_package_version_dependencies_list_response(api_client: APIClient) -> None:
+    """Test the response structure of the PackageVersionDependenciesListAPIView."""
+
+    dependency_count = 1
+
+    package = PackageFactory(name="TestPackage")
+    PackageVersionFactory(package=package)
+
+    target_dependencies = [PackageVersionFactory() for _ in range(dependency_count)]
+    package.latest.dependencies.set([dep.id for dep in target_dependencies])
+
+    namespace = package.namespace.name
+    package_name = package.name
+
+    url = f"/api/cyberstorm/package/{namespace}/{package_name}/v/latest/dependencies/"
+    response = api_client.get(url)
+
+    target_version = target_dependencies[0]
+    expected_data = {
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [
+            {
+                "description": target_version.description,
+                "icon_url": target_version.icon.url,
+                "is_active": True,
+                "name": target_version.name,
+                "namespace": target_version.package.namespace.name,
+                "version_number": target_version.version_number,
+                "is_removed": False,
+            }
+        ],
+    }
+
+    assert response.status_code == 200
+    assert response.json() == expected_data

--- a/django/thunderstore/api/cyberstorm/views/__init__.py
+++ b/django/thunderstore/api/cyberstorm/views/__init__.py
@@ -16,7 +16,10 @@ from .package_listing_list import (
 )
 from .package_permissions import PackagePermissionsAPIView
 from .package_rating import RatePackageAPIView
-from .package_version_list import PackageVersionListAPIView
+from .package_version_list import (
+    PackageVersionDependenciesListAPIView,
+    PackageVersionListAPIView,
+)
 from .team import (
     DisbandTeamAPIView,
     TeamAPIView,
@@ -39,6 +42,7 @@ __all__ = [
     "PackageListingByNamespaceListAPIView",
     "PackagePermissionsAPIView",
     "PackageVersionChangelogAPIView",
+    "PackageVersionDependenciesListAPIView",
     "PackageVersionListAPIView",
     "PackageVersionReadmeAPIView",
     "TeamAPIView",

--- a/django/thunderstore/api/cyberstorm/views/markdown.py
+++ b/django/thunderstore/api/cyberstorm/views/markdown.py
@@ -60,7 +60,7 @@ def get_package_version(
     version_number: Optional[str],
 ) -> PackageVersion:
     package = get_object_or_404(
-        Package.objects.active(),
+        Package.objects.active().select_related("latest"),
         namespace__name=namespace_id,
         name=package_name,
     )

--- a/django/thunderstore/api/cyberstorm/views/package_version_list.py
+++ b/django/thunderstore/api/cyberstorm/views/package_version_list.py
@@ -1,8 +1,14 @@
+from django.db.models import QuerySet
 from rest_framework import serializers
 from rest_framework.generics import ListAPIView, get_object_or_404
 
+from thunderstore.api.cyberstorm.serializers import (
+    CyberstormPackageDependencySerializer,
+)
+from thunderstore.api.cyberstorm.views.markdown import get_package_version
+from thunderstore.api.pagination import PackageDependenciesPaginator
 from thunderstore.api.utils import CyberstormAutoSchemaMixin
-from thunderstore.repository.models import Package
+from thunderstore.repository.models import Package, PackageVersion
 
 
 class CyberstormPackageVersionSerializer(serializers.Serializer):
@@ -28,3 +34,27 @@ class PackageVersionListAPIView(CyberstormAutoSchemaMixin, ListAPIView):
         )
 
         return package.versions.active()
+
+
+class PackageVersionDependenciesListAPIView(CyberstormAutoSchemaMixin, ListAPIView):
+    serializer_class = CyberstormPackageDependencySerializer
+    pagination_class = PackageDependenciesPaginator
+
+    def get_queryset(self) -> QuerySet[PackageVersion]:
+        version_number = self.kwargs.get("version_number")
+        if version_number == "latest":
+            version_number = None  # get_package_version understands None as latest
+
+        package_version = get_package_version(
+            namespace_id=self.kwargs["namespace_id"],
+            package_name=self.kwargs["package_name"],
+            version_number=version_number,
+        )
+
+        qs = (
+            package_version.dependencies.all()
+            .select_related("package", "package__namespace")
+            .order_by("package__namespace__name", "package__name")
+        )
+
+        return qs

--- a/django/thunderstore/api/pagination.py
+++ b/django/thunderstore/api/pagination.py
@@ -1,0 +1,5 @@
+from rest_framework.pagination import PageNumberPagination
+
+
+class PackageDependenciesPaginator(PageNumberPagination):
+    page_size = 20

--- a/django/thunderstore/api/urls.py
+++ b/django/thunderstore/api/urls.py
@@ -13,6 +13,7 @@ from thunderstore.api.cyberstorm.views import (
     PackageListingByNamespaceListAPIView,
     PackagePermissionsAPIView,
     PackageVersionChangelogAPIView,
+    PackageVersionDependenciesListAPIView,
     PackageVersionListAPIView,
     PackageVersionReadmeAPIView,
     RatePackageAPIView,
@@ -96,6 +97,11 @@ cyberstorm_urls = [
         "package/<str:namespace_id>/<str:package_name>/v/<str:version_number>/readme/",
         PackageVersionReadmeAPIView.as_view(),
         name="cyberstorm.package.version.readme",
+    ),
+    path(
+        "package/<str:namespace_id>/<str:package_name>/v/<str:version_number>/dependencies/",
+        PackageVersionDependenciesListAPIView.as_view(),
+        name="cyberstorm.package.version.dependencies-list",
     ),
     path(
         "package/<str:namespace_id>/<str:package_name>/versions/",


### PR DESCRIPTION
- Updated get_package_version() to use select_related for optimized queries.
- Implemented a serializer for package dependencies.
- Added an API list view to handle requests.
- Registered a new endpoint and included tests.