### PR TITLE
etc: Drop unused prefetches from Cyberstorm package listing

### DIFF
--- a/django/thunderstore/api/cyberstorm/views/package_listing_list.py
+++ b/django/thunderstore/api/cyberstorm/views/package_listing_list.py
@@ -205,8 +205,6 @@ class BasePackageListAPIView(PublicCacheMixin, ListAPIView):
             "package__namespace",
         ).prefetch_related(
             "categories",
-            "package__versions",
-            "package__package_ratings",
         )
 
     def _get_validated_query_params(self) -> OrderedDict:


### PR DESCRIPTION
Removes two entries from the `prefetch_related()` on `BasePackageListAPIView`: `package__versions` and `package__package_ratings`.

Stops the endpoint from grabbing every package's versions and ratings (like thousands of rows) that the serializer never reads.
