### PR TITLE
Cyberstorm api report package (TS-2638)

### DIFF
--- a/django/thunderstore/api/cyberstorm/tests/endpoint_data.py
+++ b/django/thunderstore/api/cyberstorm/tests/endpoint_data.py
@@ -30,6 +30,9 @@ ENDPOINTS = {
         "/api/cyberstorm/listing/{community_id}/{namespace_id}/{package_name}/update/": {
             "categories": ["test"],
         },
+        "/api/cyberstorm/listing/{community_id}/{namespace_id}/{package_name}/report/": {
+            "reason": "Spam",
+        },
         "/api/cyberstorm/package/{namespace_id}/{package_name}/deprecate/": {
             "deprecate": True,
         },

--- a/django/thunderstore/api/cyberstorm/tests/test_package_listing_actions.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_package_listing_actions.py
@@ -27,25 +27,8 @@ def get_reject_url(package_listing):
     return f"{get_base_url(package_listing)}/reject/"
 
 
-def perform_404_test(
-    api_client: APIClient,
-    active_package_listing: PackageListing,
-    user: UserType,
-    url: str,
-):
-    active_package_listing.package.owner.add_member(user, role="owner")
-    api_client.force_authenticate(user=user)
-
-    data = json.dumps(
-        {
-            "rejection_reason": "Invalid content",
-            "internal_notes": "Some internal notes",
-        }
-    )
-
-    response = api_client.post(url, data=data, content_type="application/json")
-    assert response.status_code == 404
-    assert response.json() == {"detail": "Not found."}
+def get_report_url(package_listing):
+    return f"{get_base_url(package_listing)}/report/"
 
 
 def perform_package_listing_action_test(
@@ -54,6 +37,7 @@ def perform_package_listing_action_test(
     user_type: str,
     url: str,
     data: dict,
+    expected_status_code_map: dict = None,
 ):
     user = TestUserTypes.get_user_by_type(user_type)
 
@@ -68,28 +52,64 @@ def perform_package_listing_action_test(
 
     package_listing.refresh_from_db()
 
-    expected_status_code = {
-        TestUserTypes.no_user: 401,
-        TestUserTypes.unauthenticated: 401,
-        TestUserTypes.regular_user: 403,
-        TestUserTypes.deactivated_user: 403,
-        TestUserTypes.service_account: 403,
-        TestUserTypes.site_admin: 200,
-        TestUserTypes.superuser: 200,
-    }
+    if not expected_status_code_map:
+        expected_status_code_map = {
+            TestUserTypes.no_user: 401,
+            TestUserTypes.unauthenticated: 401,
+            TestUserTypes.regular_user: 403,
+            TestUserTypes.deactivated_user: 403,
+            TestUserTypes.service_account: 403,
+            TestUserTypes.site_admin: 200,
+            TestUserTypes.superuser: 200,
+        }
 
-    assert response.status_code == expected_status_code[user_type]
+    assert response.status_code == expected_status_code_map[user_type]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("url_action", ["update", "approve", "reject", "report"])
+@pytest.mark.parametrize(
+    "invalid_field", ["community_id", "namespace_id", "package_name"]
+)
+def test_action_endpoints_404(
+    url_action: str,
+    invalid_field: str,
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+    user: UserType,
+):
+    community_id = active_package_listing.community.identifier
+    namespace_id = active_package_listing.package.namespace.name
+    package_name = active_package_listing.package.name
+
+    if invalid_field == "community_id":
+        community_id = "invalid-id"
+    elif invalid_field == "namespace_id":
+        namespace_id = "invalid-id"
+    elif invalid_field == "package_name":
+        package_name = "invalid-name"
+
+    url = (
+        f"/api/cyberstorm/listing/"
+        f"{community_id}/{namespace_id}/{package_name}/{url_action}/"
+    )
+
+    active_package_listing.package.owner.add_member(user, role="owner")
+    api_client.force_authenticate(user=user)
+
+    response = api_client.post(url, data={}, content_type="application/json")
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Not found."}
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("user_type", TestUserTypes.options())
-def test_update_categories_success(
+def test_update_package_listing(
     active_package_listing: PackageListing,
     api_client: APIClient,
     package_category: PackageCategory,
     user_type: str,
 ):
-
     perform_package_listing_action_test(
         api_client=api_client,
         package_listing=active_package_listing,
@@ -106,7 +126,6 @@ def test_reject_package_listing(
     active_package_listing: PackageListing,
     user_type: str,
 ):
-
     perform_package_listing_action_test(
         api_client=api_client,
         package_listing=active_package_listing,
@@ -150,50 +169,6 @@ def test_approve_package_listing(
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("url_action", ["update", "approve", "reject"])
-def test_get_community_404(
-    url_action: str,
-    api_client: APIClient,
-    active_package_listing: PackageListing,
-    user: UserType,
-):
-    url = (
-        f"/api/cyberstorm/listing/invalid_community_id/"
-        f"{active_package_listing.package.namespace.name}/"
-        f"{active_package_listing.package.name}/{url_action}/"
-    )
-
-    perform_404_test(
-        api_client=api_client,
-        active_package_listing=active_package_listing,
-        user=user,
-        url=url,
-    )
-
-
-@pytest.mark.django_db
-@pytest.mark.parametrize("url_action", ["update", "approve", "reject"])
-def test_get_package_404(
-    url_action: str,
-    api_client: APIClient,
-    active_package_listing: PackageListing,
-    user: UserType,
-):
-    url = (
-        f"/api/cyberstorm/listing/{active_package_listing.community.identifier}/"
-        f"{active_package_listing.package.namespace.name}/"
-        f"invalid_package_name/{url_action}/"
-    )
-
-    perform_404_test(
-        api_client=api_client,
-        active_package_listing=active_package_listing,
-        user=user,
-        url=url,
-    )
-
-
-@pytest.mark.django_db
 @patch(
     "thunderstore.community.models.package_listing.PackageListing.can_user_manage_approval_status"
 )
@@ -219,3 +194,45 @@ def test_reject_package_listing_permission_error(
 
     response = api_client.post(url, data=data, content_type="application/json")
     assert response.status_code == 403
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("user_type", TestUserTypes.options())
+def test_report_package_listing(
+    active_package_listing: PackageListing,
+    api_client: APIClient,
+    user_type: str,
+):
+    expected_status_code_map = {
+        TestUserTypes.no_user: 401,
+        TestUserTypes.unauthenticated: 401,
+        TestUserTypes.regular_user: 200,
+        TestUserTypes.deactivated_user: 403,
+        TestUserTypes.service_account: 403,
+        TestUserTypes.site_admin: 200,
+        TestUserTypes.superuser: 200,
+    }
+
+    perform_package_listing_action_test(
+        api_client=api_client,
+        package_listing=active_package_listing,
+        user_type=user_type,
+        url=get_report_url(active_package_listing),
+        data={"reason": "Spam"},
+        expected_status_code_map=expected_status_code_map,
+    )
+
+
+@pytest.mark.django_db
+def test_report_package_listing_required_fields(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+):
+    user = TestUserTypes.get_user_by_type(TestUserTypes.site_admin)
+    api_client.force_authenticate(user=user)
+
+    url = get_report_url(active_package_listing)
+    response = api_client.post(url, data={}, content_type="application/json")
+
+    assert response.status_code == 400
+    assert response.json() == {"reason": ["This field is required."]}

--- a/django/thunderstore/api/cyberstorm/views/__init__.py
+++ b/django/thunderstore/api/cyberstorm/views/__init__.py
@@ -7,6 +7,7 @@ from .package_listing import PackageListingAPIView, PackageListingStatusAPIView
 from .package_listing_actions import (
     ApprovePackageListingAPIView,
     RejectPackageListingAPIView,
+    ReportPackageListingAPIView,
     UpdatePackageListingCategoriesAPIView,
 )
 from .package_listing_list import (
@@ -67,4 +68,5 @@ __all__ = [
     "RejectPackageListingAPIView",
     "ApprovePackageListingAPIView",
     "UpdateTeamAPIView",
+    "ReportPackageListingAPIView",
 ]

--- a/django/thunderstore/api/urls.py
+++ b/django/thunderstore/api/urls.py
@@ -24,6 +24,7 @@ from thunderstore.api.cyberstorm.views import (
     PackageVersionReadmeAPIView,
     RatePackageAPIView,
     RejectPackageListingAPIView,
+    ReportPackageListingAPIView,
     TeamAPIView,
     TeamCreateAPIView,
     TeamMemberAddAPIView,
@@ -84,6 +85,11 @@ cyberstorm_urls = [
         "listing/<str:community_id>/<str:namespace_id>/<str:package_name>/approve/",
         ApprovePackageListingAPIView.as_view(),
         name="cyberstorm.listing.approve",
+    ),
+    path(
+        "listing/<str:community_id>/<str:namespace_id>/<str:package_name>/report/",
+        ReportPackageListingAPIView.as_view(),
+        name="cyberstorm.listing.report",
     ),
     path(
         "listing/<str:community_id>/<str:namespace_id>/<str:package_name>/reject/",


### PR DESCRIPTION
Implement view, URL and tests for reporting packages. Utilize existing service layer function and serializer used in the Experimental API.