### PR TITLE
Minor moderation-related visual changes

### DIFF
--- a/django/thunderstore/community/models/package_listing.py
+++ b/django/thunderstore/community/models/package_listing.py
@@ -217,26 +217,27 @@ class PackageListing(TimestampMixin, AdminLinkMixin, VisibilityMixin):
         rejection_reason: str,
         is_system: bool = False,
         internal_notes: Optional[str] = None,
+        should_fire_audit_event=True,
     ):
         if is_system or self.can_user_manage_approval_status(agent):
+            fields_to_update = ["rejection_reason", "review_status"]
+
             self.rejection_reason = rejection_reason
             self.review_status = PackageListingReviewStatus.rejected
-            self.notes = internal_notes or self.notes
-            self.save(
-                update_fields=(
-                    "rejection_reason",
-                    "review_status",
-                    "notes",
+            if internal_notes is not None and internal_notes != self.notes:
+                self.notes = internal_notes
+                fields_to_update.append("notes")
+
+            self.save(update_fields=fields_to_update)
+            if should_fire_audit_event:
+                message = "\n\n".join(filter(bool, (rejection_reason, internal_notes)))
+                fire_audit_event(
+                    self.build_audit_event(
+                        action=AuditAction.REJECTED,
+                        user_id=agent.pk if agent else None,
+                        message=message,
+                    )
                 )
-            )
-            message = "\n\n".join(filter(bool, (rejection_reason, internal_notes)))
-            fire_audit_event(
-                self.build_audit_event(
-                    action=AuditAction.REJECTED,
-                    user_id=agent.pk if agent else None,
-                    message=message,
-                )
-            )
         else:
             raise PermissionError()
 

--- a/django/thunderstore/community/templates/community/packagelisting_detail.html
+++ b/django/thunderstore/community/templates/community/packagelisting_detail.html
@@ -76,22 +76,18 @@ window.ts.PackageManagementPanel(
 {% endcache %}
 
 {% if show_review_status and object.is_rejected %}
-<div class="card text-white bg-danger mt-2">
-    <div class="card-body">
-        <h4 class="card-title">
-            Package rejected
-        </h4>
-        <p class="card-text">
-            This package has been rejected by site or community moderators.
-            If you think this is a mistake, please reach out to the moderators in
-            <a href="https://discord.thunderstore.io/">our Discord server</a>
-        </p>
-        {% if object.rejection_reason %}
-        <p class="card-text">
-            Reason: {{ object.rejection_reason }}
-        </p>
-        {% endif %}
-    </div>
+<div class="alert alert-danger">
+    <h4 class="card-title">
+        Package rejected
+    </h4>
+    <p class="card-text">
+        This package has been rejected by site or community moderators.
+        If you think this is a mistake, please reach out to the moderators in
+        <a href="https://discord.thunderstore.io/">our Discord server</a>
+    </p>
+    {% if object.rejection_reason %}
+    <pre class="card-text">Reason: {{ object.rejection_reason }}</pre>
+    {% endif %}
 </div>
 {% endif %}
 
@@ -109,14 +105,12 @@ window.ts.PackageManagementPanel(
 {% endif %}
 
 {% if show_internal_notes and object.notes %}
-    <div class="card text-white bg-info mt-2">
-        <div class="card-body">
-            <h4 class="card-title">
-                Internal notes
-            </h4>
-            <p class="card-text">{{ object.notes }}</p>
-        </div>
-    </div>
+<div class="alert alert-info">
+    <h4 class="card-title">
+        Internal notes
+    </h4>
+    <pre class="card-text">{{ object.notes }}</pre>
+</div>
 {% endif %}
 
 <div class="card bg-light mt-2">

--- a/django/thunderstore/community/tests/test_package_listing.py
+++ b/django/thunderstore/community/tests/test_package_listing.py
@@ -660,3 +660,85 @@ def test_package_listing_is_unavailable(
 
         listing = PackageListingFactory()
         assert listing.is_unavailable == expected
+
+
+@pytest.mark.django_db
+def test_package_listing_reject_or_approve_requires_permissions():
+    listing = PackageListingFactory()
+    user = UserFactory()
+
+    with pytest.raises(PermissionError):
+        listing.reject(
+            agent=user, rejection_reason="Invalid submission", is_system=False
+        )
+
+    with pytest.raises(PermissionError):
+        listing.approve(agent=user, is_system=False)
+
+    user.is_superuser = True
+
+    listing.reject(agent=user, rejection_reason="Invalid submission", is_system=False)
+
+    assert listing.review_status == PackageListingReviewStatus.rejected
+
+    listing.approve(agent=user, is_system=False)
+
+    assert listing.review_status == PackageListingReviewStatus.approved
+
+
+@pytest.mark.django_db
+def test_package_listing_reject_or_approve_is_system_overrides_permissions():
+    listing = PackageListingFactory()
+
+    with pytest.raises(PermissionError):
+        listing.reject(
+            agent=None, rejection_reason="Invalid submission", is_system=False
+        )
+
+    with pytest.raises(PermissionError):
+        listing.approve(agent=None, is_system=False)
+
+    listing.reject(agent=None, rejection_reason="Invalid submission", is_system=True)
+
+    assert listing.review_status == PackageListingReviewStatus.rejected
+
+    listing.approve(agent=None, is_system=True)
+
+    assert listing.review_status == PackageListingReviewStatus.approved
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("should_fire", [True, False])
+def test_package_listing_reject_audit_control(mocker, should_fire):
+    listing = PackageListingFactory()
+    mock_fire_audit = mocker.patch(
+        "thunderstore.community.models.package_listing.fire_audit_event"
+    )
+
+    listing.reject(
+        agent=None,
+        rejection_reason="Invalid submission",
+        is_system=True,
+        should_fire_audit_event=should_fire,
+    )
+
+    assert mock_fire_audit.called is should_fire
+
+
+@pytest.mark.django_db
+def test_package_listing_reject_skips_notes_if_none():
+    listing = PackageListingFactory()
+
+    original_notes = "Original notes"
+    listing.notes = original_notes
+    listing.save()
+
+    listing.reject(
+        agent=None,
+        rejection_reason="Invalid submission",
+        is_system=True,
+        internal_notes=None,
+    )
+
+    listing.refresh_from_db()
+    assert listing.notes == original_notes

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -73,32 +73,3 @@ completion.
 
 This is especially common if a task requires a model to be imported, but the
 model also wants to import the task (because code in the model calls the task).
-
-#### Example from the codebase
-
-```python
-# This example doesn't work due to a circular dependency between the code
-# modules, but it will work if the dependency is one-directional
-
-from ts_scanners.tasks.scan import scan_decompilation
-
-@shared_task(
-    queue=CeleryQueues.BackgroundTask,
-    name="ts_scanners.tasks.decompile.decompile_file",
-)
-def decompile_file(decompilation_id: str) -> str:
-    scan_decompilation(decompilation_id)
-```
-
-```python
-# This example works even if there is a circular dependency between code modules
-
-@shared_task(
-    queue=CeleryQueues.BackgroundTask,
-    name="ts_scanners.tasks.decompile.decompile_file",
-)
-def decompile_file(decompilation_id: str) -> str:
-    from ts_scanners.tasks.scan import scan_decompilation
-
-    scan_decompilation(decompilation_id)
-```


### PR DESCRIPTION
Adds a parameter to PackageListing.reject() that determines whether it fires an audit event or not in case we want to wait for a more complete audit event later.

Uses pre-formatted text and alert CSS for the reason / internal notes on the package details page.

Removes an unused example from conventions.md

This PR is required for a future Python Packages PR.