### PR TITLE
Filter package dependants by latest version only

### DIFF
--- a/django/thunderstore/api/cyberstorm/tests/test_package_listing_list.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_package_listing_list.py
@@ -809,6 +809,32 @@ def test_listing_by_dependency_view__returns_only_dependants_of_requested_packag
 
 
 @pytest.mark.django_db
+def test_listing_by_dependency_view__ignores_packages_when_only_older_version_depends_on_target(
+    api_client: APIClient,
+    community: Community,
+) -> None:
+    target_listing = PackageListingFactory(community_=community)
+    target_dependency_id = target_listing.package.latest.id
+
+    dependant_listing = PackageListingFactory(community_=community)
+    dependant_listing.package.latest.dependencies.set([target_dependency_id])
+
+    newer_version = PackageVersionFactory(
+        package=dependant_listing.package,
+        version_number="1.0.1",
+    )
+    dependant_listing.package.latest = newer_version
+    dependant_listing.package.save(update_fields=("latest",))
+
+    response = api_client.get(
+        f"/api/cyberstorm/listing/{community.identifier}/{target_listing.package.namespace.name}/{target_listing.package.name}/dependants/",
+    )
+    result = response.json()
+
+    assert result["count"] == 0
+
+
+@pytest.mark.django_db
 def test_listing_by_dependency_view__returns_only_packages_listed_in_community(
     api_client: APIClient,
     community: Community,

--- a/django/thunderstore/repository/models/package.py
+++ b/django/thunderstore/repository/models/package.py
@@ -40,13 +40,9 @@ class PackageQueryset(VisibilityFlagsQuerySet):
 
 
 def get_package_dependants(package_pk: int):
-    from thunderstore.repository.models import PackageVersion
-
-    has_dependency = PackageVersion.objects.filter(
-        dependants__package=OuterRef("pk"),
-        package_id=package_pk,
-    )
-    return Package.objects.filter(Exists(has_dependency)).active()
+    return Package.objects.filter(
+        latest__dependencies__package_id=package_pk,
+    ).active()
 
 
 @cache_function_result(CacheBustCondition.any_package_updated)


### PR DESCRIPTION
This changes the Dependants semantic from "list all mods that have ever depended on this mod" to "list all mods where the latest version depends on this mod".

The reasoning is that showing mod/modpacks in the dependants list that no longer depend on a mod is a bit confusing and adds noise.

The ability to search for mods/modpacks that have historically depended on a mod could still be useful as a separate feature. However, that should also show the version number, which it currently doesn't. For now, this use case is better handled through the API and a simple script rather than exposing it directly on the website.