### PR TITLE
Optimize community download count aggregation

### DIFF
--- a/django/thunderstore/community/models/community.py
+++ b/django/thunderstore/community/models/community.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Optional
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
 from django.db import models, transaction
-from django.db.models import Manager, QuerySet
+from django.db.models import Manager, QuerySet, Sum
 from django.urls import reverse
 from django.utils.functional import cached_property
 
@@ -366,7 +366,13 @@ class CommunityAggregatedFields(TimestampMixin, models.Model):
         listings = listings.filter_with_single_community()
 
         community.aggregated_fields.package_count = listings.count()
-        community.aggregated_fields.download_count = sum(
-            listing.total_downloads for listing in listings
+
+        from thunderstore.repository.models import PackageVersion
+
+        community.aggregated_fields.download_count = (
+            PackageVersion.objects.filter(
+                package_id__in=listings.values("package_id")
+            ).aggregate(total=Sum("downloads"))["total"]
+            or 0
         )
         community.aggregated_fields.save()

--- a/django/thunderstore/community/models/community.py
+++ b/django/thunderstore/community/models/community.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
 from django.db import models, transaction
-from django.db.models import Manager, QuerySet
+from django.db.models import Manager, QuerySet, Sum
 from django.urls import reverse
 from django.utils.functional import cached_property
 
@@ -374,7 +374,13 @@ class CommunityAggregatedFields(TimestampMixin, models.Model):
         listings = listings.filter_with_single_community()
 
         community.aggregated_fields.package_count = listings.count()
-        community.aggregated_fields.download_count = sum(
-            listing.total_downloads for listing in listings
+
+        from thunderstore.repository.models import PackageVersion
+
+        community.aggregated_fields.download_count = (
+            PackageVersion.objects.filter(
+                package_id__in=listings.values("package_id")
+            ).aggregate(total=Sum("downloads"))["total"]
+            or 0
         )
         community.aggregated_fields.save()


### PR DESCRIPTION
Community download counts were previously performed as an iterative sum over all active listings. One aggregate query per community per hour.

This fixes that by replacing it with a DB-level aggregate across the listings queryset. Improves complexity from something like O(listing_count) to like O(1) (per community).