### PR TITLE
Fix Cyberstorm datetime_created

### DIFF
--- a/django/thunderstore/api/cyberstorm/tests/test_package_listing.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_package_listing.py
@@ -319,7 +319,6 @@ def test_package_listing_view__returns_info(api_client: APIClient) -> None:
     assert actual["categories"][0]["id"] == str(category.id)
     assert actual["community_identifier"] == community.identifier
     assert actual["community_name"] == community.name
-    assert actual["datetime_created"] == _date_to_z(latest.date_created)
     assert actual["dependant_count"] == 1
     assert len(actual["dependencies"]) == 1
     assert actual["dependencies"][0]["community_identifier"] == community.identifier
@@ -335,16 +334,17 @@ def test_package_listing_view__returns_info(api_client: APIClient) -> None:
     assert actual["is_deprecated"] == listing.package.is_deprecated
     assert actual["is_nsfw"] == listing.has_nsfw_content
     assert actual["is_pinned"] == listing.package.is_pinned
-    assert actual["last_updated"] == _date_to_z(listing.package.date_updated)
     assert actual["latest_version_number"] == latest.version_number
     assert actual["name"] == listing.package.name
     assert actual["namespace"] == listing.package.namespace.name
+    assert actual["package_created"] == _date_to_z(listing.package.date_created)
     assert actual["rating_count"] == 8
     assert actual["size"] == latest.file_size
     assert actual["team"]["name"] == listing.package.owner.name
     assert len(actual["team"]["members"]) == 0
     assert actual["website_url"] == latest.website_url
     assert actual["version_count"] == 1
+    assert actual["version_created"] == _date_to_z(latest.date_created)
 
 
 @pytest.mark.django_db

--- a/django/thunderstore/api/cyberstorm/views/package_listing.py
+++ b/django/thunderstore/api/cyberstorm/views/package_listing.py
@@ -90,7 +90,6 @@ class ResponseSerializer(serializers.Serializer):
     categories = CyberstormPackageCategorySerializer(many=True)
     community_identifier = serializers.CharField(source="community.identifier")
     community_name = serializers.CharField(source="community.name")
-    datetime_created = serializers.DateTimeField(source="version.date_created")
     dependant_count = serializers.IntegerField(min_value=0)
     dependencies = DependencySerializer(many=True)
     dependency_count = serializers.IntegerField(min_value=0)
@@ -104,16 +103,17 @@ class ResponseSerializer(serializers.Serializer):
     is_deprecated = serializers.BooleanField(source="package.is_deprecated")
     is_nsfw = serializers.BooleanField(source="has_nsfw_content")
     is_pinned = serializers.BooleanField(source="package.is_pinned")
-    last_updated = serializers.DateTimeField(source="package.date_updated")
     latest_version_number = serializers.CharField(
         source="package.latest.version_number",
     )
     name = serializers.CharField(source="package.name")
     namespace = serializers.CharField(source="package.namespace.name")
+    package_created = serializers.DateTimeField(source="package.date_created")
     rating_count = serializers.IntegerField(min_value=0)
     size = serializers.IntegerField(min_value=0, source="version.file_size")
     team = CyberstormPackageTeamSerializer(source="package.owner")
     version_count = serializers.IntegerField()
+    version_created = serializers.DateTimeField(source="version.date_created")
     website_url = EmptyStringAsNoneField(source="version.website_url")
 
 


### PR DESCRIPTION
Fix Cyberstorm datetime_created which was accidentally using the latest version's datetime_created