### PR TITLE
etc: Use cached helper for Cyberstorm package dependant count

### DIFF
--- a/django/thunderstore/api/cyberstorm/views/package_listing.py
+++ b/django/thunderstore/api/cyberstorm/views/package_listing.py
@@ -37,7 +37,7 @@ from thunderstore.api.utils import (
 )
 from thunderstore.community.models.package_listing import PackageListing
 from thunderstore.core.types import UserType
-from thunderstore.repository.models.package import get_package_dependants
+from thunderstore.repository.models.package import get_package_dependants_count
 from thunderstore.repository.models.package_version import PackageVersion
 from thunderstore.repository.views.package.detail import PermissionsChecker
 
@@ -226,7 +226,7 @@ def get_custom_package_listing(
         )
 
     listing.dependency_count = dependencies.count()
-    listing.dependant_count = get_package_dependants(listing.package.pk).count()
+    listing.dependant_count = get_package_dependants_count(listing.package.pk)
 
     return listing
 

--- a/django/thunderstore/repository/models/package.py
+++ b/django/thunderstore/repository/models/package.py
@@ -54,6 +54,11 @@ def get_package_dependants_list(package_pk: int):
     return list(get_package_dependants(package_pk))
 
 
+@cache_function_result(CacheBustCondition.any_package_updated)
+def get_package_dependants_count(package_pk: int) -> int:
+    return get_package_dependants(package_pk).count()
+
+
 class Package(VisibilityMixin, AdminLinkMixin):
     objects = PackageQueryset.as_manager()
     wiki: Optional["PackageWiki"]


### PR DESCRIPTION
`get_custom_package_listing` now counts a package's dependants with `get_package_dependants_list`, the `@cache_function_result` helper that `Package` already uses, instead of the uncached `get_package_dependants(...).count()`.

Drops a correlated `Exists` subquery over the package-version table from every Cyberstorm package-detail render, serving the dependant count from cache instead.
