### PR TITLE
etc: Drop unused aggregate annotations from experimental package queryset

### DIFF
--- a/django/thunderstore/repository/api/experimental/views/package.py
+++ b/django/thunderstore/repository/api/experimental/views/package.py
@@ -1,4 +1,4 @@
-from django.db.models import Count, QuerySet, Sum
+from django.db.models import QuerySet
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework.exceptions import ValidationError
 from rest_framework.generics import ListAPIView, RetrieveAPIView, get_object_or_404
@@ -29,12 +29,6 @@ def get_package_queryset() -> "QuerySet[Package]":
             "community_listings",
             "community_listings__categories",
             "community_listings__community",
-        )
-        .annotate(
-            _total_downloads=Sum("versions__downloads"),
-        )
-        .annotate(
-            _rating_score=Count("package_ratings"),
         )
     )
 


### PR DESCRIPTION
Removes two `annotate()` calls from `get_package_queryset` in the experimental package API: `_total_downloads` (a `Sum`) and `_rating_score` (a `Count`), whose results `PackageSerializerExperimental` hardcodes to `-1` and never reads.

Cuts a fan-out join and a five-column `GROUP BY` from every experimental package list and detail request, with no change to the response.
