### PR TITLE
Fix unoptimized prefetch use during v1 cache rebuild

### DIFF
--- a/django/thunderstore/repository/api/v1/serializers.py
+++ b/django/thunderstore/repository/api/v1/serializers.py
@@ -1,3 +1,5 @@
+from distutils.version import StrictVersion
+
 from rest_framework.fields import Field
 from rest_framework.serializers import ModelSerializer, SerializerMethodField
 
@@ -64,14 +66,28 @@ class PackageListingSerializer(ModelSerializer):
     date_created = RelatedObjectField(relation_name="package")
     date_updated = RelatedObjectField(relation_name="package")
     uuid4 = RelatedObjectField(relation_name="package")
-    rating_score = RelatedObjectField(relation_name="package")
+    rating_score = SerializerMethodField()
     is_pinned = RelatedObjectField(relation_name="package")
     is_deprecated = RelatedObjectField(relation_name="package")
     categories = SerializerMethodField()
     versions = SerializerMethodField()
 
     def get_versions(self, instance):
-        versions = instance.package.available_versions
+        prefetched_versions = getattr(
+            instance.package,
+            "_prefetched_objects_cache",
+            {},
+        ).get("versions")
+
+        if prefetched_versions is None:
+            versions = instance.package.available_versions
+        else:
+            versions = sorted(
+                (version for version in prefetched_versions if version.is_active),
+                key=lambda version: StrictVersion(version.version_number),
+                reverse=True,
+            )
+
         return PackageVersionSerializer(versions, many=True, context=self.context).data
 
     def get_owner(self, instance):
@@ -86,8 +102,14 @@ class PackageListingSerializer(ModelSerializer):
     def get_donation_link(self, instance):
         return instance.package.owner.donation_link
 
+    def get_rating_score(self, instance):
+        rating_score = getattr(instance, "_rating_score", None)
+        if rating_score is not None:
+            return rating_score
+        return instance.package.rating_score
+
     def get_categories(self, instance):
-        return set(instance.categories.all().values_list("name", flat=True))
+        return {category.name for category in instance.categories.all()}
 
     def to_representation(self, instance):
         result = super().to_representation(instance)

--- a/django/thunderstore/repository/api/v1/tasks.py
+++ b/django/thunderstore/repository/api/v1/tasks.py
@@ -1,4 +1,4 @@
-from thunderstore.community.models import Community, CommunitySite
+from thunderstore.community.models import Community
 from thunderstore.core.utils import capture_exception
 from thunderstore.repository.api.v1.viewsets import serialize_package_list_for_community
 from thunderstore.repository.models import APIV1ChunkedPackageCache, APIV1PackageCache
@@ -9,17 +9,7 @@ def update_api_v1_caches() -> None:
 
 
 def update_api_v1_indexes() -> None:
-    for site in CommunitySite.objects.iterator():
-        try:
-            APIV1PackageCache.update_for_community(
-                community=site.community,
-                content=serialize_package_list_for_community(
-                    community=site.community,
-                ),
-            )
-        except Exception as e:  # pragma: no cover
-            capture_exception(e)
-    for community in Community.objects.filter(sites=None).iterator():
+    for community in Community.objects.iterator():
         try:
             APIV1PackageCache.update_for_community(
                 community=community,

--- a/django/thunderstore/repository/api/v1/tests/test_caches.py
+++ b/django/thunderstore/repository/api/v1/tests/test_caches.py
@@ -215,6 +215,37 @@ def test_api_v1_chunked_package_cache__drops_stale_caches() -> None:
 
 
 @pytest.mark.django_db
+def test_update_api_v1_caches__deduplicates_communities_with_multiple_sites(
+    monkeypatch,
+) -> None:
+    community = CommunityFactory()
+    CommunitySiteFactory(community=community)
+    CommunitySiteFactory(community=community)
+    CommunityFactory()
+
+    updated_communities = []
+
+    monkeypatch.setattr(
+        "thunderstore.repository.api.v1.tasks.serialize_package_list_for_community",
+        lambda community: b"[]",
+    )
+    monkeypatch.setattr(
+        "thunderstore.repository.api.v1.tasks.APIV1PackageCache.update_for_community",
+        lambda community, content: updated_communities.append(community.pk),
+    )
+    monkeypatch.setattr(
+        "thunderstore.repository.api.v1.tasks.APIV1PackageCache.drop_stale_cache",
+        lambda: None,
+    )
+
+    update_api_v1_caches()
+
+    assert sorted(updated_communities) == sorted(
+        Community.objects.values_list("pk", flat=True)
+    )
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize("count", (0, 1, 2, 3, 5, 8, 13))
 def test_get_package_listing_chunk__retains_received_ordering(count: int) -> None:
     assert not PackageListing.objects.exists()

--- a/django/thunderstore/repository/api/v1/viewsets.py
+++ b/django/thunderstore/repository/api/v1/viewsets.py
@@ -20,7 +20,6 @@ from thunderstore.core.types import HttpRequestType
 from thunderstore.repository.api.v1.serializers import PackageListingSerializer
 from thunderstore.repository.cache import (
     get_package_listing_queryset,
-    order_package_listing_queryset,
 )
 from thunderstore.repository.mixins import CommunityMixin
 from thunderstore.repository.models import Package
@@ -32,18 +31,20 @@ SERIALIZER_BATCH_SIZE = 200
 
 
 def serialize_package_list_for_community(community: Community) -> bytes:
-    listing_ids = get_package_listing_queryset(
+    base_queryset = get_package_listing_queryset(
         community_identifier=community.identifier
-    ).values_list("id", flat=True)
+    )
+    listing_ids = base_queryset.values_list(
+        "id",
+        flat=True,
+    )
     batch_size = SERIALIZER_BATCH_SIZE
     renderer = JSONRenderer()
     result = BytesIO()
 
     result.write(b"[")
     for index, ids in enumerate(batch(batch_size, listing_ids)):
-        queryset = order_package_listing_queryset(
-            PackageListing.objects.filter(id__in=ids)
-        )
+        queryset = base_queryset.filter(id__in=ids)
         serializer = PACKAGE_SERIALIZER(
             queryset,
             many=True,

--- a/django/thunderstore/repository/cache.py
+++ b/django/thunderstore/repository/cache.py
@@ -1,4 +1,4 @@
-from django.db.models import QuerySet
+from django.db.models import Count, Prefetch, QuerySet
 
 from thunderstore.community.models import PackageListing, Q
 
@@ -6,13 +6,27 @@ from thunderstore.community.models import PackageListing, Q
 def prefetch_package_listing_queryset(
     queryset: QuerySet[PackageListing],
 ) -> QuerySet[PackageListing]:
+    from thunderstore.repository.models import PackageVersion
+
     return queryset.select_related(
+        "community",
         "package",
         "package__owner",
         "package__latest",
+    ).annotate(
+        _rating_score=Count("package__package_ratings"),
     ).prefetch_related(
-        "package__versions",
-        "package__versions__dependencies",
+        "categories",
+        "community__sites",
+        Prefetch(
+            "package__versions",
+            queryset=PackageVersion.objects.select_related(
+                "package",
+                "package__owner",
+            ).prefetch_related(
+                "dependencies__package__owner",
+            ),
+        ),
     )
 
 


### PR DESCRIPTION
This fixes a somewhat major performance issue in cache serialization where querysets were ignored in favour of refetching PackageListing for each query batch.

Also adds a regression test for cache rebuilds.