### PR TITLE
Chunked package listing index optimization

### DIFF
--- a/django/thunderstore/repository/api/v1/tests/test_caches.py
+++ b/django/thunderstore/repository/api/v1/tests/test_caches.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pytest
 
+from thunderstore.community.consts import PackageListingReviewStatus
 from thunderstore.community.factories import (
     CommunityFactory,
     CommunitySiteFactory,
@@ -18,11 +19,15 @@ from thunderstore.repository.api.v1.tasks import (
     update_api_v1_chunked_package_caches,
 )
 from thunderstore.repository.api.v1.viewsets import _get_prefetched_listing_queryset
-from thunderstore.repository.factories import PackageVersionFactory
+from thunderstore.repository.factories import (
+    PackageRatingFactory,
+    PackageVersionFactory,
+)
 from thunderstore.repository.models import APIV1ChunkedPackageCache, APIV1PackageCache
 from thunderstore.repository.models.cache import (
     _get_sorted_active_versions,
     get_package_listing_chunk,
+    get_package_listing_ids,
 )
 
 
@@ -232,6 +237,70 @@ def test_get_package_listing_chunk__retains_received_ordering(count: int) -> Non
 
     for i, listing in enumerate(listings):
         assert listing.id == ordering[i]
+
+
+@pytest.mark.django_db
+def test_get_package_listing_chunk__rating_score_zero_when_no_ratings() -> None:
+    listing = PackageListingFactory()
+
+    result = get_package_listing_chunk([listing.id])
+
+    assert len(result) == 1
+    assert result[0]._rating_score == 0
+
+
+@pytest.mark.django_db
+def test_get_package_listing_chunk__annotates_rating_score() -> None:
+    listing = PackageListingFactory()
+    PackageRatingFactory(package=listing.package)
+    PackageRatingFactory(package=listing.package)
+
+    result = get_package_listing_chunk([listing.id])
+
+    assert len(result) == 1
+    assert result[0]._rating_score == 2
+
+
+@pytest.mark.django_db
+def test_get_package_listing_chunk__excludes_inactive_versions() -> None:
+    listing = PackageListingFactory()
+    package = listing.package
+    package.versions.all().delete()
+
+    PackageVersionFactory(package=package, version_number="1.0.0", is_active=True)
+    PackageVersionFactory(package=package, version_number="2.0.0", is_active=False)
+
+    result = get_package_listing_chunk([listing.id])
+
+    versions = list(result[0].package.versions.all())
+    assert len(versions) == 1
+    assert versions[0].version_number == "1.0.0"
+
+
+@pytest.mark.django_db
+def test_get_package_listing_ids__returns_ids_for_community() -> None:
+    community_a = CommunityFactory()
+    community_b = CommunityFactory()
+    listing_a = PackageListingFactory(community_=community_a)
+    PackageListingFactory(community_=community_b)
+
+    result = list(get_package_listing_ids(community_a))
+    ids = [id_ for chunk in result for id_ in chunk]
+
+    assert ids == [listing_a.id]
+
+
+@pytest.mark.django_db
+def test_get_package_listing_ids__does_not_return_ids_for_rejected_packages() -> None:
+    community = CommunityFactory()
+    PackageListingFactory(
+        community_=community, review_status=PackageListingReviewStatus.rejected
+    )
+
+    result = list(get_package_listing_ids(community))
+    ids = [id_ for chunk in result for id_ in chunk]
+
+    assert ids == []
 
 
 @pytest.mark.django_db

--- a/django/thunderstore/repository/models/cache.py
+++ b/django/thunderstore/repository/models/cache.py
@@ -246,9 +246,13 @@ def get_package_listing_ids(community: Community) -> Iterable[List[int]]:
     Iterate over the PackageListing in chunks to limit the amount of
     data Django keeps in memory concurrently.
     """
-    listing_ids = order_package_listing_queryset(
-        get_package_listing_base_queryset(community.identifier)
-    ).values_list("id", flat=True)
+    listing_ids = (
+        order_package_listing_queryset(
+            get_package_listing_base_queryset(community.identifier)
+        )
+        .values_list("id", flat=True)
+        .iterator(chunk_size=1000)
+    )
 
     yield from batch(1000, listing_ids)
 

--- a/django/thunderstore/repository/models/cache.py
+++ b/django/thunderstore/repository/models/cache.py
@@ -7,7 +7,8 @@ from typing import TYPE_CHECKING, Any, Iterable, List, Optional
 
 from django.core.files.base import ContentFile
 from django.db import models
-from django.db.models import Count, Prefetch
+from django.db.models import Count, OuterRef, Prefetch, Subquery
+from django.db.models.functions import Coalesce
 from django.utils import timezone
 
 from thunderstore.community.models import Community, PackageListing
@@ -255,7 +256,15 @@ def get_package_listing_ids(community: Community) -> Iterable[List[int]]:
 def get_package_listing_chunk(
     listing_ids: List[int],
 ) -> List[PackageListing]:
-    from thunderstore.repository.models import PackageVersion
+    from thunderstore.repository.models import PackageRating, PackageVersion
+
+    # Use an isolated subquery for ratings to prevent massive joins
+    ratings_subquery = Subquery(
+        PackageRating.objects.filter(package_id=OuterRef("package_id"))
+        .values("package_id")
+        .annotate(count=Count("id"))
+        .values("count")
+    )
 
     versions_prefetch = Prefetch(
         "package__versions",
@@ -276,7 +285,7 @@ def get_package_listing_chunk(
             "community__sites__site",
             versions_prefetch,
         )
-        .annotate(_rating_score=Count("package__package_ratings"))
+        .annotate(_rating_score=Coalesce(ratings_subquery, 0))
     )
 
     order_map = {lid: pos for pos, lid in enumerate(listing_ids)}


### PR DESCRIPTION
These should hopefully get our chunked package list sped up enough to make the cache periodic task run more often, as well as making the package-listing-index more reliable in general.