### PR TITLE
Make public Cyberstorm API reads CDN-cacheable; never-cache sensitive endpoints

### DIFF
--- a/django/thunderstore/api/cyberstorm/views/team.py
+++ b/django/thunderstore/api/cyberstorm/views/team.py
@@ -31,6 +31,7 @@ from thunderstore.api.cyberstorm.services.team import (
 from thunderstore.api.ordering import StrictOrderingFilter
 from thunderstore.api.utils import (
     CyberstormAutoSchemaMixin,
+    NeverCacheMixin,
     PublicCacheMixin,
     conditional_swagger_auto_schema,
 )
@@ -174,7 +175,9 @@ class DisbandTeamAPIView(APIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-class CreateServiceAccountAPIView(APIView):
+class CreateServiceAccountAPIView(NeverCacheMixin, APIView):
+    # Response includes a freshly minted service-account API token, so it must
+    # never be stored by any cache (TS QA caching notes).
     permission_classes = [IsAuthenticated]
 
     @conditional_swagger_auto_schema(

--- a/django/thunderstore/api/tests/test_utils.py
+++ b/django/thunderstore/api/tests/test_utils.py
@@ -1,0 +1,72 @@
+from django.http import HttpResponse
+
+from thunderstore.api.utils import NeverCacheMixin, PublicCacheMixin
+
+
+def parse_cache_control(response):
+    """Parse a response's Cache-Control header into a {directive: value|True} dict."""
+    raw = response.get("Cache-Control", "")
+    directives = {}
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "=" in part:
+            key, value = part.split("=", 1)
+            directives[key.strip().lower()] = value.strip()
+        else:
+            directives[part.lower()] = True
+    return directives
+
+
+class _Base:
+    """Minimal stand-in for a DRF view base that just returns the response."""
+
+    def finalize_response(self, request, response, *args, **kwargs):
+        return response
+
+
+class _PublicView(PublicCacheMixin, _Base):
+    pass
+
+
+class _NeverCacheView(NeverCacheMixin, _Base):
+    pass
+
+
+def test_public_cache_mixin_emits_shared_cache_directives():
+    response = _PublicView().finalize_response(None, HttpResponse(status=200))
+    directives = parse_cache_control(response)
+
+    # Browser-cacheable AND shared/CDN-cacheable (s-maxage), with a SWR window.
+    assert directives.get("public") is True
+    assert directives.get("max-age") == "60"
+    assert directives.get("s-maxage") == "300"
+    assert directives.get("stale-while-revalidate") == "600"
+
+
+def test_public_cache_mixin_does_not_cache_error_responses():
+    response = _PublicView().finalize_response(None, HttpResponse(status=500))
+    assert response.get("Cache-Control", "") == ""
+
+
+def test_public_cache_mixin_can_stay_browser_only():
+    view = _PublicView()
+    view.cache_shared_max_age = None
+    view.cache_stale_while_revalidate = None
+
+    response = view.finalize_response(None, HttpResponse(status=200))
+    directives = parse_cache_control(response)
+
+    assert directives.get("public") is True
+    assert directives.get("max-age") == "60"
+    assert "s-maxage" not in directives
+    assert "stale-while-revalidate" not in directives
+
+
+def test_never_cache_mixin_forbids_storing_the_response():
+    response = _NeverCacheView().finalize_response(None, HttpResponse(status=200))
+    directives = parse_cache_control(response)
+
+    assert "no-store" in directives
+    assert "private" in directives

--- a/django/thunderstore/api/utils.py
+++ b/django/thunderstore/api/utils.py
@@ -34,17 +34,29 @@ class PublicCacheMixin:
     Example:
         class ProductListView(PublicCacheMixin, ListAPIView):
 
-    1. Caching: Applies 'public' Cache-Control headers to the response.
+    1. Caching: Applies 'public' Cache-Control headers to the response. The
+       response is cacheable by both browsers (max-age) and shared/CDN caches
+       (s-maxage), with a stale-while-revalidate window so the CDN can serve
+       slightly-stale data while it refreshes in the background. These mirror the
+       cyberstorm-remix page caching defaults so the API and the pages it backs
+       cache consistently.
     2. Security: Explicitly clears 'authentication_classes' and 'permission_classes'
        to override global DRF settings in settings.py. This ensures the endpoint is strictly
        anonymous and prevents 'request.user' from being populated, which
-       mitigates the risk of caching user-specific data.
+       mitigates the risk of caching user-specific data — and, in turn, makes the
+       shared/CDN (s-maxage) caching below safe (no per-user output to cross-serve).
     """
 
     authentication_classes = []
     permission_classes = []
 
-    cache_max_age = 60  # seconds
+    cache_max_age = 60  # browser max-age, seconds
+    # Shared/CDN freshness lifetime (s-maxage). Set to None to keep a response
+    # browser-only (no shared caching).
+    cache_shared_max_age = 300  # seconds
+    # How long a shared cache may serve stale content while revalidating. Set to
+    # None to omit the directive.
+    cache_stale_while_revalidate = 600  # seconds
     cache_404s = False
 
     def finalize_response(self, request, response, *args, **kwargs):
@@ -53,5 +65,33 @@ class PublicCacheMixin:
         if response.status_code == 200 or (
             response.status_code == 404 and self.cache_404s
         ):
-            patch_cache_control(response, public=True, max_age=self.cache_max_age)
+            directives = {"public": True, "max_age": self.cache_max_age}
+            if self.cache_shared_max_age is not None:
+                directives["s_maxage"] = self.cache_shared_max_age
+            if self.cache_stale_while_revalidate is not None:
+                directives["stale_while_revalidate"] = self.cache_stale_while_revalidate
+            patch_cache_control(response, **directives)
+        return response
+
+
+class NeverCacheMixin:
+    """
+    A mixin for endpoints whose responses must never be stored by any cache —
+    browser, shared or CDN. Use it for responses that contain secrets/tokens
+    (e.g. a freshly minted service-account API token) or that are otherwise
+    user-specific or non-idempotent.
+
+    Sets ``Cache-Control: private, no-store``. POST endpoints are already not
+    stored by well-behaved shared caches, but making the intent explicit guards
+    against intermediary caches and future changes to the view (e.g. adding a
+    GET) — see TS QA caching notes.
+
+    Unlike PublicCacheMixin this does NOT touch authentication/permission
+    classes; the endpoint keeps its own. Place before the DRF view base classes
+    in the inheritance list.
+    """
+
+    def finalize_response(self, request, response, *args, **kwargs):
+        response = super().finalize_response(request, response, *args, **kwargs)
+        patch_cache_control(response, no_store=True, private=True)
         return response

--- a/django/thunderstore/frontend/api/experimental/views/markdown.py
+++ b/django/thunderstore/frontend/api/experimental/views/markdown.py
@@ -3,6 +3,7 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from thunderstore.api.utils import NeverCacheMixin
 from thunderstore.frontend.api.experimental.serializers.markdown import (
     RenderMarkdownParamsSerializer,
     RenderMarkdownResponseSerializer,
@@ -10,7 +11,7 @@ from thunderstore.frontend.api.experimental.serializers.markdown import (
 from thunderstore.markdown.templatetags.markdownify import render_markdown
 
 
-class RenderMarkdownApiView(APIView):
+class RenderMarkdownApiView(NeverCacheMixin, APIView):
     serializer_class = RenderMarkdownResponseSerializer
     permission_classes = []
 

--- a/django/thunderstore/repository/api/experimental/views/validators.py
+++ b/django/thunderstore/repository/api/experimental/views/validators.py
@@ -3,6 +3,7 @@ from rest_framework import permissions
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from thunderstore.api.utils import NeverCacheMixin
 from thunderstore.repository.api.experimental.serializers.validators import (
     IconValidatorParamsSerializer,
     ManifestV1ValidatorParamsSerializer,
@@ -15,7 +16,7 @@ from thunderstore.repository.validation.manifest import validate_manifest
 from thunderstore.repository.validation.markdown import validate_markdown
 
 
-class ReadmeValidatorApiView(APIView):
+class ReadmeValidatorApiView(NeverCacheMixin, APIView):
     """
     Validates a package readme.
     """
@@ -44,7 +45,7 @@ class ReadmeValidatorApiView(APIView):
         )
 
 
-class ManifestV1ValidatorApiView(APIView):
+class ManifestV1ValidatorApiView(NeverCacheMixin, APIView):
     """
     Validates a package manifest.
     """
@@ -78,7 +79,7 @@ class ManifestV1ValidatorApiView(APIView):
         )
 
 
-class IconValidatorApiView(APIView):
+class IconValidatorApiView(NeverCacheMixin, APIView):
     """
     Validates a package icon.
     """


### PR DESCRIPTION
From the Nimbus QA caching pass.

Public read endpoints (via PublicCacheMixin) previously emitted only
`public, max-age=60` — browser-only, no `s-maxage` — so shared/CDN caches never
stored them. Add `s-maxage=300` and `stale-while-revalidate=600` (mirroring the
cyberstorm-remix page caching defaults) so the CDN can serve and revalidate
them. This is safe because the mixin already clears authentication/permission
classes (strictly anonymous, so there is no per-user output to cross-serve). It
covers every PublicCacheMixin endpoint at once: community detail/list/filters,
team detail, package listings + dependants, version dependencies, readme,
changelog, and versions. The shared/SWR durations are class attributes, so a
view can opt back to browser-only by setting them to None.

Add a NeverCacheMixin (`private, no-store`) for responses that must never be
stored by any cache, and apply it to the endpoints flagged in QA:
- service-account create — returns a freshly minted API token;
- the submission validators (manifest-v1, readme, icon);
- the frontend render-markdown endpoint.
These are POST-only and already showed DYNAMIC at the edge, but relying on HTTP
method is implicit and fragile; making "never cache" explicit guards against
intermediary caches and future changes to the view (e.g. adding a GET).

Add unit tests for both mixins (asserting the emitted Cache-Control directives).