### PR TITLE
Cyberstorm API: add endpoint for package listing version

### DIFF
--- a/django/thunderstore/api/cyberstorm/tests/endpoint_data.py
+++ b/django/thunderstore/api/cyberstorm/tests/endpoint_data.py
@@ -8,6 +8,7 @@ ENDPOINTS = {
         "/api/cyberstorm/listing/{community_id}/{namespace_id}/{package_name}/",
         "/api/cyberstorm/listing/{community_id}/{namespace_id}/{package_name}/dependants/",
         "/api/cyberstorm/listing/{community_id}/{namespace_id}/{package_name}/status/",
+        "/api/cyberstorm/listing/{community_id}/{namespace_id}/{package_name}/v/{version_number}/",
         "/api/cyberstorm/package/{community_id}/{namespace_id}/{package_name}/permissions/",
         "/api/cyberstorm/package/{namespace_id}/{package_name}/latest/changelog/",
         "/api/cyberstorm/package/{namespace_id}/{package_name}/latest/readme/",

--- a/django/thunderstore/api/urls.py
+++ b/django/thunderstore/api/urls.py
@@ -70,6 +70,11 @@ cyberstorm_urls = [
         name="cyberstorm.listing",
     ),
     path(
+        "listing/<str:community_id>/<str:namespace_id>/<str:package_name>/v/<str:version_number>/",
+        PackageListingAPIView.as_view(),
+        name="cyberstorm.listing",
+    ),
+    path(
         "listing/<str:community_id>/<str:namespace_id>/<str:package_name>/status/",
         PackageListingStatusAPIView.as_view(),
         name="cyberstorm.listing.status",


### PR DESCRIPTION
Conceptually this muddies the water since listing is package scoped. However, the UI supports showing the community listing page for the latest version (default), or a specific version. We want to use this endpoint since it verifies that the listing is not rejected, ensuring we don't serve malicious content on the web page. This is in contrast to PackageVersionAPIView which doesn't check rejection status, as it doesn't have a way to so since it doesn't have access to community.

In the future we could consider having the package listing endpoint which returns only the listing and package specific fields, and a separate endpoint which returns the package version related fields while checking that the parent package is actually available. This would remove the conceptual ambiguity and improve cacheability.