### PR TITLE
Fix cache poisoning issue with listing paginator / QURL

### DIFF
--- a/django/thunderstore/community/templates/community/packagelisting_list.html
+++ b/django/thunderstore/community/templates/community/packagelisting_list.html
@@ -8,7 +8,7 @@
 {% block title %}{{ page_title }}{% endblock %}
 
 {% block content %}
-{% cache_until "any_package_updated" "mod-list" 300 page_obj.number cache_vary %}
+{% cache_until "any_package_updated" "mod-list" 300 cache_vary %}
 
 {% if breadcrumbs %}
 <nav class="mt-3" aria-label="breadcrumb">
@@ -32,7 +32,7 @@
 <div class="m-0 mb-2 p-0 w-100">
     <div class="btn-group d-flex" role="group" aria-label="Result ordering">
         {% for entry in sections %}
-            <a href="{% qurl allowed_params section entry.0 page %}" class="btn btn-primary {% if active_section == entry.0 %}active{% endif %}">
+            <a href="{% qurl 'section' entry.0 'page' %}" class="btn btn-primary {% if active_section == entry.0 %}active{% endif %}">
                 {{ entry.1 }}
             </a>
         {% endfor %}
@@ -43,7 +43,7 @@
 <div class="m-0 mb-2 p-0 w-100">
     <div class="btn-group d-flex" role="group" aria-label="Result ordering">
         {% for entry in ordering_modes %}
-            <a href="{% qurl allowed_params ordering entry.0 page %}" class="btn btn-secondary {% if active_ordering == entry.0 %}active{% endif %}">
+            <a href="{% qurl 'ordering' entry.0 'page' %}" class="btn btn-secondary {% if active_ordering == entry.0 %}active{% endif %}">
                 {{ entry.1 }}
             </a>
         {% endfor %}

--- a/django/thunderstore/frontend/templatetags/qurl.py
+++ b/django/thunderstore/frontend/templatetags/qurl.py
@@ -1,54 +1,19 @@
-from typing import Any, List, Set
-
-from django.template import Library, Node, TemplateSyntaxError
+from django import template
 from django.utils.http import urlencode
 
-register = Library()
+register = template.Library()
 
 
-class QurlNode(Node):
-    def __init__(
-        self,
-        allowed_params_key: str,
-        param_key: str,
-        param_val: Any,
-        removals: List[str],
-    ):
-        self.allowed_params_key = allowed_params_key
-        self.param_key = param_key
-        self.param_val = param_val
-        self.removals = removals
+@register.simple_tag(takes_context=True)
+def qurl(context, param_key, param_val, *remove_keys):
+    view = context.get("view")
+    if not view or not hasattr(view, "get_clean_params"):
+        return ""
 
-    def render(self, context):
-        request = context["request"]
-        params = request.GET.copy()
-        params.setlist(self.param_key, [self.param_val.resolve(context)])
-        allowed_params = context[self.allowed_params_key]
-        for key, _ in request.GET.items():
-            if key not in allowed_params:
-                params.pop(key)
-        for entry in self.removals:
-            try:
-                params.pop(entry)
-            except KeyError:
-                pass
-        return f"{request.path}?{urlencode(params, True)}"
+    params = view.get_clean_params()
+    for key in remove_keys:
+        params.pop(key, None)
 
+    params[param_key] = param_val
 
-@register.tag("qurl")
-def qurl(parser, token):
-    tokens = token.split_contents()
-
-    if len(tokens) < 4 or len(tokens) > 5:
-        raise TemplateSyntaxError("'%r' tag requires 3 or 4 arguments." % tokens[0])
-
-    removals = []
-    if len(tokens) == 5:
-        removals = str(tokens[4]).split(",")
-
-    return QurlNode(
-        allowed_params_key=tokens[1],
-        param_key=tokens[2],
-        param_val=parser.compile_filter(tokens[3]),
-        removals=removals,
-    )
+    return f"{view.request.path}?{urlencode(params, doseq=True)}"

