### PR TITLE
Optimize package index cache serialization

### DIFF
--- a/django/thunderstore/repository/api/v1/serializers.py
+++ b/django/thunderstore/repository/api/v1/serializers.py
@@ -1,3 +1,5 @@
+from distutils.version import StrictVersion
+
 from rest_framework.fields import Field
 from rest_framework.serializers import ModelSerializer, SerializerMethodField
 
@@ -64,15 +66,22 @@ class PackageListingSerializer(ModelSerializer):
     date_created = RelatedObjectField(relation_name="package")
     date_updated = RelatedObjectField(relation_name="package")
     uuid4 = RelatedObjectField(relation_name="package")
-    rating_score = RelatedObjectField(relation_name="package")
+    rating_score = SerializerMethodField()
     is_pinned = RelatedObjectField(relation_name="package")
     is_deprecated = RelatedObjectField(relation_name="package")
     categories = SerializerMethodField()
     versions = SerializerMethodField()
 
     def get_versions(self, instance):
-        versions = instance.package.available_versions
+        versions = sorted(
+            [v for v in instance.package.versions.all() if v.is_active],
+            key=lambda v: StrictVersion(v.version_number),
+            reverse=True,
+        )
         return PackageVersionSerializer(versions, many=True, context=self.context).data
+
+    def get_rating_score(self, instance):
+        return instance.rating_score
 
     def get_owner(self, instance):
         return instance.package.owner.name

--- a/django/thunderstore/repository/api/v1/tests/test_caches.py
+++ b/django/thunderstore/repository/api/v1/tests/test_caches.py
@@ -13,12 +13,17 @@ from thunderstore.community.factories import (
     SiteFactory,
 )
 from thunderstore.community.models import Community, CommunitySite, PackageListing
+from thunderstore.repository.api.v1.viewsets import _get_prefetched_listing_queryset
 from thunderstore.repository.api.v1.tasks import (
     update_api_v1_caches,
     update_api_v1_chunked_package_caches,
 )
+from thunderstore.repository.factories import PackageVersionFactory
 from thunderstore.repository.models import APIV1ChunkedPackageCache, APIV1PackageCache
-from thunderstore.repository.models.cache import get_package_listing_chunk
+from thunderstore.repository.models.cache import (
+    get_package_listing_chunk,
+    _get_sorted_active_versions,
+)
 
 
 @pytest.mark.django_db
@@ -227,3 +232,41 @@ def test_get_package_listing_chunk__retains_received_ordering(count: int) -> Non
 
     for i, listing in enumerate(listings):
         assert listing.id == ordering[i]
+
+
+@pytest.mark.django_db
+def test_get_sorted_active_versions__filters_inactive_and_sorts_descending() -> None:
+    listing = PackageListingFactory()
+    package = listing.package
+    package.versions.all().delete()
+
+    PackageVersionFactory(package=package, version_number="1.0.0", is_active=True)
+    PackageVersionFactory(package=package, version_number="2.0.0", is_active=False)
+    PackageVersionFactory(package=package, version_number="0.5.0", is_active=True)
+    PackageVersionFactory(package=package, version_number="1.5.0", is_active=True)
+
+    versions = _get_sorted_active_versions(package)
+
+    assert [v.version_number for v in versions] == ["1.5.0", "1.0.0", "0.5.0"]
+
+
+@pytest.mark.django_db
+def test_get_prefetched_listing_queryset__prefetches_versions_and_dependencies() -> None:
+    from django.db import connection
+    from django.test.utils import CaptureQueriesContext
+
+    listing = PackageListingFactory()
+    dependency = PackageVersionFactory()
+    version = listing.package.versions.get()
+    version.dependencies.add(dependency)
+
+    prefetched_listing = list(_get_prefetched_listing_queryset([listing.id]))[0]
+
+    with CaptureQueriesContext(connection) as ctx:
+        versions = list(prefetched_listing.package.versions.all())
+        dependencies = list(versions[0].dependencies.all())
+        dependency_owner = dependencies[0].package.owner.name
+
+    assert len(ctx.captured_queries) == 0
+    assert versions[0].is_active is True
+    assert dependency_owner == dependency.package.owner.name

