### PR TITLE
Build the chunked package list cache in Postgres

### DIFF
--- a/django/thunderstore/repository/api/v1/tests/test_caches.py
+++ b/django/thunderstore/repository/api/v1/tests/test_caches.py
@@ -1,7 +1,6 @@
 import gzip
 import json
 from datetime import timedelta
-from random import shuffle
 from typing import Any
 
 import pytest
@@ -24,11 +23,7 @@ from thunderstore.repository.factories import (
     PackageVersionFactory,
 )
 from thunderstore.repository.models import APIV1ChunkedPackageCache, APIV1PackageCache
-from thunderstore.repository.models.cache import (
-    _get_sorted_active_versions,
-    get_package_listing_chunk,
-    get_package_listing_ids,
-)
+from thunderstore.repository.models.cache import get_package_listing_ids
 
 
 @pytest.mark.django_db
@@ -225,56 +220,59 @@ def test_api_v1_chunked_package_cache__drops_stale_caches() -> None:
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("count", (0, 1, 2, 3, 5, 8, 13))
-def test_get_package_listing_chunk__retains_received_ordering(count: int) -> None:
-    assert not PackageListing.objects.exists()
-    for _ in range(count):
-        PackageListingFactory()
-
-    ordering = list(PackageListing.objects.all().values_list("id", flat=True))
-    shuffle(ordering)
-    listings = get_package_listing_chunk(ordering)
-
-    for i, listing in enumerate(listings):
-        assert listing.id == ordering[i]
-
-
-@pytest.mark.django_db
-def test_get_package_listing_chunk__rating_score_zero_when_no_ratings() -> None:
-    listing = PackageListingFactory()
-
-    result = get_package_listing_chunk([listing.id])
-
-    assert len(result) == 1
-    assert result[0]._rating_score == 0
-
-
-@pytest.mark.django_db
-def test_get_package_listing_chunk__annotates_rating_score() -> None:
-    listing = PackageListingFactory()
-    PackageRatingFactory(package=listing.package)
-    PackageRatingFactory(package=listing.package)
-
-    result = get_package_listing_chunk([listing.id])
-
-    assert len(result) == 1
-    assert result[0]._rating_score == 2
-
-
-@pytest.mark.django_db
-def test_get_package_listing_chunk__excludes_inactive_versions() -> None:
-    listing = PackageListingFactory()
+def test_api_v1_chunked_package_cache__json_shape_order_and_values(
+    community: Community,
+) -> None:
+    listing = PackageListingFactory(community_=community)
     package = listing.package
     package.versions.all().delete()
-
     PackageVersionFactory(package=package, version_number="1.0.0", is_active=True)
     PackageVersionFactory(package=package, version_number="2.0.0", is_active=False)
+    v15 = PackageVersionFactory(package=package, version_number="1.5.0", is_active=True)
+    PackageRatingFactory(package=package)
+    PackageRatingFactory(package=package)
+    dep = PackageVersionFactory()
+    v15.dependencies.add(dep)
 
-    result = get_package_listing_chunk([listing.id])
+    update_api_v1_chunked_package_caches()
+    cache = APIV1ChunkedPackageCache.get_latest_for_community(community)
+    chunk = json.loads(gzip.decompress(cache.chunks.entries.first().blob.data.read()))
 
-    versions = list(result[0].package.versions.all())
-    assert len(versions) == 1
-    assert versions[0].version_number == "1.0.0"
+    obj = chunk[0]
+    assert list(obj.keys()) == [
+        "name",
+        "full_name",
+        "owner",
+        "package_url",
+        "donation_link",
+        "date_created",
+        "date_updated",
+        "uuid4",
+        "rating_score",
+        "is_pinned",
+        "is_deprecated",
+        "has_nsfw_content",
+        "categories",
+        "versions",
+    ]
+    assert list(obj["versions"][0].keys()) == [
+        "name",
+        "full_name",
+        "description",
+        "icon",
+        "version_number",
+        "dependencies",
+        "download_url",
+        "downloads",
+        "date_created",
+        "website_url",
+        "is_active",
+        "uuid4",
+        "file_size",
+    ]
+    assert [v["version_number"] for v in obj["versions"]] == ["1.5.0", "1.0.0"]
+    assert obj["rating_score"] == 2
+    assert obj["versions"][0]["dependencies"] == [dep.full_version_name]
 
 
 @pytest.mark.django_db