--- a/django/thunderstore/frontend/tests/test_qurl.py
+++ b/django/thunderstore/frontend/tests/test_qurl.py
@@ -1,117 +1,78 @@
-from io import BytesIO
-
 import pytest
+from django.template import Context, Template
 from django.test import RequestFactory
-from django.urls import reverse
-from lxml import etree
-from rest_framework.test import APIClient
 
-from thunderstore.community.factories import PackageListingFactory
-from thunderstore.community.models import CommunitySite, PackageListingSection
-from thunderstore.frontend.templatetags.qurl import QurlNode
-
-TEST_PARAMS = (
-    ("page", True),
-    ("q", True),
-    ("included_categories", True),
-    ("excluded_categories", True),
-    ("nsfw", True),
-    ("deprecated", True),
-    ("ordering", True),
-    ("section", True),
-    ("foo", False),
-    ("jwoejfiwejof", False),
-)
+ALLOWED_PARAMS = [
+    "q",
+    "ordering",
+    "deprecated",
+    "nsfw",
+    "excluded_categories",
+    "included_categories",
+    "section",
+    "page",
+]
 
 
-@pytest.mark.django_db
-@pytest.mark.parametrize(("param", "should_exist"), TEST_PARAMS)
-def test_qurl_parameter_filtering_package_listing_view(
-    client: APIClient,
-    community_site: CommunitySite,
-    param: str,
-    should_exist: bool,
-) -> None:
-    # Param has to be a valid value or it won't be rendered
-    param_val = "foo"
+class MockView:
+    """Simulates the PackageListSearchView behavior."""
 
-    # Section select needs to exist -> create enough sections
-    for i in range(2):
-        slug = f"section-{i}"
-        PackageListingSection.objects.create(
-            community=community_site.community,
-            name=f"Section {i}",
-            slug=slug,
-        )
-        param_val = slug
+    def __init__(self, request, params):
+        self.request = request
+        self.params = params
 
