### PR TITLE
Improve team member filter query

### DIFF
--- a/django/thunderstore/social/api/experimental/views/current_user.py
+++ b/django/thunderstore/social/api/experimental/views/current_user.py
@@ -58,7 +58,7 @@ class CurrentUserTeamPermissionsExperimentalApiView(TeamPermissionsMixin, APIVie
     def get(self, request, team_name: str):
         team_member = TeamMember.objects.real_users().get(
             team__name=team_name,
-            user__username=request.user.username,
+            user=request.user,
         )
 
         serializer = self.serializer_class(


### PR DESCRIPTION
Improve a query for finding the team membership of the current user in the `CurrentUserTeamPermissionsExperimentalApiView`

Previous implementation relied on a table join that was unnecessary