@@ -301,22 +299,6 @@ def test_get_package_listing_ids__does_not_return_ids_for_rejected_packages() ->
     ids = [id_ for chunk in result for id_ in chunk]
 
     assert ids == []
-
-
-@pytest.mark.django_db
-def test_get_sorted_active_versions__filters_inactive_and_sorts_descending() -> None:
-    listing = PackageListingFactory()
-    package = listing.package
-    package.versions.all().delete()
-
-    PackageVersionFactory(package=package, version_number="1.0.0", is_active=True)
-    PackageVersionFactory(package=package, version_number="2.0.0", is_active=False)
-    PackageVersionFactory(package=package, version_number="0.5.0", is_active=True)
-    PackageVersionFactory(package=package, version_number="1.5.0", is_active=True)
-
-    versions = _get_sorted_active_versions(package)
-
-    assert [v.version_number for v in versions] == ["1.5.0", "1.0.0", "0.5.0"]
 
 
 @pytest.mark.django_db

--- a/django/thunderstore/repository/models/cache.py
+++ b/django/thunderstore/repository/models/cache.py
@@ -2,16 +2,14 @@ import gzip
 import io
 import json
 from datetime import timedelta
-from distutils.version import StrictVersion
-from typing import TYPE_CHECKING, Any, Iterable, List, Optional
+from functools import lru_cache
+from typing import Any, Iterable, List, Optional, Tuple
 
 from django.core.files.base import ContentFile
-from django.db import models
-from django.db.models import Count, OuterRef, Prefetch, Subquery, Value
-from django.db.models.functions import Coalesce, Concat, Lower
+from django.db import connection, models
 from django.utils import timezone
 
-from thunderstore.community.models import Community, PackageListing
+from thunderstore.community.models import Community, PackageListing  # noqa: F401
 from thunderstore.core.mixins import S3FileMixin, SafeDeleteMixin
 from thunderstore.repository.cache import (
     get_package_listing_base_queryset,
@@ -19,9 +17,6 @@ from thunderstore.repository.cache import (
 )
 from thunderstore.storage.models import DataBlob, DataBlobGroup
 from thunderstore.utils.batch import batch
-
-if TYPE_CHECKING:
-    from thunderstore.repository.models import Package, PackageVersion
 
 
 class APIExperimentalPackageIndexCache(S3FileMixin):
@@ -184,10 +179,10 @@ class APIV1ChunkedPackageCache(SafeDeleteMixin):
                 content_encoding="gzip",
             )
 
-        for listing_ids in get_package_listing_ids(community):
-            for listing in get_package_listing_chunk(listing_ids):
-                listing_bytes = listing_to_json(listing)
+        url_templates = _community_url_templates(community)
 
+        for listing_ids in get_package_listing_ids(community):
+            for listing_bytes in serialize_listing_chunk(url_templates, listing_ids):
                 # Always add the first listing regardless of the size limit.
                 if not chunk_content:
                     chunk_content.extend(listing_bytes)
@@ -257,109 +252,194 @@ def get_package_listing_ids(community: Community) -> Iterable[List[int]]:
     yield from batch(1000, listing_ids)
 
 
