### PR TITLE
Show Upload Readme & Changelog Preview

### DIFF
--- a/builder/src/upload.tsx
+++ b/builder/src/upload.tsx
@@ -71,6 +71,7 @@ enum SubmissionStatus {
 
 interface SubmissionFormProps {
     onSubmissionComplete?: (result: PackageSubmissionResult) => void;
+    onContentChange?: (readme: string | null, changelog: string | null) => void;
     currentCommunity: Community;
     useAsyncFlow: boolean;
 }
@@ -125,6 +126,7 @@ const SubmissionForm: React.FC<SubmissionFormProps> = observer((props) => {
         setFileUpload(null);
         setSubmissionStatus(null);
         setFormErrors(new FormErrors());
+        props.onContentChange?.(null, null);
     };
 
     const upload = async (file: File | null) => {
@@ -149,6 +151,8 @@ const SubmissionForm: React.FC<SubmissionFormProps> = observer((props) => {
                         );
                         setSubmissionStatus(SubmissionStatus.ERROR);
                     }
+                } else {
+                    props.onContentChange?.(result.readme, result.changelog);
                 }
             });
         }
@@ -566,6 +570,39 @@ export const UploadPage: React.FC<UploadPageProps> = (props) => {
         setSubmissionResult(result);
     };
 
+    const [readmePreview, setReadmePreview] = useState<string>("");
+    const [changelogPreview, setChangelogPreview] = useState<string>("");
+
+    const onContentChange = (
+        readme: string | null,
+        changelog: string | null
+    ) => {
+        if (readme) {
+            ExperimentalApi.renderMarkdown({ data: { markdown: readme } })
+                .then((result) => {
+                    setReadmePreview(result.html);
+                })
+                .catch((e) => {
+                    Sentry.captureException(e);
+                    setReadmePreview("Failed to render Readme Preview");
+                });
+        } else {
+            setReadmePreview("");
+        }
+        if (changelog) {
+            ExperimentalApi.renderMarkdown({ data: { markdown: changelog } })
+                .then((result) => {
+                    setChangelogPreview(result.html);
+                })
+                .catch((e) => {
+                    Sentry.captureException(e);
+                    setChangelogPreview("Failed to render Changelog Preview");
+                });
+        } else {
+            setChangelogPreview("");
+        }
+    };
+
     return (
         <div style={{ marginBottom: "96px" }}>
             {/* Bottom margin will affect how select option dropdowns render */}
@@ -577,9 +614,28 @@ export const UploadPage: React.FC<UploadPageProps> = (props) => {
                         currentCommunity={props.currentCommunity}
                         useAsyncFlow={!!props.useAsyncFlow}
                         onSubmissionComplete={onSubmissionComplete}
+                        onContentChange={onContentChange}
                     />
                 </div>
             </div>
+            {readmePreview && (
+                <div className={"card bg-light mb-2"}>
+                    <div className={"card-header"}>Readme Preview</div>
+                    <div
+                        className={"card-body markdown-body"}
+                        dangerouslySetInnerHTML={{ __html: readmePreview }}
+                    />
+                </div>
+            )}
+            {changelogPreview && (
+                <div className={"card bg-light mb-2"}>
+                    <div className={"card-header"}>Changelog Preview</div>
+                    <div
+                        className={"card-body markdown-body"}
+                        dangerouslySetInnerHTML={{ __html: changelogPreview }}
+                    />
+                </div>
+            )}
             {submissionResult ? (
                 <div
                     className="card bg-light mb-3"

--- a/builder/src/uploadZipValidation.ts
+++ b/builder/src/uploadZipValidation.ts
@@ -1,17 +1,24 @@
 import { FormErrors } from "./upload";
-import { BlobReader, ZipReader } from "./vendor/zip-fs-full";
+import { BlobReader, TextWriter, ZipReader } from "./vendor/zip-fs-full";
 
 export async function validateZip(
     file: File
-): Promise<{ errors: FormErrors; blockUpload: boolean }> {
+): Promise<{
+    errors: FormErrors;
+    blockUpload: boolean;
+    readme: string | null;
+    changelog: string | null;
+}> {
     let errors = new FormErrors();
 
     let blockUpload = false;
+    let readme: string | null = null;
+    let changelog: string | null = null;
 
     if (!file.name.toLowerCase().endsWith(".zip")) {
         errors.fileErrors.push("The file you selected is not a .zip!");
         blockUpload = true;
-        return { errors, blockUpload };
+        return { errors, blockUpload, readme, changelog };
     }
 
     if (file.name.toLowerCase().includes("test")) {
@@ -85,9 +92,18 @@ export async function validateZip(
                 hasReadMe = true;
                 if (entry.filename == "README.md") {
                     rootReadMe = true;
+                    const textWriter = new TextWriter("utf-8");
+                    readme = (await entry.getData(textWriter)) as string;
                 } else if (entry.filename.toLowerCase() == "readme.md") {
                     wrongCase = true;
                     rootReadMe = true;
+                }
+            }
+
+            if (entry.filename.toLowerCase().endsWith("changelog.md")) {
+                if (entry.filename == "CHANGELOG.md") {
+                    const textWriter = new TextWriter("utf-8");
+                    changelog = (await entry.getData(textWriter)) as string;
                 }
             }
 
@@ -199,5 +215,5 @@ export async function validateZip(
         errors.fileErrors.push("Your .zip file could not be read.");
     }
 
-    return { errors, blockUpload };
+    return { errors, blockUpload, readme, changelog };
 }

--- a/builder/src/vendor/zip-fs-full.d.ts
+++ b/builder/src/vendor/zip-fs-full.d.ts
@@ -61,12 +61,7 @@ export interface Entry {
     comment: string;
     crc32: number;
 
-    getData(
-        writer: zip.Writer,
-        onend: (result: any) => void,
-        onprogress?: (progress: number, total: number) => void,
-        checkCrc32?: boolean
-    ): void;
+    getData(writer: Writer): Promise<any>;
 }
 
 export class Writer {

--- a/builder/tsconfig.json
+++ b/builder/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es5",
+        "target": "es2017",
         "module": "commonjs",
         "allowJs": true,
         "checkJs": false,
@@ -9,7 +9,6 @@
         "declarationMap": true,
         "sourceMap": true,
         "removeComments": true,
-        "downlevelIteration": true,
         "useDefineForClassFields": true,
         "experimentalDecorators": true,
 


### PR DESCRIPTION
Renders the Readme and Changelog from the uploaded zip.

<img width="1767" height="1246" alt="image" src="https://github.com/user-attachments/assets/f5c5e7f8-b1fc-4173-a09b-97c6ed4c2498" />
<br/>
<br/>
I'm not sure why Entry.getData had a wrong signature in the .d.ts in the first place, but now it matches the real implementation more closely. The tsconfig required updating to es2017 to prevent the browser throwing errors, however es5 is deprecated anyway.
