### PR TITLE
Remove @lru_cache

### DIFF
--- a/django/thunderstore/api/cyberstorm/tests/test_package_listing.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_package_listing.py
@@ -436,7 +436,7 @@ def test_package_listing_query_count(
         response = api_client.get(url)
 
     assert response.status_code == 200
-    assert len(ctx.captured_queries) < 20
+    assert len(ctx.captured_queries) < 23
 
 
 @pytest.mark.django_db

--- a/django/thunderstore/community/models/community.py
+++ b/django/thunderstore/community/models/community.py
@@ -279,11 +279,9 @@ class Community(TimestampMixin, models.Model):
                 "Must be a janitor or higher to manage categories"
             )
 
-    @lru_cache
     def can_user_manage_packages(self, user: Optional[UserType]) -> bool:
         return check_validity(lambda: self.ensure_user_can_moderate_packages(user))
 
-    @lru_cache
     def can_user_manage_categories(self, user: Optional[UserType]) -> bool:
         return check_validity(lambda: self.ensure_user_can_manage_categories(user))
 


### PR DESCRIPTION
Increases the query count by at least 3 for cyberstorm's package listing endpoint and potentially others