-def get_package_listing_chunk(
-    listing_ids: List[int],
-) -> List[PackageListing]:
-    from thunderstore.repository.models import PackageRating, PackageVersion
-
-    # Use an isolated subquery for ratings to prevent massive joins
-    ratings_subquery = Subquery(
-        PackageRating.objects.filter(package_id=OuterRef("package_id"))
-        .values("package_id")
-        .annotate(count=Count("id"))
-        .values("count")
-    )
-
-    dependencies_prefetch = Prefetch(
-        "dependencies",
-        queryset=PackageVersion.objects.annotate(
-            _full_version_name=Concat(
-                "package__owner__name",
-                Value("-"),
-                "package__name",
-                Value("-"),
-                "version_number",
-            ),
-        )
-        .only("id")
-        .order_by(Lower("package__namespace__name"), Lower("package__name")),
-    )
-
-    versions_prefetch = Prefetch(
-        "package__versions",
-        queryset=PackageVersion.objects.filter(is_active=True)
-        .select_related("package", "package__owner")
-        .prefetch_related(dependencies_prefetch),
-    )
-
-    listings = (
-        PackageListing.objects.filter(id__in=listing_ids)
-        .select_related("community", "package", "package__owner")
-        .prefetch_related(
-            "categories",
-            "community__sites__site",
-            versions_prefetch,
-        )
-        .annotate(_rating_score=Coalesce(ratings_subquery, 0))
-    )
-
-    order_map = {lid: pos for pos, lid in enumerate(listing_ids)}
-    return sorted(listings, key=lambda l: order_map[l.id])
-
-
-def _get_sorted_active_versions(
-    package: "Package",
-) -> List["PackageVersion"]:
-    versions = [v for v in package.versions.all() if v.is_active]
-    versions.sort(key=lambda v: StrictVersion(v.version_number), reverse=True)
-    return versions
-
-
-def listing_to_json(listing: PackageListing) -> bytes:
-    package = listing.package
-    owner = package.owner
-    versions = _get_sorted_active_versions(package)
-
-    return json.dumps(
-        {
-            "name": package.name,
-            "full_name": package.full_package_name,
-            "owner": owner.name,
-            "package_url": listing.get_full_url(),
-            "donation_link": owner.donation_link,
-            "date_created": package.date_created.isoformat(),
-            "date_updated": package.date_updated.isoformat(),
-            "uuid4": str(package.uuid4),
-            "rating_score": listing.rating_score,
-            "is_pinned": package.is_pinned,
-            "is_deprecated": package.is_deprecated,
-            "has_nsfw_content": listing.has_nsfw_content,
-            "categories": [c.name for c in listing.categories.all()],
-            "versions": [
-                {
-                    "name": version.name,
-                    "full_name": version.full_version_name,
-                    "description": version.description,
-                    "icon": version.icon.url,
-                    "version_number": version.version_number,
-                    "dependencies": [
-                        d._full_version_name for d in version.dependencies.all()
-                    ],
-                    "download_url": version.full_download_url,
-                    "downloads": version.downloads,
-                    "date_created": version.date_created.isoformat(),
-                    "website_url": version.website_url,
-                    "is_active": version.is_active,
-                    "uuid4": str(version.uuid4),
-                    "file_size": version.file_size,
-                }
-                for version in versions
-            ],
-        },
-    ).encode()
-
-
 def get_index_blob(group: DataBlobGroup) -> DataBlob:
     chunk_urls: List[str] = [e.blob.data_url for e in group.entries.all()]
     index_content = gzip.compress(json.dumps(chunk_urls).encode(), mtime=0)
     return DataBlob.get_or_create(index_content)