--- a/django/thunderstore/repository/api/v1/tests/test_caches.py
+++ b/django/thunderstore/repository/api/v1/tests/test_caches.py
@@ -13,16 +13,16 @@ from thunderstore.community.factories import (
     SiteFactory,
 )
 from thunderstore.community.models import Community, CommunitySite, PackageListing
-from thunderstore.repository.api.v1.viewsets import _get_prefetched_listing_queryset
 from thunderstore.repository.api.v1.tasks import (
     update_api_v1_caches,
     update_api_v1_chunked_package_caches,
 )
+from thunderstore.repository.api.v1.viewsets import _get_prefetched_listing_queryset
 from thunderstore.repository.factories import PackageVersionFactory
 from thunderstore.repository.models import APIV1ChunkedPackageCache, APIV1PackageCache
 from thunderstore.repository.models.cache import (
-    get_package_listing_chunk,
     _get_sorted_active_versions,
+    get_package_listing_chunk,
 )
 
 

--- a/django/thunderstore/repository/api/v1/viewsets.py
+++ b/django/thunderstore/repository/api/v1/viewsets.py
@@ -1,8 +1,8 @@
 import json
 from io import BytesIO
-from typing import Any, Optional
+from typing import Any, Iterable, Optional
 
-from django.db.models import Count, Prefetch
+from django.db.models import Count, Prefetch, QuerySet
 from django.http import HttpResponse
 from django.utils.cache import get_conditional_response
 from django.utils.http import http_date
@@ -32,7 +32,9 @@ PACKAGE_SERIALIZER = PackageListingSerializer
 SERIALIZER_BATCH_SIZE = 200
 
 
