### PR TITLE
Make riskofrain2 the default community in OLD_EXCLUSIVE_HOST requests

### DIFF
--- a/django/thunderstore/community/middleware.py
+++ b/django/thunderstore/community/middleware.py
@@ -6,7 +6,10 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.http import Http404, HttpRequest, HttpResponse, HttpResponseRedirect
 from django.urls import reverse
 
-from thunderstore.community.utils import get_community_site_for_request
+from thunderstore.community.utils import (
+    get_community_site_for_request,
+    get_default_community,
+)
 from thunderstore.core.urls import AUTH_ROOT
 
 if TYPE_CHECKING:
@@ -58,8 +61,12 @@ class CommunitySiteMiddleware:
             if not request.path.startswith(self.auth_path):
                 return self.get_404(request)
         elif old_exclusive_host and request_host == old_exclusive_host:
-            # Allow all paths on the old exclusive host without enforcing community context
-            pass
+            # Bypass the normal domain check and supply a default community context
+            if not request.path.startswith(self.admin_path):
+                community = get_default_community()
+                if community is None:
+                    return self.get_404(request)
+                request.community = community
         elif not request.path.startswith(self.admin_path):
             try:
                 add_community_context_to_request(request)

--- a/django/thunderstore/community/tests/test_middleware.py
+++ b/django/thunderstore/community/tests/test_middleware.py
@@ -5,6 +5,7 @@ from django.test import RequestFactory
 from django.utils.encoding import iri_to_uri
 
 from thunderstore.community.middleware import CommunitySiteMiddleware
+from thunderstore.community.models import Community
 
 
 @pytest.mark.parametrize("protocol", ("http://", "https://"))
@@ -34,12 +35,27 @@ def test_community_site_middleware_get_404(
         assert response["Location"] == iri_to_uri(f"{protocol}{primary_domain}/")
 
 
-def test_community_site_middleware_old_exclusive_host(settings: Any) -> None:
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "path, expect_community",
+    (
+        ("/", True),
+        ("/any/path/", True),
+        ("/c/some_community/", True),
+        ("/admin/", False),
+    ),
+)
+def test_community_site_middleware_old_exclusive_host(
+    settings: Any, path: str, expect_community: bool
+) -> None:
+    # Ensure the community exists so get_default_community finds it
+    Community.objects.get_or_create(identifier="riskofrain2", defaults={"name": "Risk of Rain 2"})
+
     settings.OLD_EXCLUSIVE_HOST = "old.thunderstore.localhost"
     settings.AUTH_EXCLUSIVE_HOST = "auth.thunderstore.localhost"
     settings.PRIMARY_HOST = "thunderstore.localhost"
 
-    request = RequestFactory().get("/any/path/", HTTP_HOST="old.thunderstore.localhost")
+    request = RequestFactory().get(path, HTTP_HOST="old.thunderstore.localhost")
 
     def mock_get_response(req):
         from django.http import HttpResponse
@@ -52,4 +68,27 @@ def test_community_site_middleware_old_exclusive_host(settings: Any) -> None:
     assert response.status_code == 200
     assert response.content == b"OK"
     assert request.site is None
-    assert request.community is None
+
+    if expect_community:
+        assert request.community is not None
+        assert request.community.identifier == "riskofrain2"
+    else:
+        assert request.community is None
+
+
+@pytest.mark.django_db
+def test_community_site_middleware_old_exclusive_host_missing_community(
+    settings: Any,
+) -> None:
+    # Deliberately do not create the riskofrain2 community row
+    settings.OLD_EXCLUSIVE_HOST = "old.thunderstore.localhost"
+    settings.AUTH_EXCLUSIVE_HOST = "auth.thunderstore.localhost"
+    settings.PRIMARY_HOST = None
+
+    request = RequestFactory().get("/", HTTP_HOST="old.thunderstore.localhost")
+
+    middleware = CommunitySiteMiddleware(lambda req: None)
+    response = middleware(request)
+
+    assert response.status_code == 404
+    assert b"Community not found" in response.content

