### PR TITLE
Disallow latest in dependencies list view (TS-2731)

### DIFF
--- a/django/thunderstore/api/cyberstorm/tests/test_package_version_list.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_package_version_list.py
@@ -57,7 +57,7 @@ def test_package_version_list_api_view__returns_versions(
     "version, should_raise_404",
     [
         ("1.0.0", False),
-        ("latest", False),
+        ("latest", True),
         ("hello", True),
         ("world", True),
         (None, True),
@@ -108,8 +108,9 @@ def test_package_version_dependencies_list_response(api_client: APIClient) -> No
 
     namespace = package.namespace.name
     package_name = package.name
+    version_number = package.latest.version_number
 
-    url = f"/api/cyberstorm/package/{namespace}/{package_name}/v/latest/dependencies/"
+    url = f"/api/cyberstorm/package/{namespace}/{package_name}/v/{version_number}/dependencies/"
     response = api_client.get(url)
 
     target_version = target_dependencies[0]
@@ -157,8 +158,9 @@ def test_package_version_dependencies_list_version_is_active(
 
     namespace = package.namespace.name
     package_name = package.name
+    version_number = package.latest.version_number
 
-    url = f"/api/cyberstorm/package/{namespace}/{package_name}/v/latest/dependencies/"
+    url = f"/api/cyberstorm/package/{namespace}/{package_name}/v/{version_number}/dependencies/"
     response = api_client.get(url)
 
     assert response.status_code == 200

--- a/django/thunderstore/api/cyberstorm/tests/test_query_count.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_query_count.py
@@ -224,7 +224,7 @@ def test_package_version_dependencies_query_count(api_client: APIClient) -> None
     path_params = {
         "namespace_id": package.namespace.name,
         "package_name": package.name,
-        "version": "latest",
+        "version": package.latest.version_number,
     }
 
     path = fill_path_params(url, path_params)

--- a/django/thunderstore/api/cyberstorm/views/package_version_list.py
+++ b/django/thunderstore/api/cyberstorm/views/package_version_list.py
@@ -41,14 +41,10 @@ class PackageVersionDependenciesListAPIView(CyberstormAutoSchemaMixin, ListAPIVi
     pagination_class = PackageDependenciesPaginator
 
     def get_queryset(self) -> QuerySet[PackageVersion]:
-        version_number = self.kwargs.get("version_number")
-        if version_number == "latest":
-            version_number = None  # get_package_version understands None as latest
-
         package_version = get_package_version(
             namespace_id=self.kwargs["namespace_id"],
             package_name=self.kwargs["package_name"],
-            version_number=version_number,
+            version_number=self.kwargs["version_number"],
         )
 
         qs = (


### PR DESCRIPTION
Make specific version a requirement in
PackageVersionDependenciesListAPIView a requirement instead and disallow using "latest" in the URL for fetching latest version.

Refs. TS-2731