### PR TITLE
TS-3956: Accept a SemVer version_number on the package report endpoint

### DIFF
--- a/django/thunderstore/api/cyberstorm/serializers/package_listing.py
+++ b/django/thunderstore/api/cyberstorm/serializers/package_listing.py
@@ -4,6 +4,55 @@ from thunderstore.community.models import PackageCategory
 from thunderstore.repository.api.experimental.serializers import (
     CommunityFilteredModelChoiceField,
 )
+from thunderstore.repository.models import PackageVersion
+from thunderstore.ts_reports.consts import (
+    REPORT_DESCRIPTION_MAX_LENGTH,
+    REPORT_REASON_CHOICES_TUPLES,
+)
+
+
+class CyberstormPackageListingReportRequestSerializer(serializers.Serializer):
+    """
+    Cyberstorm report request: identifies the reported version by its SemVer
+    version_number (what the Cyberstorm API exposes), not a DB primary key.
+    version_number is only unique per package, so the lookup is scoped to the
+    reported package passed in via serializer context.
+
+    The field is named `version_number` (not `version`) for forwards/backwards
+    compatible deploys: the previously deployed serializer exposed a `version`
+    field typed as a PK, which would reject this semver string with a 400. Using
+    a new field name means an old backend simply ignores it (DRF drops unknown
+    fields), so a frontend shipping this contract works before the backend does.
+
+    The `Cyberstorm` class-name prefix keeps this distinct from the experimental
+    API's PackageListingReportRequestSerializer: drf-yasg derives a schema
+    ref_name from the class name and errors when two serializers share one.
+    """
+
+    version_number = serializers.SlugRelatedField(
+        slug_field="version_number",
+        required=False,
+        allow_null=True,
+        queryset=PackageVersion.objects.none(),
+    )
+    reason = serializers.ChoiceField(
+        required=True,
+        allow_blank=False,
+        allow_null=False,
+        choices=REPORT_REASON_CHOICES_TUPLES,
+    )
+    description = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+        max_length=REPORT_DESCRIPTION_MAX_LENGTH,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        package = self.context.get("package")
+        if package is not None:
+            self.fields["version_number"].queryset = package.versions.all()
 
 
 class PackageListingCategorySerializer(serializers.Serializer):

--- a/django/thunderstore/api/cyberstorm/tests/test_package_listing_actions.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_package_listing_actions.py
@@ -6,7 +6,9 @@ import pytest
 from rest_framework.test import APIClient
 
 from conftest import TestUserTypes, UserType
+from thunderstore.community.factories import PackageListingFactory
 from thunderstore.community.models import PackageCategory, PackageListing
+from thunderstore.ts_reports.models import PackageReport
 
 PACKAGE_LISTING_ACTIONS = ["update", "approve", "reject", "report", "unlist"]
 