--- a/django/thunderstore/community/tests/test_middleware.py
+++ b/django/thunderstore/community/tests/test_middleware.py
@@ -8,6 +8,15 @@ from thunderstore.community.middleware import CommunitySiteMiddleware
 from thunderstore.community.models import Community
 
 
+def make_get_response(content: bytes = b"OK", status: int = 200):
+    def get_response(req):
+        from django.http import HttpResponse
+
+        return HttpResponse(content, status=status)
+
+    return get_response
+
+
 @pytest.mark.parametrize("protocol", ("http://", "https://"))
 @pytest.mark.parametrize(
     "primary_domain, status, content",
@@ -42,14 +51,16 @@ def test_community_site_middleware_get_404(
         ("/", True),
         ("/any/path/", True),
         ("/c/some_community/", True),
-        ("/admin/", False),
+        ("/djangoadmin/", False),
     ),
 )
 def test_community_site_middleware_old_exclusive_host(
     settings: Any, path: str, expect_community: bool
 ) -> None:
     # Ensure the community exists so get_default_community finds it
-    Community.objects.get_or_create(identifier="riskofrain2", defaults={"name": "Risk of Rain 2"})
+    Community.objects.get_or_create(
+        identifier="riskofrain2", defaults={"name": "Risk of Rain 2"}
+    )
 
     settings.OLD_EXCLUSIVE_HOST = "old.thunderstore.localhost"
     settings.AUTH_EXCLUSIVE_HOST = "auth.thunderstore.localhost"