-    # Pagination has to exist -> create enough packages
-    if param == "page":
-        for i in range(25):
-            PackageListingFactory(community=community_site.community)
-        param_val = "1"
-
-    response = client.get(
-        reverse(
-            "communities:community:packages.list",
-            kwargs={"community_identifier": community_site.community.identifier},
-        )
-        + f"?{param}={param_val}",
-        HTTP_HOST=community_site.site.domain,
-    )
-
-    buffer = BytesIO(response.content)
-    tree = etree.parse(buffer, etree.HTMLParser())
-
-    param_found = False
-    for entry in tree.findall(".//a"):
-        href = entry.get("href", "")
-        if param in href and "/auth/login" not in href:
-            param_found = True
-            break
-
-    if should_exist:
-        assert param_found is True
-    else:
-        assert param_found is False
+    def get_clean_params(self):
+        return {k: v for k, v in self.params.items() if k in ALLOWED_PARAMS}
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize(("param", "should_exist"), TEST_PARAMS)
-def test_qurl_parameter_filtering_static(
-    rf: RequestFactory,
-    community_site: CommunitySite,
-    param: str,
-    should_exist: bool,
-) -> None:
-    url = (
-        reverse(
-            "communities:community:packages.list",
-            kwargs={"community_identifier": community_site.community.identifier},
-        )
-        + f"?{param}=1"
+def test_qurl_simple_tag_logic(rf: RequestFactory):
+    """Verifies that qurl updates one param while keeping others and dropping 'foo'."""
+    url = "/c/test/?q=search&foo=bar&page=1"
+    request = rf.get(url)
+
+    # Simulate the sanitized dict that get_clean_params would return
+    clean_params = {"q": "search", "page": "1"}
+    view = MockView(request, clean_params)
+
+    context = Context(
+        {
+            "view": view,
+            "request": request,
+        }
     )
-    context = {
-        "allowed_params": {
-            "q",
-            "ordering",
-            "deprecated",
-            "nsfw",
-            "excluded_categories",
-            "included_categories",
-            "section",
-            "page",
-        },
-        "request": rf.get(url),
-    }
 
-    class FilterStub:
-        def resolve(self, context):
-            return "noop"
+    # Test updating page from 1 to 2
+    template = Template("{% load qurl %}{% qurl 'page' 2 %}")
+    result = template.render(context)
 
-    qurl = QurlNode("allowed_params", "noop", FilterStub(), [])
-    result = qurl.render(context)
-    if should_exist:
-        assert param in result
-    else:
-        assert param not in result
+    assert "page=2" in result
+    assert "q=search" in result
+    assert "foo" not in result  # Dropped because it's not in clean_params
+    assert result.startswith("/c/test/")
+
+
+@pytest.mark.django_db
+def test_qurl_handles_lists(rf: RequestFactory):
+    """Ensures category lists are encoded correctly (doseq=True)."""
+    clean_params = {"included_categories": [1, 2]}
+    request = rf.get("/c/test/")
+    view = MockView(request, clean_params)
+
+    context = Context({"view": view, "request": request})
+    template = Template("{% load qurl %}{% qurl 'page' 1 %}")
+    result = template.render(context)
+
+    assert "included_categories=1" in result
+    assert "included_categories=2" in result
+    assert "page=1" in result
+
+
+@pytest.mark.django_db
+def test_qurl_missing_view(rf: RequestFactory):
+    """The tag should return an empty string if the view is missing/invalid."""
+    context = Context({"request": rf.get("/")})  # No 'view' in context
+    template = Template("{% load qurl %}{% qurl 'page' 1 %}")
+    result = template.render(context)
+
+    assert result == ""

--- a/django/thunderstore/repository/templates/repository/includes/pagination.html
+++ b/django/thunderstore/repository/templates/repository/includes/pagination.html
@@ -3,7 +3,7 @@
 <ul class="pagination my-3">
     {% if page_obj.has_previous %}
         <li class="page-item">
-            <a class="page-link" href="{% qurl allowed_params page page_obj.previous_page_number %}"><i class="fa fa-chevron-left" aria-hidden="true"></i></a>
+            <a class="page-link" href="{% qurl 'page' page_obj.previous_page_number %}"><i class="fa fa-chevron-left" aria-hidden="true"></i></a>
         </li>
     {% else %}
         <li class="page-item disabled">
@@ -12,10 +12,10 @@
     {% endif %}
 
     {% if page_obj.number|add:'-3' > 1 %}
-        <li><a class="page-link" href="{% qurl allowed_params page 1 %}">1</a></li>
+        <li><a class="page-link" href="{% qurl 'page' 1 %}">1</a></li>
     {% endif %}
     {% if page_obj.number|add:'-4' > 1 %}
-        <li><a class="page-link" href="{% qurl allowed_params page page_obj.number|add:'-4' %}">&hellip;</a></li>
+        <li><a class="page-link" href="{% qurl 'page' page_obj.number|add:'-4' %}">&hellip;</a></li>
     {% endif %}
 
     {% for i in paginator.page_range %}
@@ -25,21 +25,21 @@
             </li>
         {% elif i > page_obj.number|add:'-4' and i < page_obj.number|add:'4' %}
             <li class="page-item">
-                <a class="page-link" href="{% qurl allowed_params page i %}">{{ i }}</a>
+                <a class="page-link" href="{% qurl 'page' i %}">{{ i }}</a>
             </li>
         {% endif %}
     {% endfor %}
 
     {% if page_obj.paginator.num_pages > page_obj.number|add:'4' %}
-        <li><a class="page-link" href="{% qurl allowed_params page page_obj.number|add:'4' %}">&hellip;</a></li>
+        <li><a class="page-link" href="{% qurl 'page' page_obj.number|add:'4' %}">&hellip;</a></li>
     {% endif %}
     {% if page_obj.number|add:'3' < paginator.num_pages %}
-        <li><a class="page-link" href="{% qurl allowed_params page paginator.num_pages %}">{{ paginator.num_pages }}</a></li>
+        <li><a class="page-link" href="{% qurl 'page' paginator.num_pages %}">{{ paginator.num_pages }}</a></li>
     {% endif %}
 
     {% if page_obj.has_next %}
         <li class="page-item">
-            <a class="page-link" href="{% qurl allowed_params page page_obj.next_page_number %}"><i class="fa fa-chevron-right" aria-hidden="true"></i></a>
+            <a class="page-link" href="{% qurl 'page' page_obj.next_page_number %}"><i class="fa fa-chevron-right" aria-hidden="true"></i></a>
         </li>
     {% else %}
         <li class="page-item disabled">

--- a/django/thunderstore/repository/views/package/list.py
+++ b/django/thunderstore/repository/views/package/list.py
@@ -53,17 +53,30 @@ class PackageListSearchView(CommunityMixin, ListView):
     def get_categories(self):
         return PackageCategory.objects.exclude(~Q(community=self.community))
 
+    def get_clean_params(self):
+        allowed = {
+            "q": self.get_search_query(),
+            "ordering": self.get_active_ordering(),
+            "deprecated": "on" if self.get_is_deprecated_included() else "",
+            "nsfw": "on" if self.get_is_nsfw_included() else "",
+            "included_categories": self.get_included_categories(),
+            "excluded_categories": self.get_excluded_categories(),
+            "section": self.active_section_slug,
+            "page": self.request.GET.get("page", "1"),
+        }
+        return {k: v for k, v in allowed.items() if v not in [None, "", []]}
+
     def get_full_cache_vary(self):
-        cache_vary = self.get_cache_vary()
-        cache_vary += f".{self.get_community_cache_vary()}"
-        cache_vary += f".{self.get_search_query()}"
-        cache_vary += f".{self.get_active_ordering()}"
-        cache_vary += f".{self.get_included_categories()}"
-        cache_vary += f".{self.get_excluded_categories()}"
-        cache_vary += f".{self.get_is_deprecated_included()}"
-        cache_vary += f".{self.get_is_nsfw_included()}"
-        cache_vary += f".{self.active_section_slug}"
-        return cache_vary
+        clean = self.get_clean_params()
+        cache_parts = [
+            f"community:{self.get_community_cache_vary()}",
+            f"type:{self.get_cache_vary()}",
+        ]
+
+        for k in sorted(clean.keys()):
+            cache_parts.append(f"{k}:{clean[k]}")
+
+        return ".".join(cache_parts)
 
     def get_ordering_choices(self):
         return (

--- a/django/thunderstore/repository/views/package/tests/test_list.py
+++ b/django/thunderstore/repository/views/package/tests/test_list.py
@@ -5,8 +5,13 @@ from django.urls import reverse
 from thunderstore.cache.enums import CacheBustCondition
 from thunderstore.cache.tasks import invalidate_cache
 from thunderstore.community.consts import PackageListingReviewStatus
+from thunderstore.community.factories import (
+    PackageCategoryFactory,
+    PackageListingFactory,
+)
 from thunderstore.community.models import CommunitySite, PackageListing
 from thunderstore.core.types import UserType
+from thunderstore.repository.factories import PackageVersionFactory
 
 
 @pytest.mark.django_db
@@ -36,6 +41,37 @@ def test_package_review_list_view(
     response = client.get(url, HTTP_HOST=community_site.site.domain)
     assert response.status_code == 200
     assert active_package_listing.get_full_url().encode("utf-8") in response.content
+
+
+@pytest.mark.django_db
+def test_package_list_search_logic(
+    client: Client,
+    community_site: CommunitySite,
+):
+    url = reverse(
+        "communities:community:packages.list",
+        kwargs={
+            "community_identifier": community_site.community.identifier,
+        },
+    )
+    host = community_site.site.domain
+
+    version = PackageVersionFactory(name="Fish_and_Birds")
+    listing = PackageListingFactory(
+        package=version.package, community=community_site.community
+    )
+
+    resp = client.get(f"{url}?q= ", HTTP_HOST=host)
+    assert listing.get_full_url().encode("utf-8") in resp.content
+
+    resp = client.get(f"{url}?q=fish", HTTP_HOST=host)
+    assert listing.get_full_url().encode("utf-8") in resp.content
+
+    resp = client.get(f"{url}?q=fish birds", HTTP_HOST=host)
+    assert listing.get_full_url().encode("utf-8") in resp.content
+
+    resp = client.get(f"{url}?q=fish cats", HTTP_HOST=host)
+    assert listing.get_full_url().encode("utf-8") not in resp.content
 
 
 @pytest.mark.django_db
@@ -75,3 +111,55 @@ def test_package_list_cache_vary_sanitization(community_site: CommunitySite):
         "q:search"
     )
     assert cache_vary == expected_order
+
+
+@pytest.mark.django_db
+def test_package_list_category_filtering(
+    client: Client,
+    community_site: CommunitySite,
+    active_package_listing: PackageListing,
+):
+    cat1 = PackageCategoryFactory()
+    cat2 = PackageCategoryFactory()
+
+    active_package_listing.categories.add(cat1)
+
+    url = reverse(
+        "communities:community:packages.list",
+        kwargs={
+            "community_identifier": community_site.community.identifier,
+        },
+    )
+
+    resp = client.get(
+        f"{url}?included_categories={cat1.pk}&included_categories={cat2.pk}",
+        HTTP_HOST=community_site.site.domain,
+    )
+    assert resp.status_code == 200
+    # Package has one of the included categories, search uses OR logic for categories
+    assert active_package_listing.get_full_url().encode("utf-8") in resp.content
+
+    resp = client.get(
+        f"{url}?excluded_categories={cat1.pk}", HTTP_HOST=community_site.site.domain
+    )
+    assert resp.status_code == 200
+    # Package has one of the excluded categories, search uses OR logic for categories
+    assert active_package_listing.get_full_url().encode("utf-8") not in resp.content
+
+
+@pytest.mark.django_db
+def test_package_list_empty_category_params(
+    client: Client,
+    community_site: CommunitySite,
+):
+    url = reverse(
+        "communities:community:packages.list",
+        kwargs={
+            "community_identifier": community_site.community.identifier,
+        },
+    )
+    resp = client.get(
+        f"{url}?included_categories=arbitrarystring",
+        HTTP_HOST=community_site.site.domain,
+    )
+    assert resp.status_code == 200

--- a/django/thunderstore/repository/views/package/tests/test_list.py
+++ b/django/thunderstore/repository/views/package/tests/test_list.py
@@ -36,3 +36,42 @@ def test_package_review_list_view(
     response = client.get(url, HTTP_HOST=community_site.site.domain)
     assert response.status_code == 200
     assert active_package_listing.get_full_url().encode("utf-8") in response.content
+
+
+@pytest.mark.django_db
+def test_package_list_cache_vary_sanitization(community_site: CommunitySite):
+    """
+    Ensures that get_full_cache_vary strips poison payloads and
+    normalizes parameter order.
+    """
+    from django.test import RequestFactory
+
+    from thunderstore.repository.views.package.list import PackageListSearchView
+
+    rf = RequestFactory()
+    # A URL with unsorted params and cache poison (+payload)
+    url = "/c/test/?deprecated=on+poison&q=search&page=1"
+    request = rf.get(url)
+    request.community = community_site.community
+
+    view = PackageListSearchView()
+    view.request = request
+    view.kwargs = {}
+    view.community = community_site.community
+
+    cache_vary = view.get_full_cache_vary()
+
+    assert "deprecated:on" in cache_vary
+    assert "poison" not in cache_vary
+
+    assert f"community:{community_site.community.identifier}" in cache_vary
+
+    expected_order = (
+        f"community:{community_site.community.identifier}."
+        "type:."
+        "deprecated:on."
+        "ordering:last-updated."
+        "page:1."
+        "q:search"
+    )
+    assert cache_vary == expected_order


### PR DESCRIPTION
Fix cache poisoning issue with listing paginator / QURL by simplifying qurl.py and cleaning parameters passed to it in list.py

Added tests to ensure that this new behavior prevents the cache poisoning issue.