-def _get_prefetched_listing_queryset(ids):
+def _get_prefetched_listing_queryset(
+    ids: Iterable[int],
+) -> QuerySet[PackageListing]:
     versions_prefetch = Prefetch(
         "package__versions",
         queryset=PackageVersion.objects.filter(is_active=True)

--- a/django/thunderstore/repository/api/v1/viewsets.py
+++ b/django/thunderstore/repository/api/v1/viewsets.py
@@ -2,6 +2,7 @@ import json
 from io import BytesIO
 from typing import Any, Optional
 
+from django.db.models import Count, Prefetch
 from django.http import HttpResponse
 from django.utils.cache import get_conditional_response
 from django.utils.http import http_date
@@ -23,12 +24,35 @@ from thunderstore.repository.cache import (
     order_package_listing_queryset,
 )
 from thunderstore.repository.mixins import CommunityMixin
-from thunderstore.repository.models import Package
+from thunderstore.repository.models import Package, PackageVersion
 from thunderstore.repository.models.cache import APIV1PackageCache
 from thunderstore.utils.batch import batch
 
 PACKAGE_SERIALIZER = PackageListingSerializer
 SERIALIZER_BATCH_SIZE = 200
+
+
+def _get_prefetched_listing_queryset(ids):
+    versions_prefetch = Prefetch(
+        "package__versions",
+        queryset=PackageVersion.objects.filter(is_active=True)
+        .select_related("package", "package__owner")
+        .prefetch_related(
+            "dependencies",
+            "dependencies__package",
+            "dependencies__package__owner",
+        ),
+    )
+    return (
+        order_package_listing_queryset(PackageListing.objects.filter(id__in=ids))
+        .select_related("community", "package", "package__owner")
+        .prefetch_related(
+            "categories",
+            "community__sites__site",
+            versions_prefetch,
+        )
+        .annotate(_rating_score=Count("package__package_ratings"))
+    )
 
 
 def serialize_package_list_for_community(community: Community) -> bytes:
@@ -41,9 +65,7 @@ def serialize_package_list_for_community(community: Community) -> bytes:
 
     result.write(b"[")
     for index, ids in enumerate(batch(batch_size, listing_ids)):
-        queryset = order_package_listing_queryset(
-            PackageListing.objects.filter(id__in=ids)
-        )
+        queryset = _get_prefetched_listing_queryset(ids)
         serializer = PACKAGE_SERIALIZER(
             queryset,
             many=True,

--- a/django/thunderstore/repository/models/cache.py
+++ b/django/thunderstore/repository/models/cache.py
@@ -3,13 +3,11 @@ import io
 import json
 from datetime import timedelta
 from distutils.version import StrictVersion
-from typing import Any, Iterable, List, Optional
+from typing import TYPE_CHECKING, Any, Iterable, List, Optional
 
-from django.conf import settings
 from django.core.files.base import ContentFile
 from django.db import models
 from django.db.models import Count, Prefetch
-from django.urls import reverse
 from django.utils import timezone
 
 from thunderstore.community.models import Community, PackageListing
@@ -20,6 +18,9 @@ from thunderstore.repository.cache import (
 )
 from thunderstore.storage.models import DataBlob, DataBlobGroup
 from thunderstore.utils.batch import batch
+
+if TYPE_CHECKING:
+    from thunderstore.repository.models import Package, PackageVersion
 
 
 class APIExperimentalPackageIndexCache(S3FileMixin):
@@ -282,22 +283,12 @@ def get_package_listing_chunk(
     return sorted(listings, key=lambda l: order_map[l.id])
 
 
-def _get_sorted_active_versions(package):
-    versions = list(package.versions.all())
+def _get_sorted_active_versions(
+    package: "Package",
+) -> List["PackageVersion"]:
+    versions = [v for v in package.versions.all() if v.is_active]
     versions.sort(key=lambda v: StrictVersion(v.version_number), reverse=True)
     return versions
-
-
-def _version_download_url(version) -> str:
-    path = reverse(
-        "old_urls:packages.download",
-        kwargs={
-            "owner": version.package.owner.name,
-            "name": version.package.name,
-            "version": version.version_number,
-        },
-    )
-    return f"{settings.PROTOCOL}{settings.PRIMARY_HOST}{path}"
 
 
 def listing_to_json(listing: PackageListing) -> bytes:
@@ -330,7 +321,7 @@ def listing_to_json(listing: PackageListing) -> bytes:
                     "dependencies": [
                         d.full_version_name for d in version.dependencies.all()
                     ],
-                    "download_url": _version_download_url(version),
+                    "download_url": version.full_download_url,
                     "downloads": version.downloads,
                     "date_created": version.date_created.isoformat(),
                     "website_url": version.website_url,

--- a/django/thunderstore/repository/models/cache.py
+++ b/django/thunderstore/repository/models/cache.py
@@ -2,10 +2,14 @@ import gzip
 import io
 import json
 from datetime import timedelta
+from distutils.version import StrictVersion
 from typing import Any, Iterable, List, Optional
 
+from django.conf import settings
 from django.core.files.base import ContentFile
 from django.db import models
+from django.db.models import Count, Prefetch
+from django.urls import reverse
 from django.utils import timezone
 
 from thunderstore.community.models import Community, PackageListing
@@ -249,45 +253,73 @@ def get_package_listing_ids(community: Community) -> Iterable[List[int]]:
 
 def get_package_listing_chunk(
     listing_ids: List[int],
-) -> models.QuerySet["PackageListing"]:
-    # Keep the ordering as it was when the whole id list was read.
-    ordering = models.Case(
-        *[models.When(id=id, then=pos) for pos, id in enumerate(listing_ids)]
-    )
-    listing_ref = PackageListing.objects.filter(pk=models.OuterRef("pk"))
+) -> List[PackageListing]:
+    from thunderstore.repository.models import PackageVersion
 
-    return (
+    versions_prefetch = Prefetch(
+        "package__versions",
+        queryset=PackageVersion.objects.filter(is_active=True)
+        .select_related("package", "package__owner")
+        .prefetch_related(
+            "dependencies",
+            "dependencies__package",
+            "dependencies__package__owner",
+        ),
+    )
+
+    listings = (
         PackageListing.objects.filter(id__in=listing_ids)
         .select_related("community", "package", "package__owner")
-        .prefetch_related("categories", "community__sites", "package__versions")
-        .annotate(
-            _rating_score=models.Subquery(
-                listing_ref.annotate(
-                    ratings=models.Count("package__package_ratings"),
-                ).values("ratings"),
-            ),
+        .prefetch_related(
+            "categories",
+            "community__sites__site",
+            versions_prefetch,
         )
-        .order_by(ordering)
+        .annotate(_rating_score=Count("package__package_ratings"))
     )
+
+    order_map = {lid: pos for pos, lid in enumerate(listing_ids)}
+    return sorted(listings, key=lambda l: order_map[l.id])
+
+
+def _get_sorted_active_versions(package):
+    versions = list(package.versions.all())
+    versions.sort(key=lambda v: StrictVersion(v.version_number), reverse=True)
+    return versions
+
+
+def _version_download_url(version) -> str:
+    path = reverse(
+        "old_urls:packages.download",
+        kwargs={
+            "owner": version.package.owner.name,
+            "name": version.package.name,
+            "version": version.version_number,
+        },
+    )
+    return f"{settings.PROTOCOL}{settings.PRIMARY_HOST}{path}"
 
 
 def listing_to_json(listing: PackageListing) -> bytes:
+    package = listing.package
+    owner = package.owner
+    versions = _get_sorted_active_versions(package)
+
     return json.dumps(
         {
-            "name": listing.package.name,
-            "full_name": listing.package.full_package_name,
-            "owner": listing.package.owner.name,
+            "name": package.name,
+            "full_name": package.full_package_name,
+            "owner": owner.name,
             "package_url": listing.get_full_url(),
-            "donation_link": listing.package.owner.donation_link,
-            "date_created": listing.package.date_created.isoformat(),
-            "date_updated": listing.package.date_updated.isoformat(),
-            "uuid4": str(listing.package.uuid4),
+            "donation_link": owner.donation_link,
+            "date_created": package.date_created.isoformat(),
+            "date_updated": package.date_updated.isoformat(),
+            "uuid4": str(package.uuid4),
             "rating_score": listing.rating_score,
-            "is_pinned": listing.package.is_pinned,
-            "is_deprecated": listing.package.is_deprecated,
+            "is_pinned": package.is_pinned,
+            "is_deprecated": package.is_deprecated,
             "has_nsfw_content": listing.has_nsfw_content,
             "categories": [c.name for c in listing.categories.all()],
-            # TODO: this generates awfully lot of database hits
             "versions": [
                 {
                     "name": version.name,
@@ -298,16 +330,15 @@ def listing_to_json(listing: PackageListing) -> bytes:
                     "dependencies": [
                         d.full_version_name for d in version.dependencies.all()
                     ],
-                    "download_url": version.full_download_url,
+                    "download_url": _version_download_url(version),
                     "downloads": version.downloads,
                     "date_created": version.date_created.isoformat(),
                     "website_url": version.website_url,
-                    # TODO: what is this needed for, inactive ones have been filtered out anyway?
                     "is_active": version.is_active,
                     "uuid4": str(version.uuid4),
                     "file_size": version.file_size,
                 }
-                for version in listing.package.available_versions
+                for version in versions
             ],
         },
     ).encode()


### PR DESCRIPTION
This removes a N+1 query from both the chunked and non-chunked index serialization paths.

Previously, serializing each listing could trigger its own rating count query, plus its own available_versions query, with version deps prefetched again per package. Query count was roughly scaling with the number of packages in the index.

This change fetches listings in batches, prefetches active versions and dependencies, and annotates rating counts on the queryset. Serialization then reads from prefetch data instead of performing per-package queries.

Complexity reduction goes from around O(package_count) to O(batches).