### PR TITLE
TS-3938: Filter package listings by category/section slug, not id/uuid

### DIFF
--- a/django/thunderstore/api/cyberstorm/tests/test_moderation.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_moderation.py
@@ -1,0 +1,146 @@
+import json
+
+import pytest
+from rest_framework.test import APIClient
+
+from conftest import TestUserTypes
+from thunderstore.community.consts import PackageListingReviewStatus
+from thunderstore.community.models import PackageListing
+
+QUEUE_URL = "/api/cyberstorm/moderation/review-queue/packages/"
+BULK_URL = "/api/cyberstorm/moderation/review-queue/packages/bulk-action/"
+
+
+@pytest.mark.django_db
+def test_review_queue_requires_authentication(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+):
+    active_package_listing.request_review()
+    response = api_client.get(QUEUE_URL)
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db
+def test_review_queue_forbidden_for_non_moderator(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+):
+    active_package_listing.request_review()
+    user = TestUserTypes.get_user_by_type(TestUserTypes.regular_user)
+    api_client.force_authenticate(user=user)
+
+    response = api_client.get(QUEUE_URL)
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_review_queue_lists_requested_packages_for_moderator(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+):
+    active_package_listing.review_status = PackageListingReviewStatus.rejected
+    active_package_listing.save()
+    active_package_listing.request_review()
+
+    user = TestUserTypes.get_user_by_type(TestUserTypes.superuser)
+    api_client.force_authenticate(user=user)
+
+    response = api_client.get(QUEUE_URL)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["count"] == 1
+    item = body["results"][0]
+    # Surfaces a rejected listing (hidden by the public endpoints).
+    assert item["name"] == active_package_listing.package.name
+    assert item["review_status"] == "rejected"
+    assert item["is_review_requested"] is True
+
+
+@pytest.mark.django_db
+def test_review_queue_excludes_non_requested(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+):
+    user = TestUserTypes.get_user_by_type(TestUserTypes.superuser)
+    api_client.force_authenticate(user=user)
+
+    response = api_client.get(QUEUE_URL)
+    assert response.status_code == 200
+    assert response.json()["count"] == 0
+
+
+@pytest.mark.django_db
+def test_review_queue_bulk_approve(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+):
+    active_package_listing.request_review()
+    user = TestUserTypes.get_user_by_type(TestUserTypes.superuser)
+    api_client.force_authenticate(user=user)
+
+    response = api_client.post(
+        BULK_URL,
+        data=json.dumps(
+            {
+                "package_listing_ids": [active_package_listing.pk],
+                "status": "approved",
+            }
+        ),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200, response.json()
+    assert response.json()["updated"] == 1
+    active_package_listing.refresh_from_db()
+    assert active_package_listing.review_status == PackageListingReviewStatus.approved
+    assert active_package_listing.is_review_requested is False
+
+
+@pytest.mark.django_db
+def test_review_queue_bulk_request_review(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+):
+    user = TestUserTypes.get_user_by_type(TestUserTypes.superuser)
+    api_client.force_authenticate(user=user)
+
+    response = api_client.post(
+        BULK_URL,
+        data=json.dumps(
+            {
+                "package_listing_ids": [active_package_listing.pk],
+                "status": "review-queue",
+            }
+        ),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200, response.json()
+    active_package_listing.refresh_from_db()
+    assert active_package_listing.is_review_requested is True
+
+
+@pytest.mark.django_db
+def test_review_queue_bulk_action_forbidden_for_non_moderator(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+):
+    active_package_listing.request_review()
+    user = TestUserTypes.get_user_by_type(TestUserTypes.regular_user)
+    api_client.force_authenticate(user=user)
+
+    response = api_client.post(
+        BULK_URL,
+        data=json.dumps(
+            {
+                "package_listing_ids": [active_package_listing.pk],
+                "status": "approved",
+            }
+        ),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 403
+    active_package_listing.refresh_from_db()
+    assert active_package_listing.review_status != PackageListingReviewStatus.approved

--- a/django/thunderstore/api/cyberstorm/tests/test_package_listing_actions.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_package_listing_actions.py
@@ -7,6 +7,7 @@ from rest_framework.test import APIClient
 
 from conftest import TestUserTypes, UserType
 from thunderstore.community.models import PackageCategory, PackageListing
+from thunderstore.ts_reports.models import PackageReport
 
 PACKAGE_LISTING_ACTIONS = ["update", "approve", "reject", "report", "unlist"]
 
@@ -243,6 +244,48 @@ def test_report_package_listing_required_fields(
 
     assert response.status_code == 400
     assert response.json() == {"reason": ["This field is required."]}
+
+
+@pytest.mark.django_db
+def test_report_package_listing_records_version(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+):
+    user = TestUserTypes.get_user_by_type(TestUserTypes.site_admin)
+    api_client.force_authenticate(user=user)
+    version = active_package_listing.package.latest
+
+    url = get_report_url(active_package_listing)
+    response = api_client.post(
+        url,
+        data=json.dumps({"reason": "Spam", "version": version.version_number}),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200, response.json()
+    report = PackageReport.objects.filter(
+        package=active_package_listing.package
+    ).first()
+    assert report is not None
+    assert report.package_version == version
+
+
+@pytest.mark.django_db
+def test_report_package_listing_rejects_unknown_version(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+):
+    user = TestUserTypes.get_user_by_type(TestUserTypes.site_admin)
+    api_client.force_authenticate(user=user)
+
+    url = get_report_url(active_package_listing)
+    response = api_client.post(
+        url,
+        data=json.dumps({"reason": "Spam", "version": "9.9.9-does-not-exist"}),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 400
 
 
 @pytest.mark.django_db

--- a/django/thunderstore/api/cyberstorm/tests/test_package_listing_list.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_package_listing_list.py
@@ -163,7 +163,7 @@ def test_base_view__when_including_category__filters_out_not_matched(
     PackageListingFactory(community_=community, categories=[])
     included = PackageListingFactory(community_=community, categories=[cat])
 
-    request = APIRequestFactory().get("/", {"included_categories": [str(cat.id)]})
+    request = APIRequestFactory().get("/", {"included_categories": [cat.slug]})
     response = BasePackageListAPIView().dispatch(
         request,
         community_id=community.identifier,
@@ -182,7 +182,7 @@ def test_base_view__when_excluding_category__filters_out_matched(
     included = PackageListingFactory(community_=community, categories=[])
     PackageListingFactory(community_=community, categories=[cat])
 
-    request = APIRequestFactory().get("/", {"excluded_categories": [str(cat.id)]})
+    request = APIRequestFactory().get("/", {"excluded_categories": [cat.slug]})
     response = BasePackageListAPIView().dispatch(
         request,
         community_id=community.identifier,
@@ -212,7 +212,7 @@ def test_base_view__when_requesting_section__filters_based_on_categories(
     PackageListingFactory(community_=community, categories=[excluded])
     PackageListingFactory(community_=community, categories=[irrelevant])
 
-    request = APIRequestFactory().get("/", {"section": section.uuid})
+    request = APIRequestFactory().get("/", {"section": section.slug})
     response = BasePackageListAPIView().dispatch(
         request,
         community_id=community.identifier,
@@ -229,7 +229,7 @@ def test_base_view__when_requesting_nonexisting_section__does_nothing() -> None:
 
     request = APIRequestFactory().get(
         "/",
-        {"section": "decade00-0000-4000-a000-000000000000"},
+        {"section": "nonexistent-section-slug"},
     )
     response = BasePackageListAPIView().dispatch(
         request,
@@ -539,7 +539,7 @@ def test_base_view__when_multiple_pages_of_results__page_urls_retain_paramaters(
         "/",
         data={
             "deprecated": True,
-            "included_categories": [str(cat.id)],
+            "included_categories": [cat.slug],
             "ordering": "most-downloaded",
             "page": 2,
             "q": "test",
@@ -551,10 +551,10 @@ def test_base_view__when_multiple_pages_of_results__page_urls_retain_paramaters(
     )
 
     assert response.data["previous"].endswith(
-        f"?deprecated=True&included_categories={cat.id}&nsfw=False&ordering=most-downloaded&page=1&q=test",
+        f"?deprecated=True&included_categories={cat.slug}&nsfw=False&ordering=most-downloaded&page=1&q=test",
     )
     assert response.data["next"].endswith(
-        f"?deprecated=True&included_categories={cat.id}&nsfw=False&ordering=most-downloaded&page=3&q=test",
+        f"?deprecated=True&included_categories={cat.slug}&nsfw=False&ordering=most-downloaded&page=3&q=test",
     )
 
 

--- a/django/thunderstore/api/cyberstorm/views/__init__.py
+++ b/django/thunderstore/api/cyberstorm/views/__init__.py
@@ -2,6 +2,10 @@ from .community import CommunityAPIView
 from .community_filters import CommunityFiltersAPIView
 from .community_list import CommunityListAPIView
 from .markdown import PackageVersionChangelogAPIView, PackageVersionReadmeAPIView
+from .moderation import (
+    ModerationReviewQueueBulkActionAPIView,
+    ModerationReviewQueuePackagesAPIView,
+)
 from .package_deprecate import DeprecatePackageAPIView
 from .package_listing import PackageListingAPIView, PackageListingStatusAPIView
 from .package_listing_actions import (
@@ -49,6 +53,8 @@ __all__ = [
     "DisconnectUserLinkedAccountAPIView",
     "DeprecatePackageAPIView",
     "DisbandTeamAPIView",
+    "ModerationReviewQueueBulkActionAPIView",
+    "ModerationReviewQueuePackagesAPIView",
     "PackageListingAPIView",
     "PackageListingStatusAPIView",
     "PackageListingByCommunityListAPIView",

--- a/django/thunderstore/api/cyberstorm/views/moderation.py
+++ b/django/thunderstore/api/cyberstorm/views/moderation.py
@@ -1,0 +1,180 @@
+from django.db.models import Q
+from rest_framework import serializers, status
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.generics import ListAPIView
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from thunderstore.api.cyberstorm.services.package_listing import (
+    approve_package_listing,
+    reject_package_listing,
+)
+from thunderstore.api.utils import conditional_swagger_auto_schema
+from thunderstore.community.consts import PackageListingReviewStatus
+from thunderstore.community.models import PackageListing
+from thunderstore.repository.views.package._utils import get_moderatable_communities
+
+# Extra "status" option for the bulk action that moves listings into the review
+# queue (the is_review_requested flag) rather than setting a review_status.
+REVIEW_QUEUE_STATUS = "review-queue"
+
+
+def get_moderatable_communities_or_403(user):
+    communities = get_moderatable_communities(user)
+    if not communities:
+        raise PermissionDenied(
+            "You don't have moderation permissions in any community."
+        )
+    return communities
+
+
+class ReviewQueuePackageSerializer(serializers.Serializer):
+    id = serializers.IntegerField()  # noqa: A003
+    community_identifier = serializers.CharField(source="community.identifier")
+    community_name = serializers.CharField(source="community.name")
+    namespace = serializers.CharField(source="package.namespace.name")
+    name = serializers.CharField(source="package.name")
+    review_status = serializers.CharField()
+    is_review_requested = serializers.BooleanField()
+    last_updated = serializers.DateTimeField(source="package.date_updated")
+    icon_url = serializers.SerializerMethodField()
+
+    def get_icon_url(self, obj):
+        latest = obj.package.latest
+        return latest.icon.url if latest and latest.icon else None
+
+
+class ReviewQueuePaginator(PageNumberPagination):
+    page_size = 20
+    page_size_query_param = "page_size"
+    max_page_size = 100
+
+
+class ModerationReviewQueuePackagesAPIView(ListAPIView):
+    """
+    Packages that have requested review, across the communities the
+    authenticated user can moderate.
+
+    Unlike the public listing endpoints this deliberately surfaces
+    rejected/unreviewed listings, so the response is never publicly cached.
+    """
+
+    permission_classes = [IsAuthenticated]
+    serializer_class = ReviewQueuePackageSerializer
+    pagination_class = ReviewQueuePaginator
+
+    def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return PackageListing.objects.none()
+
+        communities = get_moderatable_communities_or_403(self.request.user)
+        qs = (
+            PackageListing.objects.active()
+            .filter(is_review_requested=True, community_id__in=communities)
+            .select_related(
+                "community",
+                "package",
+                "package__namespace",
+                "package__latest",
+            )
+            .order_by("-datetime_created")
+        )
+
+        query = self.request.query_params.get("q")
+        if query:
+            qs = qs.filter(
+                Q(package__name__icontains=query)
+                | Q(package__namespace__name__icontains=query)
+            )
+
+        return qs
+
+    def finalize_response(self, request, response, *args, **kwargs):
+        response = super().finalize_response(request, response, *args, **kwargs)
+        response["Cache-Control"] = "no-store, private"
+        return response
+
+
+class ReviewQueueBulkActionSerializer(serializers.Serializer):
+    package_listing_ids = serializers.ListField(
+        child=serializers.IntegerField(),
+        allow_empty=False,
+    )
+    status = serializers.ChoiceField(  # noqa: A003
+        choices=[
+            PackageListingReviewStatus.unreviewed,
+            PackageListingReviewStatus.approved,
+            PackageListingReviewStatus.rejected,
+            REVIEW_QUEUE_STATUS,
+        ],
+    )
+    rejection_reason = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        default="",
+    )
+    internal_notes = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+    )
+
+
+class ModerationReviewQueueBulkActionAPIView(APIView):
+    """
+    Apply a review status (or move into the review queue) to several listings
+    at once. Only listings in communities the user can moderate are touched.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    @conditional_swagger_auto_schema(
+        operation_id="cyberstorm.moderation.review_queue.bulk_action",
+        request_body=ReviewQueueBulkActionSerializer,
+        responses={200: "Success"},
+        tags=["cyberstorm"],
+    )
+    def post(self, request, *args, **kwargs) -> Response:
+        communities = get_moderatable_communities_or_403(request.user)
+
+        serializer = ReviewQueueBulkActionSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        listings = PackageListing.objects.active().filter(
+            pk__in=data["package_listing_ids"],
+            community_id__in=communities,
+        )
+
+        updated = 0
+        for listing in listings:
+            self._apply_status(request.user, listing, data)
+            updated += 1
+
+        return Response({"updated": updated}, status=status.HTTP_200_OK)
+
+    def _apply_status(self, user, listing, data) -> None:
+        new_status = data["status"]
+
+        if new_status == PackageListingReviewStatus.approved:
+            approve_package_listing(
+                agent=user,
+                notes=data.get("internal_notes"),
+                listing=listing,
+            )
+        elif new_status == PackageListingReviewStatus.rejected:
+            reject_package_listing(
+                agent=user,
+                reason=data.get("rejection_reason") or "",
+                notes=data.get("internal_notes"),
+                listing=listing,
+            )
+        elif new_status == PackageListingReviewStatus.unreviewed:
+            listing.community.ensure_user_can_moderate_packages(user)
+            listing.review_status = PackageListingReviewStatus.unreviewed
+            listing.save(update_fields=("review_status",))
+        elif new_status == REVIEW_QUEUE_STATUS:
+            listing.community.ensure_user_can_moderate_packages(user)
+            listing.request_review()

--- a/django/thunderstore/api/cyberstorm/views/package_listing_actions.py
+++ b/django/thunderstore/api/cyberstorm/views/package_listing_actions.py
@@ -146,7 +146,10 @@ class ReportPackageListingAPIView(APIView):
             community_id=kwargs["community_id"],
         )
 
-        request_serializer = PackageListingReportRequestSerializer(data=request.data)
+        request_serializer = PackageListingReportRequestSerializer(
+            data=request.data,
+            context={"package": listing.package},
+        )
         request_serializer.is_valid(raise_exception=True)
 
         report_package_listing(

--- a/django/thunderstore/api/cyberstorm/views/package_listing_list.py
+++ b/django/thunderstore/api/cyberstorm/views/package_listing_list.py
@@ -51,7 +51,9 @@ class PackageListRequestSerializer(serializers.Serializer):
     )
     page = serializers.IntegerField(default=1, min_value=1)
     q = serializers.CharField(required=False, help_text="Free text search")
-    section = serializers.UUIDField(required=False)
+    section = serializers.CharField(
+        required=False, help_text="PackageListingSection slug"
+    )
 
 
 class PackageListResponseSerializer(serializers.Serializer):
@@ -151,7 +153,7 @@ class BasePackageListAPIView(PublicCacheMixin, ListAPIView):
         qs = filter_nsfw(params["nsfw"], qs)
         qs = filter_in_categories(params["included_categories"], qs)
         qs = filter_not_in_categories(params["excluded_categories"], qs)
-        qs = filter_by_section(params.get("section"), qs)
+        qs = filter_by_section(params.get("section"), qs, community)
         qs = filter_by_query(params.get("q"), qs)
 
         return qs.order_by(
@@ -390,59 +392,67 @@ def filter_nsfw(
 
 
 def filter_in_categories(
-    category_ids: List[str],
+    category_slugs: List[str],
     queryset: QuerySet[PackageListing],
 ) -> QuerySet[PackageListing]:
     """
     Include only packages belonging to specific categories.
 
-    Multiple categories are OR-joined, i.e. if category_ids contain A
+    Multiple categories are OR-joined, i.e. if category_slugs contain A
     and B, packages belonging to either will be returned.
     """
-    if not category_ids:
+    if not category_slugs:
         return queryset
 
-    return queryset.exclude(~Q(categories__id__in=category_ids))
+    return queryset.exclude(~Q(categories__slug__in=category_slugs))
 
 
 def filter_not_in_categories(
-    category_ids: List[str],
+    category_slugs: List[str],
     queryset: QuerySet[PackageListing],
 ) -> QuerySet[PackageListing]:
     """
     Exclude packages belonging to specific categories.
 
-    Multiple categories are OR-joined, i.e. if category_ids contain A
+    Multiple categories are OR-joined, i.e. if category_slugs contain A
     and B, packages belonging to either will be rejected.
     """
-    if not category_ids:
+    if not category_slugs:
         return queryset
 
-    return queryset.exclude(categories__id__in=category_ids)
+    return queryset.exclude(categories__slug__in=category_slugs)
 
 
 def filter_by_section(
-    section_uuid: Optional[str],
+    section_slug: Optional[str],
     queryset: QuerySet[PackageListing],
+    community: Optional[Community] = None,
 ) -> QuerySet[PackageListing]:
     """
     PackageListingSections can be used as shortcut for multiple
     category filters.
+
+    Section slugs are unique per community, so the lookup is scoped to the
+    given community to avoid cross-community slug collisions.
     """
-    if not section_uuid:
+    if not section_slug:
         return queryset
 
+    section_qs = PackageListingSection.objects.prefetch_related(
+        "require_categories",
+        "exclude_categories",
+    )
+    if community is not None:
+        section_qs = section_qs.filter(community=community)
+
     try:
-        section = PackageListingSection.objects.prefetch_related(
-            "require_categories",
-            "exclude_categories",
-        ).get(uuid=section_uuid)
+        section = section_qs.get(slug=section_slug)
     except PackageListingSection.DoesNotExist:
         required = []
         excluded = []
     else:
-        required = section.require_categories.values_list("pk", flat=True)
-        excluded = section.exclude_categories.values_list("pk", flat=True)
+        required = section.require_categories.values_list("slug", flat=True)
+        excluded = section.exclude_categories.values_list("slug", flat=True)
 
     queryset = filter_in_categories(required, queryset)
     return filter_not_in_categories(excluded, queryset)

--- a/django/thunderstore/api/urls.py
+++ b/django/thunderstore/api/urls.py
@@ -11,6 +11,8 @@ from thunderstore.api.cyberstorm.views import (
     DeprecatePackageAPIView,
     DisbandTeamAPIView,
     DisconnectUserLinkedAccountAPIView,
+    ModerationReviewQueueBulkActionAPIView,
+    ModerationReviewQueuePackagesAPIView,
     PackageListingAPIView,
     PackageListingByCommunityListAPIView,
     PackageListingByDependencyListAPIView,
@@ -94,6 +96,16 @@ cyberstorm_urls = [
         "listing/<str:community_id>/<str:namespace_id>/<str:package_name>/approve/",
         ApprovePackageListingAPIView.as_view(),
         name="cyberstorm.listing.approve",
+    ),
+    path(
+        "moderation/review-queue/packages/",
+        ModerationReviewQueuePackagesAPIView.as_view(),
+        name="cyberstorm.moderation.review-queue.packages",
+    ),
+    path(
+        "moderation/review-queue/packages/bulk-action/",
+        ModerationReviewQueueBulkActionAPIView.as_view(),
+        name="cyberstorm.moderation.review-queue.bulk-action",
     ),
     path(
         "listing/<str:community_id>/<str:namespace_id>/<str:package_name>/report/",

--- a/django/thunderstore/community/api/experimental/serializers.py
+++ b/django/thunderstore/community/api/experimental/serializers.py
@@ -1,5 +1,4 @@
 from rest_framework import serializers
-from rest_framework.relations import PrimaryKeyRelatedField
 
 from thunderstore.community.models import PackageCategory
 from thunderstore.repository.api.experimental.serializers import (
@@ -34,10 +33,15 @@ class PackageListingUpdateResponseSerializer(serializers.Serializer):
 
 
 class PackageListingReportRequestSerializer(serializers.Serializer):
-    version = PrimaryKeyRelatedField(
+    # The reported version is identified by its SemVer version_number (what the
+    # Cyberstorm API exposes), not a DB primary key. version_number is only
+    # unique per package, so the lookup is scoped to the reported package passed
+    # in via serializer context.
+    version = serializers.SlugRelatedField(
+        slug_field="version_number",
         required=False,
         allow_null=True,
-        queryset=PackageVersion.objects.all(),
+        queryset=PackageVersion.objects.none(),
     )
     reason = serializers.ChoiceField(
         required=True,
@@ -51,3 +55,9 @@ class PackageListingReportRequestSerializer(serializers.Serializer):
         allow_null=True,
         max_length=REPORT_DESCRIPTION_MAX_LENGTH,
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        package = self.context.get("package")
+        if package is not None:
+            self.fields["version"].queryset = package.versions.all()


### PR DESCRIPTION
TS-3938: Filter package listings by category/section slug, not id/uuid

The Cyberstorm package listing API identified section and category filters by
database id (section UUID, category pk). Switch the contract to slugs to match
the frontend: accept `section` as a slug (CharField), look it up scoped to the
community (slugs are unique per community, so the lookup must be scoped to
avoid cross-community collisions), and filter categories by `categories__slug__in`.
Tests updated to pass slugs.

TS-3956: Accept a SemVer version_number on the package report endpoint

The report serializer required a PackageVersion primary key, but the Cyberstorm
API only exposes the SemVer version_number, so the Nimbus report form could
never send a version. Resolve the reported version by version_number instead,
scoped to the reported package via serializer context (version_number is only
unique per package). An unknown version_number now 400s. Adds tests covering a
recorded version and a rejected unknown version.

TS-3946: Add moderation review-queue API + bulk review-status endpoint

Adds an authenticated Cyberstorm API powering the Nimbus review queue:
- GET /api/cyberstorm/moderation/review-queue/packages/ lists packages with
  is_review_requested across the communities the user can moderate. Unlike the
  public listing endpoints it deliberately surfaces rejected/unreviewed
  listings, so it sets Cache-Control: no-store and 403s non-moderators.
- POST .../bulk-action/ applies a review status (approved/rejected/unreviewed)
  or moves listings into the review queue, in bulk, scoped to the moderator's
  communities (reusing the existing approve/reject services).