### PR TITLE
Add /auth/logout url

### DIFF
--- a/django/thunderstore/core/urls.py
+++ b/django/thunderstore/core/urls.py
@@ -43,6 +43,12 @@ urlpatterns = [
     path("robots.txt", robots_txt_view, name="robots.txt"),
     path(AUTH_ROOT, include("social_django.urls", namespace="social")),
     path(
+        "auth/logout/",
+        CustomLogoutView.as_view(),
+        kwargs={"next_page": "/"},
+        name="auth-logout",
+    ),
+    path(
         "logout/", CustomLogoutView.as_view(), kwargs={"next_page": "/"}, name="logout"
     ),
     path("package/", include((legacy_package_urls, "old_urls"), namespace="old_urls")),


### PR DESCRIPTION
The logout link points to thunderstore.dev/logout/ which is not routed to Django, falling through to the React UI catch-all and returning a 404.

Add /auth/logout/ Django route and update the frontend to send users to auth.thunderstore.dev/auth/logout/ instead. This host has a catch-all ingress to Django, and CommunitySiteMiddleware allows /auth/* paths.

The legacy /logout/ path is preserved for old.thunderstore.dev.

NOTE: frontend is updated in Nimbus. (https://github.com/thunderstore-io/thunderstore-ui/pull/1856)

Refs. TS-3345