### PR TITLE
Stop creating instances of PackageVersionDownloadEvent

### DIFF
--- a/django/thunderstore/repository/tasks/downloads.py
+++ b/django/thunderstore/repository/tasks/downloads.py
@@ -1,3 +1,5 @@
+import random
+import time
 from datetime import datetime
 
 from celery import shared_task
@@ -27,11 +29,13 @@ class AnalyticsEventPackageDownload(BaseModel):
 )
 def log_version_download(version_id: int, timestamp: str):
     timestamp_dt = datetime.fromisoformat(timestamp)
+    generated_id = (int(time.time() * 1000) << 20) | random.getrandbits(20)
     with transaction.atomic():
-        event = PackageVersionDownloadEvent.objects.create(
-            version_id=version_id,
-            timestamp=timestamp_dt,
-        )
+        ### Download events are now stored in our analytics database
+        # event = PackageVersionDownloadEvent.objects.create(
+        #     version_id=version_id,
+        #     timestamp=timestamp_dt,
+        # )
         PackageVersion.objects.filter(id=version_id).update(
             downloads=F("downloads") + 1
         )
@@ -42,7 +46,7 @@ def log_version_download(version_id: int, timestamp: str):
             lambda: send_kafka_message(
                 topic=KafkaTopic.A_PACKAGE_DOWNLOAD_V1,
                 payload_string=AnalyticsEventPackageDownload(
-                    id=event.id,
+                    id=generated_id,
                     version_id=version_id,
                     timestamp=timestamp_dt,
                 ).json(),

--- a/django/thunderstore/repository/tests/test_download_metrics.py
+++ b/django/thunderstore/repository/tests/test_download_metrics.py
@@ -68,23 +68,23 @@ def test_download_metrics__can_log_download_event__rate_limit(
 def test_download_metrics_log_download_event(
     package_version: PackageVersion,
 ):
-    assert TimeseriesDownloadEvent.objects.count() == 0
+    # assert TimeseriesDownloadEvent.objects.count() == 0
     assert package_version.downloads == 0
 
     PackageVersion.log_download_event(package_version.id, "127.0.0.1")
     package_version.refresh_from_db()
-    assert TimeseriesDownloadEvent.objects.count() == 1
+    # assert TimeseriesDownloadEvent.objects.count() == 1
     assert package_version.downloads == 1
 
     PackageVersion.log_download_event(package_version.id, "127.0.0.1")
     package_version.refresh_from_db()
-    assert TimeseriesDownloadEvent.objects.count() == 1
+    # assert TimeseriesDownloadEvent.objects.count() == 1
     assert package_version.downloads == 1
 
     log_version_download(package_version.id, timezone.now().isoformat())
     package_version.refresh_from_db()
-    assert (
-        TimeseriesDownloadEvent.objects.filter(version_id=package_version.id).count()
-        == 2
-    )
+    # assert (
+    #     TimeseriesDownloadEvent.objects.filter(version_id=package_version.id).count()
+    #     == 2
+    # )
     assert package_version.downloads == 2


### PR DESCRIPTION
Stop creating instances of PackageVersionDownloadEvent by commenting out the code that creates it and generating IDs instead.