@@ -243,6 +245,103 @@ def test_report_package_listing_required_fields(
 
     assert response.status_code == 400
     assert response.json() == {"reason": ["This field is required."]}
+
+
+@pytest.mark.django_db
+def test_report_package_listing_records_version(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+):
+    user = TestUserTypes.get_user_by_type(TestUserTypes.site_admin)
+    api_client.force_authenticate(user=user)
+    version = active_package_listing.package.latest
+
+    url = get_report_url(active_package_listing)
+    response = api_client.post(
+        url,
+        data=json.dumps({"reason": "Spam", "version_number": version.version_number}),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200, response.json()
+    report = PackageReport.objects.get(
+        package=active_package_listing.package,
+        package_version=version,
+    )
+    assert report.package_version == version
+
+
+@pytest.mark.django_db
+def test_report_package_listing_rejects_unknown_version(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+):
+    user = TestUserTypes.get_user_by_type(TestUserTypes.site_admin)
+    api_client.force_authenticate(user=user)
+
+    url = get_report_url(active_package_listing)
+    response = api_client.post(
+        url,
+        data=json.dumps({"reason": "Spam", "version_number": "9.9.9-does-not-exist"}),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db
+def test_report_package_listing_ignores_legacy_version_field(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+):
+    # Backwards/forwards compatibility: a client built against the old contract
+    # (the `version` PK field) gets its `version` ignored rather than erroring,
+    # mirroring how an old backend ignores the new `version_number` field. The
+    # report still succeeds, just without a recorded version.
+    user = TestUserTypes.get_user_by_type(TestUserTypes.site_admin)
+    api_client.force_authenticate(user=user)
+    version = active_package_listing.package.latest
+
+    url = get_report_url(active_package_listing)
+    response = api_client.post(
+        url,
+        data=json.dumps({"reason": "Spam", "version": version.pk}),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200, response.json()
+    report = PackageReport.objects.get(package=active_package_listing.package)
+    assert report.package_version is None
+
+
+@pytest.mark.django_db
+def test_report_package_listing_version_lookup_is_scoped_to_package(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+):
+    # Another package shares the same version_number (both default to 1.0.0);
+    # the reported version must resolve to the reported package's version,
+    # never the other package's.
+    user = TestUserTypes.get_user_by_type(TestUserTypes.site_admin)
+    api_client.force_authenticate(user=user)
+    version = active_package_listing.package.latest
+
+    other_listing = PackageListingFactory(community_=active_package_listing.community)
+    assert other_listing.package.latest.version_number == version.version_number
+
+    url = get_report_url(active_package_listing)
+    response = api_client.post(
+        url,
+        data=json.dumps({"reason": "Spam", "version_number": version.version_number}),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200, response.json()
+    report = PackageReport.objects.get(
+        package=active_package_listing.package,
+        package_version=version,
+    )
+    assert report.package_version.package == active_package_listing.package
 
 
 @pytest.mark.django_db

--- a/django/thunderstore/api/cyberstorm/views/package_listing_actions.py
+++ b/django/thunderstore/api/cyberstorm/views/package_listing_actions.py
@@ -5,6 +5,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from thunderstore.api.cyberstorm.serializers.package_listing import (
+    CyberstormPackageListingReportRequestSerializer,
     PackageListingApproveSerializer,
     PackageListingCategoriesSerializer,
     PackageListingRejectSerializer,
@@ -18,9 +19,6 @@ from thunderstore.api.cyberstorm.services.package_listing import (
     update_categories,
 )
 from thunderstore.api.utils import conditional_swagger_auto_schema
-from thunderstore.community.api.experimental.serializers import (
-    PackageListingReportRequestSerializer,
-)
 from thunderstore.repository.models import PackageListing
 
 
@@ -136,7 +134,7 @@ class ReportPackageListingAPIView(APIView):
     @conditional_swagger_auto_schema(
         operation_id="cyberstorm.package_listing.report",
         tags=["cyberstorm"],
-        request_body=PackageListingReportRequestSerializer,
+        request_body=CyberstormPackageListingReportRequestSerializer,
         responses={200: "Success"},
     )
     def post(self, request, *args, **kwargs) -> Response:
@@ -146,7 +144,10 @@ class ReportPackageListingAPIView(APIView):
             community_id=kwargs["community_id"],
         )
 
-        request_serializer = PackageListingReportRequestSerializer(data=request.data)
+        request_serializer = CyberstormPackageListingReportRequestSerializer(
+            data=request.data,
+            context={"package": listing.package},
+        )
         request_serializer.is_valid(raise_exception=True)
 
         report_package_listing(
@@ -154,7 +155,7 @@ class ReportPackageListingAPIView(APIView):
             reason=request_serializer.validated_data.get("reason"),
             package=listing.package,
             package_listing=listing,
-            package_version=request_serializer.validated_data.get("version"),
+            package_version=request_serializer.validated_data.get("version_number"),
             description=request_serializer.validated_data.get("description"),
         )
 


### PR DESCRIPTION
The report serializer required a PackageVersion primary key, but the Cyberstorm
API only exposes the SemVer version_number, so the Nimbus report form could
never send a version. Resolve the reported version by version_number instead,
scoped to the reported package via serializer context (version_number is only
unique per package). An unknown version_number now 400s. Adds tests covering a
recorded version and a rejected unknown version.