### PR TITLE
Optimize dependencies list queryset query (TS-2672)

### DIFF
--- a/django/thunderstore/api/cyberstorm/serializers/package.py
+++ b/django/thunderstore/api/cyberstorm/serializers/package.py
@@ -67,7 +67,15 @@ class CyberstormPackageDependencySerializer(serializers.Serializer):
     name = serializers.CharField()
     namespace = serializers.CharField(source="package.namespace.name")
     version_number = serializers.CharField()
-    is_removed = serializers.BooleanField()
+    is_removed = serializers.SerializerMethodField()
+
+    def get_is_removed(self, obj: PackageVersion) -> bool:
+        package_is_removed = not (
+            obj.package.is_active and obj.package_has_active_versions
+        )
+        if package_is_removed:
+            return True
+        return not obj.is_active
 
     def get_description(self, obj: PackageVersion) -> str:
         return (

--- a/django/thunderstore/api/cyberstorm/tests/test_query_count.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_query_count.py
@@ -233,5 +233,5 @@ def test_package_version_dependencies_query_count(api_client: APIClient) -> None
         client=api_client,
         method="get",
         path=path,
-        max_queries=25,  # TODO: this could be optimized further
+        max_queries=MAX_QUERIES,
     )

--- a/django/thunderstore/api/cyberstorm/views/package_version_list.py
+++ b/django/thunderstore/api/cyberstorm/views/package_version_list.py
@@ -1,4 +1,4 @@
-from django.db.models import QuerySet
+from django.db.models import Exists, OuterRef, QuerySet
 from rest_framework import serializers
 from rest_framework.generics import ListAPIView, get_object_or_404
 
@@ -54,6 +54,13 @@ class PackageVersionDependenciesListAPIView(CyberstormAutoSchemaMixin, ListAPIVi
         qs = (
             package_version.dependencies.all()
             .select_related("package", "package__namespace")
+            .annotate(
+                package_has_active_versions=Exists(
+                    PackageVersion.objects.filter(
+                        package_id=OuterRef("package__pk"), is_active=True
+                    )
+                )
+            )
             .order_by("package__namespace__name", "package__name")
         )
 


### PR DESCRIPTION
Annotate the queryset with active_package_versions instead of calling PackageVersion.is_removed, which avoids triggering an N+1 query.

Refs. TS-2672