### PR TITLE
Add hidden propert to PackageCategory model

### DIFF
--- a/builder/src/api/models.ts
+++ b/builder/src/api/models.ts
@@ -88,6 +88,7 @@ export interface CurrentUserInfo {
 export interface PackageCategory {
     name: string;
     slug: string;
+    hidden: boolean;
 }
 
 export interface PackageAvailableCommunity {

--- a/builder/src/components/CommunitySelector.tsx
+++ b/builder/src/components/CommunitySelector.tsx
@@ -24,7 +24,9 @@ const CategorySelector: React.FC<CategorySelectorProps> = ({
             : ExperimentalApi.listCategories({ communityIdentifier });
 
         promise.then((result) => {
-            const next = current.concat(result.results);
+            // Filter out hidden categories for UI dropdown
+            const visible = result.results.filter((c) => !c.hidden);
+            const next = current.concat(visible);
             setCategories(next);
             if (result.pagination.next_link) {
                 enumerateCategories(

--- a/django/thunderstore/api/cyberstorm/serializers/community.py
+++ b/django/thunderstore/api/cyberstorm/serializers/community.py
@@ -44,6 +44,7 @@ class CyberstormPackageCategorySerializer(serializers.Serializer):
     id = serializers.CharField()  # noqa: A003
     name = serializers.CharField()
     slug = serializers.SlugField()
+    hidden = serializers.BooleanField()
 
 
 class CyberstormPackageListingSectionSerializer(serializers.Serializer):

--- a/django/thunderstore/api/cyberstorm/tests/test_community_filters.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_community_filters.py
@@ -10,8 +10,8 @@ def test_community_filters_api_view__returns_package_categories(
     api_client: APIClient,
     community: Community,
 ):
-    c1 = PackageCategoryFactory(community=community)
-    c2 = PackageCategoryFactory(community=community)
+    c1 = PackageCategoryFactory(community=community, hidden=False)
+    c2 = PackageCategoryFactory(community=community, hidden=True)
 
     response = api_client.get(
         f"/api/cyberstorm/community/{community.identifier}/filters/",
@@ -19,11 +19,10 @@ def test_community_filters_api_view__returns_package_categories(
     result = response.json()
 
     assert len(result["package_categories"]) == 2
-    category_ids = [c["id"] for c in result["package_categories"]]
-    assert isinstance(category_ids[0], str)
-    assert isinstance(category_ids[1], str)
-    assert str(c1.id) in category_ids
-    assert str(c2.id) in category_ids
+    # Hidden categories should be included in API response
+    by_id = {c["id"]: c for c in result["package_categories"]}
+    assert by_id[str(c1.id)]["hidden"] is False
+    assert by_id[str(c2.id)]["hidden"] is True
 
 
 @pytest.mark.django_db

--- a/django/thunderstore/community/admin/package_category.py
+++ b/django/thunderstore/community/admin/package_category.py
@@ -5,11 +5,12 @@ from ..models.package_category import PackageCategory
 
 @admin.register(PackageCategory)
 class PackageCategoryAdmin(admin.ModelAdmin):
-    list_filter = ("community",)
+    list_filter = ("community", "hidden")
     list_display = (
         "id",
         "name",
         "slug",
+        "hidden",
         "datetime_created",
         "datetime_updated",
         "community",

--- a/django/thunderstore/community/api/experimental/serializers.py
+++ b/django/thunderstore/community/api/experimental/serializers.py
@@ -25,6 +25,7 @@ class PackageListingUpdateRequestSerializer(serializers.Serializer):
 class PackageCategoryExperimentalSerializer(serializers.Serializer):
     name = serializers.CharField()
     slug = serializers.SlugField()
+    hidden = serializers.BooleanField()
 
 
 class PackageListingUpdateResponseSerializer(serializers.Serializer):

--- a/django/thunderstore/community/migrations/0038_add_packagecategory_hidden.py
+++ b/django/thunderstore/community/migrations/0038_add_packagecategory_hidden.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("community", "0037_create_default_visibility_for_existing_listings"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="packagecategory",
+            name="hidden",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/django/thunderstore/community/models/package_category.py
+++ b/django/thunderstore/community/models/package_category.py
@@ -1,11 +1,19 @@
 from django.db import models
-from django.db.models import Manager
 
 from thunderstore.core.mixins import TimestampMixin
 
 
+class PackageCategoryQuerySet(models.QuerySet):
+    def visible(self):
+        return self.filter(hidden=False)
+
+
+class PackageCategoryManager(models.Manager.from_queryset(PackageCategoryQuerySet)):
+    pass
+
+
 class PackageCategory(TimestampMixin, models.Model):
-    objects: "Manager[PackageCategory]"
+    objects = PackageCategoryManager()
     community = models.ForeignKey(
         "community.Community",
         related_name="package_categories",
@@ -13,6 +21,7 @@ class PackageCategory(TimestampMixin, models.Model):
     )
     name = models.CharField(max_length=512)
     slug = models.SlugField()
+    hidden = models.BooleanField(default=False)
 
     def __str__(self):
         return f"{self.community.name} -> {self.name}"

--- a/django/thunderstore/community/tests/test_package_category_queryset.py
+++ b/django/thunderstore/community/tests/test_package_category_queryset.py
@@ -1,0 +1,51 @@
+import pytest
+
+from thunderstore.community.factories import CommunityFactory, PackageListingFactory
+from thunderstore.community.models import PackageCategory
+
+
+@pytest.mark.django_db
+def test_packagecategory_objects_visible_filters_hidden_flag():
+    community = CommunityFactory()
+    visible = PackageCategory.objects.create(
+        community=community, name="Visible", slug="visible", hidden=False
+    )
+    hidden = PackageCategory.objects.create(
+        community=community, name="Hidden", slug="hidden", hidden=True
+    )
+
+    result = list(PackageCategory.objects.visible().order_by("slug"))
+
+    assert result == [visible]
+    assert hidden not in result
+
+
+@pytest.mark.django_db
+def test_related_manager_visible_on_community_package_categories():
+    community = CommunityFactory()
+    visible = PackageCategory.objects.create(
+        community=community, name="Visible", slug="visible", hidden=False
+    )
+    PackageCategory.objects.create(
+        community=community, name="Hidden", slug="hidden", hidden=True
+    )
+
+    result = list(community.package_categories.visible().order_by("slug"))
+
+    assert result == [visible]
+
+
+@pytest.mark.django_db
+def test_related_manager_visible_on_listing_categories():
+    listing = PackageListingFactory()
+    visible = PackageCategory.objects.create(
+        community=listing.community, name="Visible", slug="visible", hidden=False
+    )
+    hidden = PackageCategory.objects.create(
+        community=listing.community, name="Hidden", slug="hidden", hidden=True
+    )
+    listing.categories.set([visible, hidden])
+
+    result = list(listing.categories.visible().order_by("slug"))
+
+    assert result == [visible]

--- a/django/thunderstore/frontend/api/experimental/tests/test_community_package_list.py
+++ b/django/thunderstore/frontend/api/experimental/tests/test_community_package_list.py
@@ -476,3 +476,376 @@ def __query_api(client: APIClient, identifier: str, query: str = "") -> Dict:
     response = client.get(f"{url}?{query}")
     assert response.status_code == 200
     return response.json()
+
+
+from typing import Dict, List, Union
+
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from thunderstore.cache.enums import CacheBustCondition
+from thunderstore.cache.tasks import invalidate_cache
+from thunderstore.community.consts import PackageListingReviewStatus
+from thunderstore.community.factories import CommunitySiteFactory, PackageListingFactory
+from thunderstore.community.models import PackageCategory, PackageListingSection
+from thunderstore.community.models.package_listing import PackageListing
+from thunderstore.frontend.api.experimental.views import CommunityPackageListApiView
+from thunderstore.repository.factories import (
+    PackageRatingFactory,
+    PackageVersionFactory,
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def clear_pagination_cache():
+    invalidate_cache(CacheBustCondition.any_package_updated)
+
+
+@pytest.mark.django_db
+def test_only_packages_listed_in_community_are_returned(api_client: APIClient) -> None:
+    listing1 = PackageListingFactory()
+    PackageListingFactory()
+
+    data = __query_api(api_client, listing1.community.identifier)
+
+    __assert_packages_by_listings(data, listing1)
+
+
+@pytest.mark.django_db
+def test_only_active_packages_are_returned(api_client: APIClient) -> None:
+    listing1 = PackageListingFactory(package_kwargs={"is_active": False})
+    PackageListingFactory()
+
+    data = __query_api(api_client, listing1.community.identifier)
+
+    assert len(data["packages"]) == 0
+
+
+@pytest.mark.django_db
+def test_only_community_listings_for_correct_community_are_included_in_queryset() -> None:
+    """
+    Due to the implementation, test case
+    test_only_packages_listed_in_community_are_returned might
+    incorrectly pass sometimes when data is returned from the database
+    in a fortunate order. That test case still has its uses, since this
+    one only checks a small part of the data fetching implementation.
+    """
+    listing1 = PackageListingFactory()
+    listing2 = PackageListingFactory(package_=listing1.package)
+
+    qs1 = CommunityPackageListApiView().get_queryset(listing1.community)
+    qs2 = CommunityPackageListApiView().get_queryset(listing2.community)
+
+    assert len(qs1.all()) == 1
+    assert len(qs1.all()[0].community_listings.all()) == 1
+    assert (
+        qs1.all()[0].community_listings.all()[0].community.name
+        == listing1.community.name
+    )
+    assert len(qs2.all()) == 1
+    assert len(qs2.all()[0].community_listings.all()) == 1
+    assert (
+        qs2.all()[0].community_listings.all()[0].community.name
+        == listing2.community.name
+    )
+
+
+@pytest.mark.django_db
+def test_rejected_packages_are_not_returned(api_client: APIClient) -> None:
+    listing1 = PackageListingFactory(
+        review_status=PackageListingReviewStatus.unreviewed
+    )
+    listing2 = PackageListingFactory(
+        community_=listing1.community, review_status=PackageListingReviewStatus.approved
+    )
+    PackageListingFactory(
+        community_=listing1.community, review_status=PackageListingReviewStatus.rejected
+    )
+
+    data = __query_api(api_client, listing1.community.identifier)
+
+    __assert_packages_by_listings(data, [listing2, listing1])
+
+
+@pytest.mark.django_db
+def test_only_approved_packages_are_returned_when_approval_is_required(
+    api_client: APIClient,
+) -> None:
+    listing1 = PackageListingFactory(
+        review_status=PackageListingReviewStatus.unreviewed
+    )
+    listing1.community.require_package_listing_approval = True
+    listing1.community.save()
+    listing2 = PackageListingFactory(
+        community_=listing1.community, review_status=PackageListingReviewStatus.approved
+    )
+    PackageListingFactory(
+        community_=listing1.community, review_status=PackageListingReviewStatus.rejected
+    )
+
+    data = __query_api(api_client, listing1.community.identifier)
+
+    __assert_packages_by_listings(data, listing2)
+
+
+@pytest.mark.django_db
+def test_deprecated_packages_are_returned_only_when_requested(
+    api_client: APIClient,
+) -> None:
+    active = PackageListingFactory()
+    PackageListingFactory(
+        community_=active.community, package_kwargs={"is_deprecated": True}
+    )
+
+    data = __query_api(api_client, active.community.identifier)
+
+    __assert_packages_by_listings(data, active)
+
+    data = __query_api(api_client, active.community.identifier, "deprecated=on")
+
+    assert len(data["packages"]) == 2
+
+
+@pytest.mark.django_db
+def test_nsfw_packages_are_returned_only_when_requested(api_client: APIClient) -> None:
+    sfw = PackageListingFactory()
+    PackageListingFactory(community_=sfw.community, has_nsfw_content=True)
+
+    data = __query_api(api_client, sfw.community.identifier)
+
+    __assert_packages_by_listings(data, sfw)
+
+    data = __query_api(api_client, sfw.community.identifier, "nsfw=true")
+
+    assert len(data["packages"]) == 2
+
+
+@pytest.mark.django_db
+def test_packages_are_filtered_by_required_categories(api_client: APIClient) -> None:
+    site = CommunitySiteFactory()
+    cat1 = PackageCategory.objects.create(
+        name="c1", slug="c1", community=site.community
+    )
+    cat2 = PackageCategory.objects.create(
+        name="c2", slug="c2", community=site.community
+    )
+    PackageListingFactory(community_=site.community)
+    pl2 = PackageListingFactory(community_=site.community, categories=[cat1])
+    pl3 = PackageListingFactory(community_=site.community, categories=[cat2])
+
+    data = __query_api(
+        api_client, site.community.identifier, f"included_categories={cat1.slug}"
+    )
+
+    __assert_packages_by_listings(data, pl2)
+
+    data = __query_api(
+        api_client,
+        site.community.identifier,
+        f"included_categories={cat1.slug}&included_categories={cat2.slug}",
+    )
+
+    __assert_packages_by_listings(data, [pl3, pl2])
+
+
+@pytest.mark.django_db
+def test_packages_are_filtered_by_excluded_categories(api_client: APIClient) -> None:
+    site = CommunitySiteFactory()
+    cat1 = PackageCategory.objects.create(
+        name="c1", slug="c1", community=site.community
+    )
+    cat2 = PackageCategory.objects.create(
+        name="c2", slug="c2", community=site.community
+    )
+    pl1 = PackageListingFactory(community_=site.community)
+    PackageListingFactory(community_=site.community, categories=[cat1])
+    pl3 = PackageListingFactory(community_=site.community, categories=[cat2])
+
+    data = __query_api(
+        api_client, site.community.identifier, f"excluded_categories={cat1.slug}"
+    )
+
+    __assert_packages_by_listings(data, [pl3, pl1])
+
+    data = __query_api(
+        api_client,
+        site.community.identifier,
+        f"excluded_categories={cat1.slug}&excluded_categories={cat2.slug}",
+    )
+
+    __assert_packages_by_listings(data, pl1)
+
+
+@pytest.mark.django_db
+def test_packages_are_filtered_by_sections(api_client: APIClient) -> None:
+    site = CommunitySiteFactory()
+    required = PackageCategory.objects.create(
+        name="r", slug="r", community=site.community
+    )
+    excluded = PackageCategory.objects.create(
+        name="e", slug="e", community=site.community
+    )
+    irrelevant = PackageCategory.objects.create(
+        name="i", slug="i", community=site.community
+    )
+    section = PackageListingSection.objects.create(
+        name="Modpacks", slug="modpacks", community=site.community
+    )
+    section.require_categories.set([required])
+    section.exclude_categories.set([excluded])
+    expected = PackageListingFactory(community_=site.community, categories=[required])
+    PackageListingFactory(community_=site.community, categories=[required, excluded])
+    PackageListingFactory(community_=site.community, categories=[excluded])
+    PackageListingFactory(community_=site.community, categories=[irrelevant])
+
+    data = __query_api(api_client, site.community.identifier, f"section={section.slug}")
+
+    __assert_packages_by_listings(data, expected)
+
+
+@pytest.mark.django_db
+def test_packages_are_filtered_by_query(api_client: APIClient) -> None:
+    site = CommunitySiteFactory()
+    listing1 = PackageListingFactory(community_=site.community)
+    listing2 = PackageListingFactory(community_=site.community)
+    listing3 = PackageListingFactory(community_=site.community)
+
+    data = __query_api(
+        api_client, site.community.identifier, f"q={listing1.package.name}"
+    )
+
+    __assert_packages_by_listings(data, listing1)
+
+    data = __query_api(
+        api_client, site.community.identifier, f"q={listing2.package.owner.name}"
+    )
+
+    __assert_packages_by_listings(data, listing2)
+
+    data = __query_api(
+        api_client,
+        site.community.identifier,
+        f"q={listing3.package.latest.description}",
+    )
+
+    __assert_packages_by_listings(data, listing3)
+
+
+@pytest.mark.django_db
+def test_packages_are_ordered_by_update_date_by_default(api_client: APIClient) -> None:
+    site = CommunitySiteFactory()
+    listing1 = PackageListingFactory(
+        community_=site.community,
+        package_kwargs={"date_updated": "2022-02-02 01:23:45Z"},
+    )
+    listing2 = PackageListingFactory(
+        community_=site.community,
+        package_kwargs={"date_updated": "2022-02-22 01:23:45Z"},
+    )
+    listing3 = PackageListingFactory(
+        community_=site.community,
+        package_kwargs={"date_updated": "2022-02-12 01:23:45Z"},
+    )
+
+    data = __query_api(api_client, site.community.identifier)
+
+    __assert_packages_by_listings(data, [listing2, listing3, listing1])
+
+
+@pytest.mark.django_db
+def test_packages_can_be_ordered_by_creation_date(api_client: APIClient) -> None:
+    site = CommunitySiteFactory()
+    listing1 = PackageListingFactory(
+        community_=site.community,
+        package_kwargs={"date_created": "2022-02-12 01:23:45Z"},
+    )
+    listing2 = PackageListingFactory(
+        community_=site.community,
+        package_kwargs={"date_created": "2022-02-22 01:23:45Z"},
+    )
+    listing3 = PackageListingFactory(
+        community_=site.community,
+        package_kwargs={"date_created": "2022-02-02 01:23:45Z"},
+    )
+
+    data = __query_api(api_client, site.community.identifier, "ordering=newest")
+
+    __assert_packages_by_listings(data, [listing2, listing1, listing3])
+
+
+@pytest.mark.django_db
+def test_paginated_results_are_cached(api_client: APIClient) -> None:
+    # First request should fetch fresh data.
+    listing = PackageListingFactory(package_version_kwargs={"downloads": 1})
+
+    data = __query_api(api_client, listing.community.identifier)
+
+    assert len(data["packages"]) == 1
+    assert data["packages"][0]["download_count"] == 1
+
+    # Changes shouldn't be returned until cache is busted.
+    listing.package.latest.downloads = 3
+    listing.package.latest.save()
+
+    data = __query_api(api_client, listing.community.identifier)
+
+    assert len(data["packages"]) == 1
+    assert data["packages"][0]["download_count"] == 1
+
+    # Manual cache busting should update the results.
+    invalidate_cache(CacheBustCondition.any_package_updated)
+
+    data = __query_api(api_client, listing.community.identifier)
+
+    assert len(data["packages"]) == 1
+    assert data["packages"][0]["download_count"] == 3
+
+
+@pytest.mark.django_db
+def test_hidden_categories_are_excluded_from_ui_lists(api_client: APIClient) -> None:
+    site = CommunitySiteFactory()
+    visible = PackageCategory.objects.create(
+        name="visible", slug="visible", community=site.community, hidden=False
+    )
+    hidden = PackageCategory.objects.create(
+        name="hidden", slug="hidden", community=site.community, hidden=True
+    )
+    # listing with both categories
+    listing = PackageListingFactory(
+        community_=site.community, categories=[visible, hidden]
+    )
+
+    data = __query_api(api_client, site.community.identifier)
+
+    # Top-level categories should exclude hidden
+    top_categories = data["categories"]
+    assert {c["slug"] for c in top_categories} == {"visible"}
+
+    # Package card categories should exclude hidden
+    assert len(data["packages"]) == 1
+    pkg_categories = data["packages"][0]["categories"]
+    assert {c["slug"] for c in pkg_categories} == {"visible"}
+
+
+def __query_api(
+    client: APIClient, community_identifier: str, query_params: str = ""
+) -> Dict[str, Union[str, int, bool, List[Dict]]]:
+    url = reverse(
+        "api:experimental:frontend.community.packages",
+        kwargs={"community_identifier": community_identifier},
+    )
+    if query_params:
+        url = f"{url}?{query_params}"
+    response = client.get(url)
+    assert response.status_code == 200
+    return response.json()
+
+
+def __assert_packages_by_listings(data, listings):
+    if not isinstance(listings, list):
+        listings = [listings]
+
+    assert len(listings) == len(data["packages"])
+    for index, expected in enumerate(listings):
+        assert expected.package.name == data["packages"][index]["package_name"]

--- a/django/thunderstore/frontend/api/experimental/views/community_package_list.py
+++ b/django/thunderstore/frontend/api/experimental/views/community_package_list.py
@@ -245,7 +245,7 @@ class CommunityPackageListApiView(APIView):
             {
                 "categories": [
                     PackageCategorySerializer(c).data
-                    for c in p.community_listings.all()[0].categories.all()
+                    for c in p.community_listings.all()[0].categories.visible()
                 ],
                 "community_identifier": community.identifier,
                 "community_name": community.name,
@@ -270,7 +270,7 @@ class CommunityPackageListApiView(APIView):
                 "cover_image_src": community.cover_image_url,
                 "categories": [
                     PackageCategorySerializer(c).data
-                    for c in community.package_categories.all()
+                    for c in community.package_categories.visible()
                 ],
                 "community_name": community.name,
                 "packages": packages,

--- a/django/thunderstore/frontend/api/experimental/views/package_details.py
+++ b/django/thunderstore/frontend/api/experimental/views/package_details.py
@@ -110,7 +110,8 @@ class PackageDetailApiView(APIView):
                 "bg_image_src": listing.community.background_image_url,
                 "cover_image_src": listing.community.cover_image_url,
                 "categories": [
-                    PackageCategorySerializer(c).data for c in listing.categories.all()
+                    PackageCategorySerializer(c).data
+                    for c in listing.categories.visible()
                 ],
                 "community_name": listing.community.name,
                 "community_identifier": listing.community.identifier,

--- a/django/thunderstore/repository/views/package/detail.py
+++ b/django/thunderstore/repository/views/package/detail.py
@@ -152,11 +152,11 @@ class PackageDetailView(PackageListingDetailView):
             "canUpdateCategories": self.permissions_checker.can_manage_categories,
             "csrfToken": self.csrf_token,
             "currentCategories": [
-                format_category(x) for x in package_listing.categories.all()
+                format_category(x) for x in package_listing.categories.visible()
             ],
             "availableCategories": [
                 format_category(x)
-                for x in package_listing.community.package_categories.all()
+                for x in package_listing.community.package_categories.visible()
             ],
             "packageListingId": package_listing.pk,
         }

--- a/django/thunderstore/schema_import/schema.py
+++ b/django/thunderstore/schema_import/schema.py
@@ -11,6 +11,7 @@ class SchemaThunderstoreSection(BaseModel):
 
 class SchemaThunderstoreCategory(BaseModel):
     label: str
+    hidden: bool = False
 
 
 class SchemaCommunity(BaseModel):

--- a/django/thunderstore/schema_import/sync.py
+++ b/django/thunderstore/schema_import/sync.py
@@ -69,6 +69,7 @@ def import_community(identifier: str, schema: SchemaCommunity):
         ):
             category = PackageCategory(slug=k, community=community)
         category.name = v.label
+        category.hidden = getattr(v, "hidden", False)
         category.save()
 
     for index, (k, v) in enumerate(schema.sections.items()):

--- a/django/thunderstore/schema_import/tests/test_sync.py
+++ b/django/thunderstore/schema_import/tests/test_sync.py
@@ -93,3 +93,31 @@ def test_import_autolisted_packages(active_package: Package):
     assert PackageListing.objects.filter(is_auto_imported=True).count() == 0
     import_schema_communities(schema)
     assert PackageListing.objects.filter(is_auto_imported=True).count() == 1
+
+
+@pytest.mark.django_db
+def test_import_categories_hidden_flag():
+    schema = Schema(
+        schemaVersion="0.0.1",
+        games=dict(),
+        communities={
+            "test": SchemaCommunity(
+                displayName="Test community",
+                categories={
+                    "visible": {"label": "Visible", "hidden": False},
+                    "hidden": {"label": "Hidden Cat", "hidden": True},
+                },
+                sections=dict(),
+                shortDescription=None,
+                discordUrl=None,
+                wikiUrl=None,
+                autolistPackageIds=None,
+            ),
+        },
+        packageInstallers=dict(),
+    )
+    import_schema_communities(schema)
+    community = Community.objects.get(identifier="test")
+    cats = {c.slug: c for c in community.package_categories.all()}
+    assert cats["visible"].hidden is False
+    assert cats["hidden"].hidden is True


### PR DESCRIPTION
Add a new `hidden` property to the `PackageCategory` model and disable rendering of hidden categories on the UI side.

Include the property in APIs that return categories as objects so frontend can be updated to exclude them.