@@ -92,3 +103,85 @@ def test_community_site_middleware_old_exclusive_host_missing_community(
 
     assert response.status_code == 404
     assert b"Community not found" in response.content
+
+
+def test_community_site_middleware_auth_exclusive_host_allows_auth_paths(
+    settings: Any,
+) -> None:
+    settings.AUTH_EXCLUSIVE_HOST = "auth.thunderstore.localhost"
+    settings.OLD_EXCLUSIVE_HOST = None
+    settings.PRIMARY_HOST = "thunderstore.localhost"
+
+    request = RequestFactory().get(
+        "/auth/login/", HTTP_HOST="auth.thunderstore.localhost"
+    )
+    middleware = CommunitySiteMiddleware(make_get_response())
+    response = middleware(request)
+
+    assert response.status_code == 200
+    assert request.community is None
+    assert request.site is None
+
+
+def test_community_site_middleware_auth_exclusive_host_blocks_non_auth_paths(
+    settings: Any,
+) -> None:
+    settings.AUTH_EXCLUSIVE_HOST = "auth.thunderstore.localhost"
+    settings.OLD_EXCLUSIVE_HOST = None
+    settings.PRIMARY_HOST = None
+
+    request = RequestFactory().get("/", HTTP_HOST="auth.thunderstore.localhost")
+    middleware = CommunitySiteMiddleware(make_get_response())
+    response = middleware(request)
+
+    assert response.status_code == 404
+
+
+def test_community_site_middleware_admin_path_skips_community_context(
+    settings: Any,
+) -> None:
+    settings.AUTH_EXCLUSIVE_HOST = None
+    settings.OLD_EXCLUSIVE_HOST = None
+
+    request = RequestFactory().get("/djangoadmin/", HTTP_HOST="testsite.test")
+    middleware = CommunitySiteMiddleware(make_get_response())
+    response = middleware(request)
+
+    assert response.status_code == 200
+    assert request.community is None
+    assert request.site is None
+
+
+@pytest.mark.django_db
+def test_community_site_middleware_unknown_host_returns_404(
+    settings: Any,
+) -> None:
+    settings.AUTH_EXCLUSIVE_HOST = None
+    settings.OLD_EXCLUSIVE_HOST = None
+    settings.PRIMARY_HOST = None
+    settings.ALLOWED_HOSTS = ["unknown.thunderstore.localhost"]
+
+    request = RequestFactory().get("/", HTTP_HOST="unknown.thunderstore.localhost")
+    middleware = CommunitySiteMiddleware(make_get_response())
+    response = middleware(request)
+
+    assert response.status_code == 404
+    assert b"Community not found" in response.content
+
+
+@pytest.mark.django_db
+def test_community_site_middleware_unknown_host_redirects_to_primary(
+    settings: Any,
+) -> None:
+    settings.AUTH_EXCLUSIVE_HOST = None
+    settings.OLD_EXCLUSIVE_HOST = None
+    settings.PRIMARY_HOST = "thunderstore.io"
+    settings.PROTOCOL = "https://"
+    settings.ALLOWED_HOSTS = ["unknown.thunderstore.localhost"]
+
+    request = RequestFactory().get("/", HTTP_HOST="unknown.thunderstore.localhost")
+    middleware = CommunitySiteMiddleware(make_get_response())
+    response = middleware(request)
+
+    assert response.status_code == 302
+    assert response["Location"] == "https://thunderstore.io/"

--- a/django/thunderstore/community/tests/test_utils.py
+++ b/django/thunderstore/community/tests/test_utils.py
@@ -1,0 +1,44 @@
+import pytest
+
+from thunderstore.community.models import Community
+from thunderstore.community.utils import (
+    get_community_for_request,
+    get_default_community,
+)
+
+
+@pytest.mark.django_db
+def test_get_default_community_returns_none_when_missing():
+    Community.objects.filter(identifier="riskofrain2").delete()
+    assert get_default_community() is None
+
+
+@pytest.mark.django_db
+def test_get_default_community_returns_community_when_present():
+    community, _ = Community.objects.get_or_create(
+        identifier="riskofrain2", defaults={"name": "Risk of Rain 2"}
+    )
+    result = get_default_community()
+    assert result == community
+
+
+@pytest.mark.django_db
+def test_get_community_for_request_returns_existing_community(rf):
+    community, _ = Community.objects.get_or_create(
+        identifier="riskofrain2", defaults={"name": "Risk of Rain 2"}
+    )
+    request = rf.get("/")
+    result = get_community_for_request(request)
+    assert result == community
+    assert Community.objects.filter(identifier="riskofrain2").count() == 1
+
+
+@pytest.mark.django_db
+def test_get_community_for_request_creates_community_when_missing(rf):
+    Community.objects.filter(identifier="riskofrain2").delete()
+    request = rf.get("/")
+    result = get_community_for_request(request)
+    assert result is not None
+    assert result.identifier == "riskofrain2"
+    assert result.name == "Risk of Rain 2"
+    assert Community.objects.filter(identifier="riskofrain2").count() == 1

--- a/django/thunderstore/community/utils.py
+++ b/django/thunderstore/community/utils.py
@@ -14,6 +14,10 @@ def get_community_for_request(request):
     return Community.objects.create(identifier="riskofrain2", name="Risk of Rain 2")
 
 
+def get_default_community() -> Optional[Community]:
+    return Community.objects.filter(identifier="riskofrain2").first()
+
+
 def get_community_site_for_request(request):
     site = get_current_site(request)
     return CommunitySite.objects.select_related("site", "community").get(site=site)

--- a/django/thunderstore/community/utils.py
+++ b/django/thunderstore/community/utils.py
@@ -6,16 +6,16 @@ from thunderstore.community.models import Community, CommunitySite
 from thunderstore.repository.models import Package
 
 
+def get_default_community() -> Optional[Community]:
+    return Community.objects.filter(identifier="riskofrain2").first()
+
+
 # TODO: Remove and rely on request.community when request is actually available
 def get_community_for_request(request):
-    community = Community.objects.filter(identifier="riskofrain2").first()
+    community = get_default_community()
     if community:
         return community
     return Community.objects.create(identifier="riskofrain2", name="Risk of Rain 2")
-
-
-def get_default_community() -> Optional[Community]:
-    return Community.objects.filter(identifier="riskofrain2").first()
 
 
 def get_community_site_for_request(request):


### PR DESCRIPTION
This is to ensure the older paths that assume CommunitySite exists, work
properly in the old. subdomain.