+
+
+# URL-safe sentinels absent from owner/package/version values, so SQL replace() is unambiguous.
+_OWNER, _NAME, _VERSION, _ICON = "~owner~", "~name~", "~version~", "~icon~"
+
+
+def _community_url_templates(community: Community) -> dict:
+    """URL/icon templates carrying sentinels the chunk SQL fills in per row."""
+    from django.conf import settings
+    from django.urls import reverse
+
+    from thunderstore.frontend.url_reverse import get_community_url_reverse_args
+    from thunderstore.repository.models import PackageVersion
+
+    site = community.main_site
+    hostname = settings.PRIMARY_HOST if site is None else site.site.domain
+    return {
+        "package_url": settings.PROTOCOL
+        + hostname
+        + reverse(
+            **get_community_url_reverse_args(
+                community, "packages.detail", {"owner": _OWNER, "name": _NAME}
+            )
+        ),
+        "download_url": settings.PROTOCOL
+        + settings.PRIMARY_HOST
+        + reverse(
+            "old_urls:packages.download",
+            kwargs={"owner": _OWNER, "name": _NAME, "version": _VERSION},
+        ),
+        "icon": PackageVersion._meta.get_field("icon").storage.url(_ICON),
+    }
+
+
+def _json_object(fields: List[Tuple[str, str]]) -> str:
+    """Render (json_key, sql_expr) pairs into json_build_object(). Arg order is the
+    emitted JSON key order."""
+    args = ", ".join(f"'{key}', {expr}" for key, expr in fields)
+    return f"json_build_object({args})"
+
+
+@lru_cache(maxsize=1)
+def _chunk_sql() -> str:
+    """Build a chunk's listing JSON in Postgres. _listing_fields/_version_fields
+    are the sole declaration of the index's fields and key order."""
+    from thunderstore.community.models import PackageCategory, PackageListing
+    from thunderstore.repository.models import (
+        Namespace,
+        Package,
+        PackageRating,
+        PackageVersion,
+        Team,
+    )
+
+    def tb(m):
+        return m._meta.db_table
+
+    def co(m, f):
+        return m._meta.get_field(f).column
+
+    def pkc(m):
+        return m._meta.pk.column
+
+    def m2m_cols(model, field_name):
+        # Through-table (table, pk, from_col, to_col) via Django's m2m field-name API.
+        field = model._meta.get_field(field_name)
+        through = field.remote_field.through._meta
+        from_col = through.get_field(field.m2m_field_name()).column
+        to_col = through.get_field(field.m2m_reverse_field_name()).column
+        return through.db_table, through.pk.column, from_col, to_col
+
+    cat_table, _, cat_from, cat_to = m2m_cols(PackageListing, "categories")
+    dep_table, _, dep_from, dep_to = m2m_cols(PackageVersion, "dependencies")
+
+    def iso(col):
+        # Match datetime.isoformat(): 6-digit fraction, dropped when zero.
+        b = f"{col} AT TIME ZONE 'UTC'"
+        full = "'YYYY-MM-DD\"T\"HH24:MI:SS.US+00:00'"
+        secs = "'YYYY-MM-DD\"T\"HH24:MI:SS+00:00'"
+        return (
+            f"CASE WHEN to_char({b}, 'US') = '000000' "
+            f"THEN to_char({b}, {secs}) ELSE to_char({b}, {full}) END"
+        )
+
+    # Order deps by namespace then package name (lowercased), matching the
+    # chunked index path from #1319. Unfiltered by is_active, like dependencies.all().
+    deps = f"""COALESCE((
+        SELECT json_agg(
+            downer.name || '-' || dpkg.name || '-' || dv.version_number
+            ORDER BY lower(dns.name), lower(dpkg.name)
+        )
+        FROM {dep_table} pvd
+        JOIN {tb(PackageVersion)} dv ON dv.{pkc(PackageVersion)} = pvd.{dep_to}
+        JOIN {tb(Package)} dpkg ON dpkg.{pkc(Package)} = dv.{co(PackageVersion, 'package')}
+        JOIN {tb(Team)} downer ON downer.{pkc(Team)} = dpkg.{co(Package, 'owner')}
+        JOIN {tb(Namespace)} dns ON dns.{pkc(Namespace)} = dpkg.{co(Package, 'namespace')}
+        WHERE pvd.{dep_from} = v.{pkc(PackageVersion)}
+    ), '[]'::json)"""
+
+    download_url = (
+        f"replace(replace(replace(%(download_url)s, "
+        f"'{_OWNER}', owner.name), '{_NAME}', pkg.name), '{_VERSION}', v.version_number)"
+    )
+
+    _version_fields = [
+        ("name", "v.name"),
+        ("full_name", "owner.name || '-' || pkg.name || '-' || v.version_number"),
+        ("description", "v.description"),
+        ("icon", f"replace(%(icon)s, '{_ICON}', v.icon)"),
+        ("version_number", "v.version_number"),
+        ("dependencies", deps),
+        ("download_url", download_url),
+        ("downloads", "v.downloads"),
+        ("date_created", iso("v.date_created")),
+        ("website_url", "v.website_url"),
+        ("is_active", "v.is_active"),
+        ("uuid4", "v.uuid4"),
+        ("file_size", "v.file_size"),
+    ]
+    version_obj = _json_object(_version_fields)
+
+    # Semver order: version_number is validated X.Y.Z, so a numeric component sort is total.
+    versions = f"""COALESCE((
+        SELECT json_agg(s.obj ORDER BY s.v1 DESC, s.v2 DESC, s.v3 DESC)
+        FROM (
+            SELECT {version_obj} AS obj,
+                split_part(v.version_number, '.', 1)::numeric AS v1,
+                split_part(v.version_number, '.', 2)::numeric AS v2,
+                split_part(v.version_number, '.', 3)::numeric AS v3
+            FROM {tb(PackageVersion)} v
+            WHERE v.{co(PackageVersion, 'package')} = pkg.{pkc(Package)} AND v.is_active
+        ) s
+    ), '[]'::json)"""
+
+    categories = f"""COALESCE((
+        SELECT json_agg(cat.name ORDER BY cat.name)
+        FROM {cat_table} lc
+        JOIN {tb(PackageCategory)} cat ON cat.{pkc(PackageCategory)} = lc.{cat_to}
+        WHERE lc.{cat_from} = pl.{pkc(PackageListing)}
+    ), '[]'::json)"""
+
+    rating = (
+        f"(SELECT count(*) FROM {tb(PackageRating)} r "
+        f"WHERE r.{co(PackageRating, 'package')} = pkg.{pkc(Package)})"
+    )
+
+    package_url = f"replace(replace(%(package_url)s, '{_OWNER}', owner.name), '{_NAME}', pkg.name)"
+
+    _listing_fields = [
+        ("name", "pkg.name"),
+        ("full_name", "owner.name || '-' || pkg.name"),
+        ("owner", "owner.name"),
+        ("package_url", package_url),
+        ("donation_link", "owner.donation_link"),
+        ("date_created", iso("pkg.date_created")),
+        ("date_updated", iso("pkg.date_updated")),
+        ("uuid4", "pkg.uuid4"),
+        ("rating_score", rating),
+        ("is_pinned", "pkg.is_pinned"),
+        ("is_deprecated", "pkg.is_deprecated"),
+        ("has_nsfw_content", "pl.has_nsfw_content"),
+        ("categories", categories),
+        ("versions", versions),
+    ]
+    return f"""
+    SELECT ({_json_object(_listing_fields)})::text
+    FROM unnest(%(ids)s::int[]) WITH ORDINALITY AS req(id, ord)
+    JOIN {tb(PackageListing)} pl ON pl.{pkc(PackageListing)} = req.id
+    JOIN {tb(Package)} pkg ON pkg.{pkc(Package)} = pl.{co(PackageListing, 'package')}
+    JOIN {tb(Team)} owner ON owner.{pkc(Team)} = pkg.{co(Package, 'owner')}
+    ORDER BY req.ord
+    """
+
+
+def serialize_listing_chunk(
+    url_templates: dict, listing_ids: List[int]
+) -> Iterable[bytes]:
+    """Yield each listing's JSON in listing_ids order, built in Postgres so no ORM
+    objects are hydrated for the chunk."""
+    ids = list(listing_ids)
+    if not ids:
+        return
+    params = {**url_templates, "ids": ids}
+    with connection.cursor() as cursor:
+        cursor.execute(_chunk_sql(), params)
+        for (listing_json,) in cursor:
+            yield listing_json.encode()

--- a/django/thunderstore/repository/tests/test_cache_models.py
+++ b/django/thunderstore/repository/tests/test_cache_models.py
@@ -274,7 +274,7 @@ def test_api_v1_chunked_package_cache__when_community_has_one_package__creates_p
 # Serialized size of a minimal listing returned by PackageListingFactory.
 # Has some padding since the exact size varies a bit based on how many
 # packages the test creates and thus how long the package names are.
-TEST_PACKAGE_BYTES = 1000
+TEST_PACKAGE_BYTES = 1200
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
benched on my local prod reproduction: 52,000 listings, ~450k versions, ~10.9M dependency edges

### Per 1000-listing chunk
| metric | before (ORM) | after (SQL) | delta |
| --- | ---: | ---: | ---: |
| peak memory | 711 MB | 8 MB | −89× |
| wall | 11.6 s | 0.8 s | −14× |

### Whole community (52,000 listings)
| metric | before (ORM) | after (SQL) |
| --- | ---: | ---: |
| peak memory | ~711 MB | 46.5 MB |
| wall | ~600 s | 50 s |
| output | — | 332 MB / 25 gzip blobs |

Identical in output to the pre-existing serializer.