### PR TITLE
Seed source data in local dev environment setup.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+# https://docs.codecov.com/docs/codecov-yaml
+ignore:
+  - django/patch_coverage_xml_for_gutters.py

--- a/django/.coveragerc
+++ b/django/.coveragerc
@@ -1,6 +1,10 @@
 [run]
 branch = True
 data_file = coverage.coverage
+# relative_files: stable thunderstore/... paths in coverage.xml across Docker vs host.
+# Cobertura may still use <source>/app</source>; run patch_coverage_xml_for_gutters.py
+# after `coverage xml` (or chain it in the same docker compose exec) for Coverage Gutters.
+relative_files = True
 omit =
     *migrations/*
     *settings*

--- a/django/patch_coverage_xml_for_gutters.py
+++ b/django/patch_coverage_xml_for_gutters.py
@@ -1,0 +1,49 @@
+"""
+Normalize Cobertura <source> for Coverage Gutters.
+
+coverage.py writes <source>/app</source> when tests run in Docker; the extension
+then cannot match files under this django/ folder. Replacing that tag with
+<source>.</source> makes paths relative to coverage.xml (this directory), which
+matches coverageBaseDir in .vscode settings.
+
+Run on the host after coverage.xml is written (bind-mounted from Docker):
+
+  docker compose exec django sh -c "cd /app && coverage xml -o coverage.xml"
+  python patch_coverage_xml_for_gutters.py
+
+Or in one exec (no separate host step):
+
+  docker compose exec django sh -c "cd /app && coverage xml -o coverage.xml && python patch_coverage_xml_for_gutters.py"
+
+`.coveragerc` uses relative_files = True so class filenames stay thunderstore/...
+
+This utility is listed in .coveragerc [run] omit so it is not traced and does not
+appear in coverage.xml (Codecov has no per-file pragma in Python source).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    django_root = Path(__file__).resolve().parent
+    xml_path = django_root / "coverage.xml"
+    if not xml_path.is_file():
+        print(f"No file: {xml_path}", file=sys.stderr)
+        return 1
+    marker = "<source>/app</source>"
+    text = xml_path.read_text(encoding="utf-8")
+    if marker not in text:
+        print("Nothing to patch (already local or different layout).")
+        return 0
+    xml_path.write_text(
+        text.replace(marker, "<source>.</source>", 1),
+        encoding="utf-8",
+    )
+    print("Patched coverage.xml: <source>/app</source> -> <source>.</source>")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/django/thunderstore/core/management/commands/content/package_version.py
+++ b/django/thunderstore/core/management/commands/content/package_version.py
@@ -1,4 +1,4 @@
-from django.db.models import signals
+from django.db.models import Q, signals
 
 from thunderstore.core.management.commands.content.base import (
     ContentPopulator,
@@ -6,10 +6,127 @@ from thunderstore.core.management.commands.content.base import (
     dummy_package_icon,
 )
 from thunderstore.repository.models import Package, PackageVersion
+from thunderstore.storage.models import DataBlob, DataBlobGroup
 from thunderstore.utils.iterators import print_progress
+
+try:
+    from ts_scanners.models.decompilation import Decompilation, DecompilationStatus
+except ModuleNotFoundError as exc:
+    if exc.name != "ts_scanners":
+        raise
+    Decompilation = None
+    DecompilationStatus = None
 
 
 class PackageVersionPopulator(ContentPopulator):
+    def _clear_file_tree_seed_artifacts(self, group: DataBlobGroup) -> None:
+        """Remove seeded entries and scanner rows so the group can be repopulated."""
+        assert Decompilation is not None
+        entry_qs = group.entries.all()
+        blob_ids = list(entry_qs.values_list("blob_id", flat=True))
+        if blob_ids:
+            Decompilation.objects.filter(
+                Q(target_id__in=blob_ids) | Q(result_id__in=blob_ids)
+            ).delete()
+        entry_qs.delete()
+        if group.is_complete:
+            group.is_complete = False
+            group.save(update_fields=("is_complete",))
+
+    def _build_mock_source(
+        self, package_name: str, file_index: int, line_count: int
+    ) -> str:
+        lines = [
+            "using System;",
+            "",
+            f"namespace {package_name}.Generated{file_index}",
+            "{",
+            f"    public static class GeneratedClass{file_index}",
+            "    {",
+        ]
+        lines.extend(
+            [
+                f'        public static string Line{line_idx:03d}() => "Generated {line_idx} for {package_name}";'
+                for line_idx in range(1, line_count + 1)
+            ]
+        )
+        lines += [
+            "    }",
+            "}",
+            "",
+        ]
+        return "\n".join(lines)
+
+    def _seed_package_source_data(self) -> None:
+        source_data_file_count = 5
+        source_data_lines_per_file = 400
+
+        if Decompilation is None or DecompilationStatus is None:
+            print("Skipping package source seed data: ts_scanners is not available.")
+            return
+
+        version = (
+            PackageVersion.objects.select_related("package")
+            .order_by("-date_created")
+            .filter(is_active=True)
+            .first()
+        )
+
+        if not version:
+            print("No active package version found for source data seeding.")
+            return
+
+        tree_name = f"File tree of package: {version.full_version_name}"
+
+        file_tree = None
+        if version.file_tree_id:
+            existing = version.file_tree
+            if existing.name == tree_name:
+                file_tree = existing
+            else:
+                self._clear_file_tree_seed_artifacts(existing)
+                version.file_tree = None
+                version.save(update_fields=("file_tree",))
+                existing.delete()
+
+        if file_tree is None:
+            file_tree = DataBlobGroup.objects.filter(name=tree_name).first()
+
+        if file_tree is None:
+            file_tree = DataBlobGroup.objects.create(name=tree_name)
+
+        if version.file_tree_id != file_tree.id:
+            version.file_tree = file_tree
+            version.save(update_fields=("file_tree",))
+
+        self._clear_file_tree_seed_artifacts(file_tree)
+
+        for file_index in range(source_data_file_count):
+            file_name = f"Generated/SourceFile{file_index + 1:02d}.dll"
+            file_content = (
+                f"binary content for {version.full_version_name} file {file_index + 1}"
+            ).encode("utf-8")
+            reference = file_tree.add_entry(file_content, file_name)
+
+            source_text = self._build_mock_source(
+                package_name=version.package.name,
+                file_index=file_index + 1,
+                line_count=source_data_lines_per_file,
+            )
+            result_blob = DataBlob.get_or_create(source_text.encode("utf-8"))
+
+            Decompilation.objects.update_or_create(
+                target=reference.blob,
+                defaults={
+                    "status": DecompilationStatus.SUCCESS,
+                    "error_message": "",
+                    "result": result_blob,
+                },
+            )
+
+        file_tree.set_complete()
+        print(f"Seeded package source data for {version.full_version_name}.")
+
     def populate(self, context: ContentPopulatorContext) -> None:
         print("Populating package versions...")
 
@@ -59,6 +176,7 @@ class PackageVersionPopulator(ContentPopulator):
         signals.post_delete.connect(PackageVersion.post_delete, sender=PackageVersion)
         signals.post_save.connect(Package.post_save, sender=Package)
         signals.post_delete.connect(Package.post_delete, sender=Package)
+        self._seed_package_source_data()
 
     def clear(self) -> None:
         print("Deleting existing package versions...")

--- a/django/thunderstore/core/tests/test_package_version_populator.py
+++ b/django/thunderstore/core/tests/test_package_version_populator.py
@@ -1,0 +1,303 @@
+import builtins
+import importlib
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from thunderstore.core.management.commands.content.base import ContentPopulatorContext
+from thunderstore.core.management.commands.content.package_version import (
+    PackageVersionPopulator,
+)
+from thunderstore.repository.factories import PackageFactory, PackageVersionFactory
+from thunderstore.repository.models import PackageVersion
+from thunderstore.storage.models import DataBlobGroup
+
+
+@pytest.mark.django_db
+def test_package_version_populator_clear_deletes_versions() -> None:
+    PackageVersionFactory()
+    assert PackageVersion.objects.exists()
+
+    PackageVersionPopulator().clear()
+
+    assert not PackageVersion.objects.exists()
+
+
+@pytest.mark.django_db
+def test_package_version_populator_populate_creates_expected_versions() -> None:
+    package = PackageFactory()
+    assert package.versions.count() == 0
+
+    context = ContentPopulatorContext(packages=[package], version_count=3)
+    PackageVersionPopulator().populate(context)
+
+    versions = list(
+        package.versions.order_by("version_number").values_list(
+            "version_number", flat=True
+        )
+    )
+    assert versions == ["0.0.0", "1.0.0", "2.0.0"]
+
+
+@pytest.mark.django_db
+def test_package_version_populator_populate_respects_existing_version_count() -> None:
+    package = PackageFactory()
+    PackageVersionFactory(package=package, name=package.name, version_number="0.0.0")
+
+    context = ContentPopulatorContext(packages=[package], version_count=2)
+    PackageVersionPopulator().populate(context)
+
+    versions = list(
+        package.versions.order_by("version_number").values_list(
+            "version_number", flat=True
+        )
+    )
+    assert versions == ["0.0.0", "1.0.0"]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("reuse_icon", (True, False))
+def test_package_version_populator_reuse_icon_behavior(reuse_icon: bool) -> None:
+    packages = [PackageFactory(), PackageFactory()]
+    context = ContentPopulatorContext(
+        packages=packages,
+        version_count=2,
+        reuse_icon=reuse_icon,
+    )
+
+    PackageVersionPopulator().populate(context)
+
+    icon_paths = list(
+        PackageVersion.objects.order_by("pk").values_list("icon", flat=True)
+    )
+    assert len(icon_paths) == 4
+    if reuse_icon:
+        assert len(set(icon_paths)) == 1
+    else:
+        assert len(set(icon_paths)) == 4
+
+
+@pytest.mark.django_db
+def test_package_version_populator_seed_skips_without_ts_scanners(
+    mocker, capsys: pytest.CaptureFixture[str]
+) -> None:
+    mocker.patch(
+        "thunderstore.core.management.commands.content.package_version.Decompilation",
+        None,
+    )
+    mocker.patch(
+        "thunderstore.core.management.commands.content.package_version.DecompilationStatus",
+        None,
+    )
+
+    PackageVersionPopulator()._seed_package_source_data()
+
+    out = capsys.readouterr().out
+    assert "Skipping package source seed data: ts_scanners is not available." in out
+
+
+@pytest.mark.django_db
+def test_package_version_populator_seed_skips_without_active_version(
+    mocker, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Real ts_scanners (and its DB tables) may be absent in CI; fakes still hit
+    # the query + early-return branch.
+    fake_status = mocker.Mock()
+    fake_status.SUCCESS = "SUCCESS"
+    fake_decompilation = mocker.MagicMock()
+    mocker.patch(
+        "thunderstore.core.management.commands.content.package_version.Decompilation",
+        fake_decompilation,
+    )
+    mocker.patch(
+        "thunderstore.core.management.commands.content.package_version.DecompilationStatus",
+        fake_status,
+    )
+
+    PackageVersion.objects.all().delete()
+    assert not PackageVersion.objects.filter(is_active=True).exists()
+
+    PackageVersionPopulator()._seed_package_source_data()
+
+    out = capsys.readouterr().out
+    assert "No active package version found for source data seeding." in out
+    fake_decompilation.objects.update_or_create.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_package_version_populator_seed_writes_file_tree_and_decompilation_calls(
+    mocker, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Full seed path without real ts_scanners installed (mocks ORM entrypoints)."""
+    fake_status = mocker.Mock()
+    fake_status.SUCCESS = "SUCCESS"
+    fake_decompilation = mocker.MagicMock()
+    mocker.patch(
+        "thunderstore.core.management.commands.content.package_version.Decompilation",
+        fake_decompilation,
+    )
+    mocker.patch(
+        "thunderstore.core.management.commands.content.package_version.DecompilationStatus",
+        fake_status,
+    )
+
+    version = PackageVersionFactory()
+    assert version.file_tree_id is None
+
+    PackageVersionPopulator()._seed_package_source_data()
+
+    version.refresh_from_db()
+    assert version.file_tree_id is not None
+    assert version.file_tree.is_complete is True
+
+    assert fake_decompilation.objects.update_or_create.call_count == 5
+    out = capsys.readouterr().out
+    assert f"Seeded package source data for {version.full_version_name}." in out
+
+
+@pytest.mark.django_db
+def test_package_version_populator_seed_reuses_same_file_tree_on_reseed(
+    mocker, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fake_status = mocker.Mock()
+    fake_status.SUCCESS = "SUCCESS"
+    fake_decompilation = mocker.MagicMock()
+    mocker.patch(
+        "thunderstore.core.management.commands.content.package_version.Decompilation",
+        fake_decompilation,
+    )
+    mocker.patch(
+        "thunderstore.core.management.commands.content.package_version.DecompilationStatus",
+        fake_status,
+    )
+
+    version = PackageVersionFactory()
+    populator = PackageVersionPopulator()
+
+    populator._seed_package_source_data()
+    version.refresh_from_db()
+    first_group_id = version.file_tree_id
+    assert first_group_id is not None
+
+    fake_decompilation.objects.update_or_create.reset_mock()
+    populator._seed_package_source_data()
+
+    version.refresh_from_db()
+    assert version.file_tree_id == first_group_id
+    assert version.file_tree.is_complete is True
+    assert fake_decompilation.objects.update_or_create.call_count == 5
+    out = capsys.readouterr().out
+    assert (
+        out.count(f"Seeded package source data for {version.full_version_name}.") == 2
+    )
+
+
+@pytest.mark.django_db
+def test_package_version_populator_seed_replaces_mismatched_file_tree(
+    mocker,
+) -> None:
+    fake_status = mocker.Mock()
+    fake_status.SUCCESS = "SUCCESS"
+    fake_decompilation = mocker.MagicMock()
+    mocker.patch(
+        "thunderstore.core.management.commands.content.package_version.Decompilation",
+        fake_decompilation,
+    )
+    mocker.patch(
+        "thunderstore.core.management.commands.content.package_version.DecompilationStatus",
+        fake_status,
+    )
+
+    version = PackageVersionFactory()
+    wrong_tree = DataBlobGroup.objects.create(name="Wrong file tree label")
+    version.file_tree = wrong_tree
+    version.save(update_fields=("file_tree",))
+
+    PackageVersionPopulator()._seed_package_source_data()
+
+    version.refresh_from_db()
+    expected_name = f"File tree of package: {version.full_version_name}"
+    assert version.file_tree.name == expected_name
+    assert version.file_tree_id != wrong_tree.pk
+    assert not DataBlobGroup.objects.filter(pk=wrong_tree.pk).exists()
+
+
+@pytest.mark.django_db
+def test_package_version_populator_seed_attaches_orphan_group_with_matching_name(
+    mocker,
+) -> None:
+    fake_status = mocker.Mock()
+    fake_status.SUCCESS = "SUCCESS"
+    fake_decompilation = mocker.MagicMock()
+    mocker.patch(
+        "thunderstore.core.management.commands.content.package_version.Decompilation",
+        fake_decompilation,
+    )
+    mocker.patch(
+        "thunderstore.core.management.commands.content.package_version.DecompilationStatus",
+        fake_status,
+    )
+
+    version = PackageVersionFactory()
+    tree_name = f"File tree of package: {version.full_version_name}"
+    orphan = DataBlobGroup.objects.create(name=tree_name)
+    assert version.file_tree_id is None
+
+    PackageVersionPopulator()._seed_package_source_data()
+
+    version.refresh_from_db()
+    assert version.file_tree_id == orphan.pk
+    assert version.file_tree.is_complete is True
+
+
+def test_package_version_module_reraises_non_ts_scanners_module_not_found() -> None:
+    mod_name = "thunderstore.core.management.commands.content.package_version"
+    sys.modules.pop(mod_name, None)
+    real_import = builtins.__import__
+
+    def import_hook(
+        name: str,
+        globalns=None,
+        localns=None,
+        fromlist=(),
+        level: int = 0,
+    ):
+        if name == "ts_scanners.models.decompilation":
+            raise ModuleNotFoundError(name="some_transitive_dependency")
+        return real_import(name, globalns, localns, fromlist, level)
+
+    try:
+        with patch("builtins.__import__", side_effect=import_hook):
+            with pytest.raises(ModuleNotFoundError) as excinfo:
+                importlib.import_module(mod_name)
+        assert excinfo.value.name == "some_transitive_dependency"
+    finally:
+        sys.modules.pop(mod_name, None)
+        importlib.import_module(mod_name)
+
+
+def test_package_version_module_sets_decompilation_none_when_import_fails() -> None:
+    mod_name = "thunderstore.core.management.commands.content.package_version"
+    sys.modules.pop(mod_name, None)
+    real_import = builtins.__import__
+
+    def import_hook(
+        name: str,
+        globalns=None,
+        localns=None,
+        fromlist=(),
+        level: int = 0,
+    ):
+        if name == "ts_scanners.models.decompilation":
+            raise ModuleNotFoundError(name="ts_scanners")
+        return real_import(name, globalns, localns, fromlist, level)
+
+    try:
+        with patch("builtins.__import__", side_effect=import_hook):
+            mod = importlib.import_module(mod_name)
+        assert mod.Decompilation is None
+        assert mod.DecompilationStatus is None
+    finally:
+        sys.modules.pop(mod_name, None)
+        importlib.import_module(mod_name)


### PR DESCRIPTION
Extend setup_dev_env to generate mock decompilation source data for the latest package version so analysis/source views can be exercised locally without manual data preparation.