### PR TITLE
Cyberstorm API: allow saving team "profile" with empty donation link

### DIFF
--- a/django/thunderstore/api/cyberstorm/serializers/team.py
+++ b/django/thunderstore/api/cyberstorm/serializers/team.py
@@ -59,7 +59,7 @@ class CyberstormCreateTeamSerializer(serializers.Serializer):
 
 class CyberstormTeamUpdateSerializer(serializers.Serializer):
     donation_link = serializers.CharField(
-        max_length=1024, validators=[URLValidator(["https"])]
+        allow_null=True, max_length=1024, validators=[URLValidator(schemes=["https"])]
     )
 
 

--- a/django/thunderstore/api/cyberstorm/tests/test_team.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_team.py
@@ -350,6 +350,28 @@ def test_team_update_succeeds(
 
 
 @pytest.mark.django_db
+def test_team_update_succeeds_unset_donation_link(
+    api_client: APIClient,
+    user: UserType,
+    team: Team,
+):
+    TeamMemberFactory(team=team, user=user, role="owner")
+    team.donation_link = "https://example.com"
+    team.save()
+    api_client.force_authenticate(user)
+
+    response = api_client.patch(
+        f"/api/cyberstorm/team/{team.name}/update/",
+        json.dumps({"donation_link": None}),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"donation_link": None}
+    assert Team.objects.get(pk=team.pk).donation_link is None
+
+
+@pytest.mark.django_db
 def test_team_update_fails_user_not_authenticated(
     api_client: APIClient,
     team: Team,


### PR DESCRIPTION
- URLValidator rejects empty strings, but teams must be able to unset a previously used donation link
- Skipping the validation for empty string was attempted, but that will make saving the team fail, since the model field uses the cursed null=True rule
- Casting empty string to null before validation was attempted (the team form used by the legacy site behaves this way) but I couldn't find a clean place to do so. The serializers shouldn't change the received value and editing the received data in view function felt dirty. Decided to change the client to submit nulls instead of empty strings