### PR TITLE
Adjust link generation to not rely on PRIMARY_HOST in many places

### DIFF
--- a/django/thunderstore/community/models/community.py
+++ b/django/thunderstore/community/models/community.py
@@ -297,6 +297,11 @@ class Community(TimestampMixin, models.Model):
             sites = list(self.sites.select_related("site"))
         if not sites:
             return None
+        # CommunitySite has no Meta.ordering, so sort the already-materialized
+        # list by pk (no extra query, and it works for the prefetched case too)
+        # to keep the fallback below deterministic instead of dependent on DB
+        # row order when no site matches PRIMARY_HOST.
+        sites.sort(key=lambda community_site: community_site.pk)
         for community_site in sites:
             if community_site.site.domain == settings.PRIMARY_HOST:
                 return community_site
@@ -306,6 +311,16 @@ class Community(TimestampMixin, models.Model):
         # Host-relative URL for in-site navigation, so links rendered on the
         # legacy site stay on the host that served the page instead of jumping
         # to the community's main_site (the new app) host.
+        #
+        # Unlike PackageListing.get_absolute_url(), this deliberately does NOT go
+        # through get_community_url_reverse_args() and always uses the explicit
+        # `/c/<id>/` scheme. Community links are cross-community (community tiles,
+        # the popular-communities nav), so the target usually isn't the community
+        # implied by the current host. The implicit `old_urls:` scheme carries no
+        # community identifier (old_urls:packages.list -> /package/), so routing
+        # through the helper would resolve every link to the serving host's own
+        # community. The explicit route is registered on every host, so it also
+        # resolves on the legacy site.
         return reverse(
             "communities:community:packages.list",
             kwargs={

--- a/django/thunderstore/community/models/community.py
+++ b/django/thunderstore/community/models/community.py
@@ -284,22 +284,41 @@ class Community(TimestampMixin, models.Model):
 
     @cached_property
     def main_site(self) -> Optional["CommunitySite"]:
-        try:
-            return self.sites.all()[0]
-        except IndexError:
+        # Prefer the site on PRIMARY_HOST (the canonical main domain) so absolute
+        # URLs built from main_site (the v1 API `package_url`, full_url, …) don't
+        # drift to a secondary host like the legacy `old.` mirror. Reuse the
+        # prefetched `sites` when available (CommunityMixin prefetches them with
+        # select_related("site")); otherwise issue a single select_related query
+        # so the domain comparison below doesn't trigger an N+1 on
+        # community_site.site.
+        if "sites" in getattr(self, "_prefetched_objects_cache", {}):
+            sites = list(self.sites.all())
+        else:
+            sites = list(self.sites.select_related("site"))
+        if not sites:
             return None
+        for community_site in sites:
+            if community_site.site.domain == settings.PRIMARY_HOST:
+                return community_site
+        return sites[0]
+
+    def get_absolute_url(self) -> str:
+        # Host-relative URL for in-site navigation, so links rendered on the
+        # legacy site stay on the host that served the page instead of jumping
+        # to the community's main_site (the new app) host.
+        return reverse(
+            "communities:community:packages.list",
+            kwargs={
+                "community_identifier": self.identifier,
+            },
+        )
 
     @property
     def full_url(self):
         return (
             self.main_site.full_url
             if Community.should_use_old_urls(self)
-            else reverse(
-                "communities:community:packages.list",
-                kwargs={
-                    "community_identifier": self.identifier,
-                },
-            )
+            else self.get_absolute_url()
         )
 
     @property

--- a/django/thunderstore/community/templates/community/community_list.html
+++ b/django/thunderstore/community/templates/community/community_list.html
@@ -16,7 +16,7 @@
         {% for object in object_list %}
             <div class="col-6 col-md-4 col-lg-3 mb-2 p-1 d-flex flex-column">
                 <div class="p-0 bg-light">
-                    <a href="{{ object.full_url }}">
+                    <a href="{{ object.get_absolute_url }}">
                         {% if object.cover_image %}
                         <img class="w-100" src="{% thumbnail_url object.cover_image 360 480 %}" alt="{{ object.name }} icon">
                         {% else %}

--- a/django/thunderstore/community/templates/community/includes/version_table.html
+++ b/django/thunderstore/community/templates/community/includes/version_table.html
@@ -11,7 +11,7 @@
             <td>{{ version.version_number }}</td>
             <td>{{ version.downloads }}</td>
             <td class="d-flex gap-1">
-                <a href="{{ version.full_download_url }}" type="button" class="btn btn-primary">Download</a>
+                <a href="{{ version.relative_download_url }}" type="button" class="btn btn-primary">Download</a>
                 <a href="{{ version.install_url }}" type="button" class="btn btn-primary">Install</a>
             </td>
         </tr>

--- a/django/thunderstore/community/templates/community/packagelisting_detail.html
+++ b/django/thunderstore/community/templates/community/packagelisting_detail.html
@@ -161,7 +161,7 @@ window.ts.PackageManagementPanel(
     {% endif %}
 
     <div class="{% if object.has_mod_manager_support %} col-12 col-sm-6 px-3 pr-sm-3 pl-sm-1 mt-1 mt-sm-0 {% else %}col-12{% endif %}">
-        <a href="{{ object.package.latest.full_download_url }}" type="button" class="btn btn-primary w-100 text-large">
+        <a href="{{ object.package.latest.relative_download_url }}" type="button" class="btn btn-primary w-100 text-large">
             <i class="fa fa-download mr-2" aria-hidden="true"></i>Manual Download
         </a>
     </div>

--- a/django/thunderstore/community/templates/community/packagelisting_list.html
+++ b/django/thunderstore/community/templates/community/packagelisting_list.html
@@ -159,7 +159,7 @@
                     </div>
                 </div>
                 {% endif %}
-                <a href="{{ object.get_full_url }}">
+                <a href="{{ object.get_absolute_url }}">
                     <img class="w-100" src="{% thumbnail_url object.package.icon 256 256 %}" alt="{{ object.package }} icon">
                 </a>
             </div>

--- a/django/thunderstore/community/tests/test_community.py
+++ b/django/thunderstore/community/tests/test_community.py
@@ -1,5 +1,6 @@
 import pytest
 from django.core.exceptions import ValidationError
+from django.db.models import Prefetch
 
 from conftest import TestUserTypes
 from thunderstore.community.consts import PackageListingReviewStatus
@@ -204,6 +205,73 @@ def test_community_full_url(
     else:
         expected = f"/c/{community.identifier}/"
     assert community.full_url == expected
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("has_site", (False, True))
+def test_community_get_absolute_url(
+    community: Community,
+    has_site: bool,
+) -> None:
+    # get_absolute_url is always the host-relative path, regardless of whether
+    # the community has a main_site, so in-site navigation stays on the host
+    # that served the page (e.g. the legacy old. site).
+    if has_site:
+        CommunitySiteFactory(community=community)
+    assert community.get_absolute_url() == f"/c/{community.identifier}/"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("primary_created_first", (True, False))
+def test_community_main_site_prefers_primary_host(
+    community: Community,
+    primary_created_first: bool,
+    settings,
+) -> None:
+    # main_site must deterministically resolve to the PRIMARY_HOST site even when
+    # the community is also bound to the legacy `old.` mirror host, so absolute
+    # URLs built from it (the v1 API package_url, full_url, …) never drift to old.
+    settings.PRIMARY_HOST = "primary.example.localhost"
+    domains = ["primary.example.localhost", "legacy.example.localhost"]
+    if not primary_created_first:
+        domains.reverse()
+    for domain in domains:
+        CommunitySiteFactory(community=community, site__domain=domain)
+
+    # Reload so main_site (a cached_property) is computed against the new sites.
+    community = Community.objects.get(pk=community.pk)
+
+    assert community.main_site.site.domain == "primary.example.localhost"
+    assert "primary.example.localhost" in community.full_url
+    assert "legacy.example.localhost" not in community.full_url
+
+
+@pytest.mark.django_db
+def test_community_main_site_does_not_n_plus_one(
+    community: Community,
+    django_assert_num_queries,
+    settings,
+) -> None:
+    settings.PRIMARY_HOST = "primary.example.localhost"
+    for domain in (
+        "legacy.example.localhost",
+        "other.example.localhost",
+        "primary.example.localhost",
+    ):
+        CommunitySiteFactory(community=community, site__domain=domain)
+
+    # Not prefetched: a single select_related query must resolve every site and
+    # its domain — the per-site comparison must not add a query per row.
+    fresh = Community.objects.get(pk=community.pk)
+    with django_assert_num_queries(1):
+        assert fresh.main_site.site.domain == "primary.example.localhost"
+
+    # Prefetched the way CommunityMixin loads it: main_site must hit no queries.
+    prefetched = Community.objects.prefetch_related(
+        Prefetch("sites", queryset=CommunitySite.objects.select_related("site"))
+    ).get(pk=community.pk)
+    with django_assert_num_queries(0):
+        assert prefetched.main_site.site.domain == "primary.example.localhost"
 
 
 @pytest.mark.django_db

--- a/django/thunderstore/community/tests/test_community.py
+++ b/django/thunderstore/community/tests/test_community.py
@@ -242,8 +242,37 @@ def test_community_main_site_prefers_primary_host(
     community = Community.objects.get(pk=community.pk)
 
     assert community.main_site.site.domain == "primary.example.localhost"
-    assert "primary.example.localhost" in community.full_url
-    assert "legacy.example.localhost" not in community.full_url
+    # full_url resolves to the main_site's absolute URL; assert it exactly
+    # (rather than a substring membership check, which CodeQL flags as
+    # incomplete URL sanitization) so the host is pinned and the legacy mirror
+    # is excluded by construction.
+    assert community.full_url == f"{settings.PROTOCOL}primary.example.localhost/"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("reverse_creation_order", (False, True))
+def test_community_main_site_fallback_is_deterministic(
+    community: Community,
+    reverse_creation_order: bool,
+    settings,
+) -> None:
+    # When no site matches PRIMARY_HOST, main_site must still resolve to a
+    # stable row (the lowest pk) instead of whatever order the DB happens to
+    # return, so absolute URLs built from it don't flap between hosts.
+    settings.PRIMARY_HOST = "primary.example.localhost"
+    domains = ["a.example.localhost", "b.example.localhost"]
+    if reverse_creation_order:
+        domains.reverse()
+    created = [
+        CommunitySiteFactory(community=community, site__domain=domain)
+        for domain in domains
+    ]
+    lowest_pk_site = min(created, key=lambda community_site: community_site.pk)
+
+    # Reload so main_site (a cached_property) is computed fresh against the DB.
+    community = Community.objects.get(pk=community.pk)
+
+    assert community.main_site.pk == lowest_pk_site.pk
 
 
 @pytest.mark.django_db

--- a/django/thunderstore/community/tests/test_views.py
+++ b/django/thunderstore/community/tests/test_views.py
@@ -55,4 +55,4 @@ def test_community_list_view(client, community_site):
     assert response.status_code == 200
     data = response.content.decode()
     assert community_site.community.name in data
-    assert community_site.community.full_url in data
+    assert community_site.community.get_absolute_url() in data

--- a/django/thunderstore/frontend/templates/base.html
+++ b/django/thunderstore/frontend/templates/base.html
@@ -54,7 +54,7 @@
                                 <h6 class="title">Popular communities</h6>
                                 <div class="grid" role="list">
                                     {% for community in selectable_communities|slice:":8"|dictsort:"name" %}
-                                        <a class="grid-item" href="{{ community.full_url }}" role="listitem">{{ community.name }}</a>
+                                        <a class="grid-item" href="{{ community.get_absolute_url }}" role="listitem">{{ community.name }}</a>
                                     {% endfor %}
                                 </div>
                             </div>

--- a/django/thunderstore/repository/api/experimental/views/submit.py
+++ b/django/thunderstore/repository/api/experimental/views/submit.py
@@ -8,6 +8,7 @@ from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from thunderstore.core.utils import make_full_url
 from thunderstore.repository.api.experimental.serializers import (
     PackageSubmissionMetadataSerializer,
     PackageSubmissionResult,
@@ -63,7 +64,10 @@ class SubmitPackageApiView(APIView):
                 {
                     "community": listing.community,
                     "categories": listing.categories.all(),
-                    "url": listing.get_full_url(),
+                    # Build the URL against the requesting host so the legacy
+                    # upload page links stay on the host that served it,
+                    # instead of the listing's main_site (new app) host.
+                    "url": make_full_url(request, listing.get_absolute_url()),
                 }
             )
 

--- a/django/thunderstore/repository/api/experimental/views/submit_async.py
+++ b/django/thunderstore/repository/api/experimental/views/submit_async.py
@@ -4,6 +4,7 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from thunderstore.core.utils import make_full_url
 from thunderstore.repository.api.experimental.serializers import (
     PackageSubmissionMetadataSerializer,
     PackageSubmissionResult,
@@ -30,7 +31,12 @@ class PackageSubmissionStatusSerializer(serializers.Serializer):
                 {
                     "community": listing.community,
                     "categories": listing.categories.all(),
-                    "url": listing.get_full_url(),
+                    # Build the URL against the requesting host so the legacy
+                    # upload page links stay on the host that served it,
+                    # instead of the listing's main_site (new app) host.
+                    "url": make_full_url(
+                        self.context.get("request"), listing.get_absolute_url()
+                    ),
                 }
             )
 
@@ -76,7 +82,9 @@ class CreateAsyncPackageSubmissionApiView(APIView):
             ).data,
         )
         submission.schedule_if_appropriate()
-        response_serializer = PackageSubmissionStatusSerializer(instance=submission)
+        response_serializer = PackageSubmissionStatusSerializer(
+            instance=submission, context={"request": request}
+        )
         return Response(response_serializer.data)
 
 
@@ -101,5 +109,6 @@ class PollSubmissionStatusApiView(APIView):
         submission.schedule_if_appropriate()
         serializer = PackageSubmissionStatusSerializer(
             instance=submission,
+            context={"request": request},
         )
         return Response(serializer.data)

--- a/django/thunderstore/repository/models/package_version.py
+++ b/django/thunderstore/repository/models/package_version.py
@@ -272,6 +272,13 @@ class PackageVersion(VisibilityMixin, AdminLinkMixin):
         return f"{settings.PROTOCOL}{settings.PRIMARY_HOST}{self._download_url}"
 
     @property
+    def relative_download_url(self) -> str:
+        # Host-relative download path so legacy-site templates keep the user on
+        # the host that served the page. full_download_url hard-codes
+        # PRIMARY_HOST and must stay absolute for API / mod-manager consumers.
+        return self._download_url
+
+    @property
     def install_url(self):
         path = f"{self.package.owner.name}/{self.package.name}/{self.version_number}"
         return f"ror2mm://v1/install/{settings.PRIMARY_HOST}/{path}/"

--- a/django/thunderstore/repository/templates/repository/packageversion_detail.html
+++ b/django/thunderstore/repository/templates/repository/packageversion_detail.html
@@ -87,7 +87,7 @@
                 <td>{{ object.version_number }}</td>
             <tr>
                 <td>Download link</td>
-                <td><a href="{{ object.full_download_url }}">{{ object.full_version_name }}.zip</a></td>
+                <td><a href="{{ object.relative_download_url }}">{{ object.full_version_name }}.zip</a></td>
             </tr>
             <tr>
                 <td>Downloads</td>

--- a/django/thunderstore/repository/tests/test_package_version.py
+++ b/django/thunderstore/repository/tests/test_package_version.py
@@ -90,6 +90,27 @@ def test_package_version_full_download_url(
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize(
+    "primary_host",
+    ("primary.example.org", "secondary.example.org"),
+)
+def test_package_version_relative_download_url(
+    active_package_listing: PackageListing,
+    primary_host: str,
+    settings: Any,
+) -> None:
+    # The relative download URL is host-agnostic: it never embeds PRIMARY_HOST,
+    # so a download link rendered on the legacy site stays on the serving host.
+    settings.PRIMARY_HOST = primary_host
+    package = active_package_listing.package
+    namespace = package.namespace.name
+    version = package.latest
+    expected = f"/package/download/{namespace}/{package.name}/{version.version_number}/"
+    assert version.relative_download_url == expected
+    assert primary_host not in version.relative_download_url
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize("format_spec", PackageFormats.values + [None, "invalid"])
 def test_package_version_format_spec_constraint(
     package_version: PackageVersion,

--- a/django/thunderstore/repository/views/package/create.py
+++ b/django/thunderstore/repository/views/package/create.py
@@ -77,7 +77,10 @@ class PackageCreateOldView(CommunityMixin, CreateView):
             community__in=form.cleaned_data.get("communities"),
         ).first()
         # TODO: Remove reliance on instance.get_absolute_url()
+        # Use the host-relative URL so the redirect stays on the host that
+        # served the upload form (e.g. the legacy old. site) instead of
+        # jumping to the listing's main_site (the new app) host.
         redirect_url = (
-            listing.get_full_url() if listing else instance.get_absolute_url()
+            listing.get_absolute_url() if listing else instance.get_absolute_url()
         )
         return redirect(redirect_url)

--- a/django/thunderstore/repository/views/package/tests/test_list.py
+++ b/django/thunderstore/repository/views/package/tests/test_list.py
@@ -40,7 +40,7 @@ def test_package_review_list_view(
 
     response = client.get(url, HTTP_HOST=community_site.site.domain)
     assert response.status_code == 200
-    assert active_package_listing.get_full_url().encode("utf-8") in response.content
+    assert active_package_listing.get_absolute_url().encode("utf-8") in response.content
 
 
 @pytest.mark.django_db
@@ -62,16 +62,16 @@ def test_package_list_search_logic(
     )
 
     resp = client.get(f"{url}?q= ", HTTP_HOST=host)
-    assert listing.get_full_url().encode("utf-8") in resp.content
+    assert listing.get_absolute_url().encode("utf-8") in resp.content
 
     resp = client.get(f"{url}?q=fish", HTTP_HOST=host)
-    assert listing.get_full_url().encode("utf-8") in resp.content
+    assert listing.get_absolute_url().encode("utf-8") in resp.content
 
     resp = client.get(f"{url}?q=fish birds", HTTP_HOST=host)
-    assert listing.get_full_url().encode("utf-8") in resp.content
+    assert listing.get_absolute_url().encode("utf-8") in resp.content
 
     resp = client.get(f"{url}?q=fish cats", HTTP_HOST=host)
-    assert listing.get_full_url().encode("utf-8") not in resp.content
+    assert listing.get_absolute_url().encode("utf-8") not in resp.content
 
 
 @pytest.mark.django_db
@@ -137,14 +137,14 @@ def test_package_list_category_filtering(
     )
     assert resp.status_code == 200
     # Package has one of the included categories, search uses OR logic for categories
-    assert active_package_listing.get_full_url().encode("utf-8") in resp.content
+    assert active_package_listing.get_absolute_url().encode("utf-8") in resp.content
 
     resp = client.get(
         f"{url}?excluded_categories={cat1.pk}", HTTP_HOST=community_site.site.domain
     )
     assert resp.status_code == 200
     # Package has one of the excluded categories, search uses OR logic for categories
-    assert active_package_listing.get_full_url().encode("utf-8") not in resp.content
+    assert active_package_listing.get_absolute_url().encode("utf-8") not in resp.content
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
As we move to use the old. subdomain in the near future with the Django
frontend; the links need to be generated on the same host and not on the
PRIMARY_HOST. This ensures links in old. subdomain link to old.
subdomain urls and not outside of the subdomain.