### PR TITLE
WIP: TS-3946: Add moderation review-queue API + bulk review-status endpoint

### DIFF
--- a/django/thunderstore/api/cyberstorm/services/package_listing.py
+++ b/django/thunderstore/api/cyberstorm/services/package_listing.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from django.db import transaction
 
 from thunderstore.core.exceptions import PermissionValidationError
@@ -50,6 +52,31 @@ def approve_package_listing(
     listing.approve(agent=agent, internal_notes=notes)
     listing.clear_review_request()
 
+    get_package_listing_or_404.clear_cache_with_args(
+        namespace=listing.package.namespace.name,
+        name=listing.package.name,
+        community=listing.community,
+    )
+
+
+@transaction.atomic
+def set_package_listing_unreviewed(
+    agent: UserType, listing: PackageListing, notes: Optional[str] = None
+) -> None:
+    from thunderstore.community.consts import PackageListingReviewStatus
+
+    listing.community.ensure_user_can_moderate_packages(agent)
+
+    update_fields = ["review_status"]
+    listing.review_status = PackageListingReviewStatus.unreviewed
+    # Let the moderator jot/keep internal notes without committing to a decision.
+    if notes is not None and notes != listing.notes:
+        listing.notes = notes
+        update_fields.append("notes")
+    listing.save(update_fields=tuple(update_fields))
+
+    # Review status feeds visibility checks (PackageListingViewMixin.get_object),
+    # so the cached listing lookup must be busted like it is for approve/reject.
     get_package_listing_or_404.clear_cache_with_args(
         namespace=listing.package.namespace.name,
         name=listing.package.name,

--- a/django/thunderstore/api/cyberstorm/tests/test_moderation.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_moderation.py
@@ -1,0 +1,259 @@
+import json
+
+import pytest
+from rest_framework.test import APIClient
+
+from conftest import TestUserTypes
+from thunderstore.community.consts import PackageListingReviewStatus
+from thunderstore.community.models import PackageListing
+
+# GET lists the review queue; PATCH bulk-updates review status on the same URL.
+REVIEW_URL = "/api/cyberstorm/moderation/review/packages/"
+QUEUE_URL = REVIEW_URL
+BULK_URL = REVIEW_URL
+
+
+@pytest.mark.django_db
+def test_review_queue_requires_authentication(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+):
+    active_package_listing.request_review()
+    response = api_client.get(QUEUE_URL)
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db
+def test_review_queue_forbidden_for_non_moderator(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+):
+    active_package_listing.request_review()
+    user = TestUserTypes.get_user_by_type(TestUserTypes.regular_user)
+    api_client.force_authenticate(user=user)
+
+    response = api_client.get(QUEUE_URL)
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_review_queue_lists_requested_packages_for_moderator(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+):
+    active_package_listing.review_status = PackageListingReviewStatus.rejected
+    active_package_listing.save()
+    active_package_listing.request_review()
+
+    user = TestUserTypes.get_user_by_type(TestUserTypes.superuser)
+    api_client.force_authenticate(user=user)
+
+    response = api_client.get(QUEUE_URL)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["count"] == 1
+    item = body["results"][0]
+    # Surfaces a rejected listing (hidden by the public endpoints).
+    assert item["name"] == active_package_listing.package.name
+    assert item["review_status"] == "rejected"
+    assert item["is_review_requested"] is True
+
+
+@pytest.mark.django_db
+def test_review_queue_filters_by_review_status(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+):
+    active_package_listing.review_status = PackageListingReviewStatus.rejected
+    active_package_listing.save()
+    active_package_listing.request_review()
+
+    user = TestUserTypes.get_user_by_type(TestUserTypes.superuser)
+    api_client.force_authenticate(user=user)
+
+    # Matching status returns the listing.
+    response = api_client.get(REVIEW_URL, {"review_status": "rejected"})
+    assert response.status_code == 200
+    assert response.json()["count"] == 1
+
+    # A different status filters it out.
+    response = api_client.get(REVIEW_URL, {"review_status": "approved"})
+    assert response.status_code == 200
+    assert response.json()["count"] == 0
+
+
+@pytest.mark.django_db
+def test_review_queue_exposes_moderation_context(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+):
+    active_package_listing.rejection_reason = "Looks off"
+    active_package_listing.notes = "internal scratchpad"
+    active_package_listing.save()
+    active_package_listing.request_review()
+
+    user = TestUserTypes.get_user_by_type(TestUserTypes.superuser)
+    api_client.force_authenticate(user=user)
+
+    item = api_client.get(REVIEW_URL).json()["results"][0]
+    assert item["rejection_reason"] == "Looks off"
+    assert item["internal_notes"] == "internal scratchpad"
+
+
+@pytest.mark.django_db
+def test_review_queue_community_filter_and_options(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+):
+    active_package_listing.request_review()
+    community = active_package_listing.community
+
+    user = TestUserTypes.get_user_by_type(TestUserTypes.superuser)
+    api_client.force_authenticate(user=user)
+
+    body = api_client.get(REVIEW_URL).json()
+    # The queue's communities are offered as filter options, with counts.
+    assert {
+        "identifier": community.identifier,
+        "name": community.name,
+        "count": 1,
+    } in body["communities"]
+
+    # Filtering by the listing's community returns it; another doesn't.
+    assert (
+        api_client.get(REVIEW_URL, {"community": community.identifier}).json()["count"]
+        == 1
+    )
+    assert api_client.get(REVIEW_URL, {"community": "nope"}).json()["count"] == 0
+
+
+@pytest.mark.django_db
+def test_review_queue_excludes_non_requested(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+):
+    user = TestUserTypes.get_user_by_type(TestUserTypes.superuser)
+    api_client.force_authenticate(user=user)
+
+    response = api_client.get(QUEUE_URL)
+    assert response.status_code == 200
+    assert response.json()["count"] == 0
+
+
+@pytest.mark.django_db
+def test_review_queue_bulk_approve(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+):
+    active_package_listing.request_review()
+    user = TestUserTypes.get_user_by_type(TestUserTypes.superuser)
+    api_client.force_authenticate(user=user)
+
+    response = api_client.patch(
+        BULK_URL,
+        data=json.dumps(
+            {
+                "package_listing_ids": [active_package_listing.pk],
+                "status": "approved",
+            }
+        ),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200, response.json()
+    assert response.json()["updated"] == 1
+    active_package_listing.refresh_from_db()
+    assert active_package_listing.review_status == PackageListingReviewStatus.approved
+    assert active_package_listing.is_review_requested is False
+
+
+@pytest.mark.django_db
+def test_review_queue_bulk_unreviewed_busts_listing_cache(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+):
+    from thunderstore.repository.views.package._utils import get_package_listing_or_404
+
+    active_package_listing.review_status = PackageListingReviewStatus.approved
+    active_package_listing.save()
+
+    namespace = active_package_listing.package.namespace.name
+    name = active_package_listing.package.name
+    community = active_package_listing.community
+
+    # Prime the cached lookup with the approved status.
+    cached = get_package_listing_or_404(
+        namespace=namespace, name=name, community=community
+    )
+    assert cached.review_status == PackageListingReviewStatus.approved
+
+    user = TestUserTypes.get_user_by_type(TestUserTypes.superuser)
+    api_client.force_authenticate(user=user)
+
+    response = api_client.patch(
+        BULK_URL,
+        data=json.dumps(
+            {
+                "package_listing_ids": [active_package_listing.pk],
+                "status": "unreviewed",
+            }
+        ),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200, response.json()
+    active_package_listing.refresh_from_db()
+    assert active_package_listing.review_status == PackageListingReviewStatus.unreviewed
+
+    # The cached lookup must reflect the new status, not the stale approval.
+    refreshed = get_package_listing_or_404(
+        namespace=namespace, name=name, community=community
+    )
+    assert refreshed.review_status == PackageListingReviewStatus.unreviewed
+
+
+@pytest.mark.django_db
+def test_review_queue_bulk_action_rejects_oversized_batch(
+    api_client: APIClient,
+):
+    user = TestUserTypes.get_user_by_type(TestUserTypes.superuser)
+    api_client.force_authenticate(user=user)
+
+    response = api_client.patch(
+        BULK_URL,
+        data=json.dumps(
+            {
+                "package_listing_ids": list(range(1, 102)),
+                "status": "approved",
+            }
+        ),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 400
+    assert "package_listing_ids" in response.json()
+
+
+@pytest.mark.django_db
+def test_review_queue_bulk_action_forbidden_for_non_moderator(
+    api_client: APIClient,
+    active_package_listing: PackageListing,
+):
+    active_package_listing.request_review()
+    user = TestUserTypes.get_user_by_type(TestUserTypes.regular_user)
+    api_client.force_authenticate(user=user)
+
+    response = api_client.patch(
+        BULK_URL,
+        data=json.dumps(
+            {
+                "package_listing_ids": [active_package_listing.pk],
+                "status": "approved",
+            }
+        ),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 403
+    active_package_listing.refresh_from_db()
+    assert active_package_listing.review_status != PackageListingReviewStatus.approved

--- a/django/thunderstore/api/cyberstorm/views/__init__.py
+++ b/django/thunderstore/api/cyberstorm/views/__init__.py
@@ -2,6 +2,7 @@ from .community import CommunityAPIView
 from .community_filters import CommunityFiltersAPIView
 from .community_list import CommunityListAPIView
 from .markdown import PackageVersionChangelogAPIView, PackageVersionReadmeAPIView
+from .moderation import ModerationReviewPackagesAPIView
 from .package_deprecate import DeprecatePackageAPIView
 from .package_listing import PackageListingAPIView, PackageListingStatusAPIView
 from .package_listing_actions import (
@@ -49,6 +50,7 @@ __all__ = [
     "DisconnectUserLinkedAccountAPIView",
     "DeprecatePackageAPIView",
     "DisbandTeamAPIView",
+    "ModerationReviewPackagesAPIView",
     "PackageListingAPIView",
     "PackageListingStatusAPIView",
     "PackageListingByCommunityListAPIView",

--- a/django/thunderstore/api/cyberstorm/views/moderation.py
+++ b/django/thunderstore/api/cyberstorm/views/moderation.py
@@ -1,0 +1,246 @@
+from django.db.models import Count, Q
+from rest_framework import serializers, status
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.generics import ListAPIView
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from thunderstore.api.cyberstorm.services.package_listing import (
+    approve_package_listing,
+    reject_package_listing,
+    set_package_listing_unreviewed,
+)
+from thunderstore.api.utils import conditional_swagger_auto_schema
+from thunderstore.community.consts import PackageListingReviewStatus
+from thunderstore.community.models import PackageListing
+from thunderstore.repository.views.package._utils import get_moderatable_communities
+
+
+def get_moderatable_communities_or_403(user):
+    communities = get_moderatable_communities(user)
+    if not communities:
+        raise PermissionDenied(
+            "You don't have moderation permissions in any community."
+        )
+    return communities
+
+
+class ReviewListingSerializer(serializers.Serializer):
+    id = serializers.IntegerField()  # noqa: A003
+    community_identifier = serializers.CharField(source="community.identifier")
+    community_name = serializers.CharField(source="community.name")
+    namespace = serializers.CharField(source="package.namespace.name")
+    name = serializers.CharField(source="package.name")
+    review_status = serializers.CharField()
+    is_review_requested = serializers.BooleanField()
+    last_updated = serializers.DateTimeField(source="package.date_updated")
+    icon_url = serializers.SerializerMethodField()
+    # Surface the existing moderation context so the reviewer can read/edit it
+    # in place without opening the Django admin. Coerce nulls to "" so the
+    # frontend always gets plain strings to bind to its editable fields.
+    rejection_reason = serializers.SerializerMethodField()
+    internal_notes = serializers.SerializerMethodField()
+
+    def get_icon_url(self, obj):
+        latest = obj.package.latest
+        return latest.icon.url if latest and latest.icon else None
+
+    def get_rejection_reason(self, obj):
+        return obj.rejection_reason or ""
+
+    def get_internal_notes(self, obj):
+        return obj.notes or ""
+
+
+class ReviewCommunitySerializer(serializers.Serializer):
+    identifier = serializers.CharField()
+    name = serializers.CharField()
+    count = serializers.IntegerField()
+
+
+class ReviewListingPaginator(PageNumberPagination):
+    page_size = 20
+    page_size_query_param = "page_size"
+    max_page_size = 100
+
+
+class ReviewBulkUpdateSerializer(serializers.Serializer):
+    package_listing_ids = serializers.ListField(
+        child=serializers.IntegerField(),
+        allow_empty=False,
+        # Cap the batch size so a single request can't force unbounded DB work.
+        max_length=100,
+    )
+    status = serializers.ChoiceField(  # noqa: A003
+        choices=[
+            PackageListingReviewStatus.unreviewed,
+            PackageListingReviewStatus.approved,
+            PackageListingReviewStatus.rejected,
+        ],
+    )
+    rejection_reason = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        default="",
+    )
+    internal_notes = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+    )
+
+
+class ModerationReviewPackagesAPIView(ListAPIView):
+    """
+    Package listings awaiting review, across the communities the authenticated
+    user can moderate.
+
+    This is the package-listing target of the generic moderation "review"
+    surface (future entities — e.g. comments — get their own sibling view).
+
+    - GET lists the review-requested listings (optionally filtered by free-text
+      query `q`, `review_status` and/or `community`).
+    - PATCH applies a review status to several listings at once.
+
+    Unlike the public listing endpoints this deliberately surfaces
+    rejected/unreviewed listings, so the response is never publicly cached.
+    """
+
+    permission_classes = [IsAuthenticated]
+    serializer_class = ReviewListingSerializer
+    pagination_class = ReviewListingPaginator
+
+    @conditional_swagger_auto_schema(
+        operation_id="cyberstorm.moderation.review.packages.list",
+        responses={200: ReviewListingSerializer(many=True)},
+        tags=["cyberstorm"],
+    )
+    def get(self, request, *args, **kwargs) -> Response:
+        return super().get(request, *args, **kwargs)
+
+    def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return PackageListing.objects.none()
+
+        communities = get_moderatable_communities_or_403(self.request.user)
+        qs = (
+            PackageListing.objects.active()
+            .filter(is_review_requested=True, community_id__in=communities)
+            .select_related(
+                "community",
+                "package",
+                "package__namespace",
+                "package__latest",
+            )
+            .order_by("-datetime_created")
+        )
+
+        query = self.request.query_params.get("q")
+        if query:
+            qs = qs.filter(
+                Q(package__name__icontains=query)
+                | Q(package__namespace__name__icontains=query)
+            )
+
+        review_status = self.request.query_params.get("review_status")
+        valid_statuses = {
+            PackageListingReviewStatus.unreviewed,
+            PackageListingReviewStatus.approved,
+            PackageListingReviewStatus.rejected,
+        }
+        if review_status in valid_statuses:
+            qs = qs.filter(review_status=review_status)
+
+        community = self.request.query_params.get("community")
+        if community:
+            qs = qs.filter(community__identifier=community)
+
+        return qs
+
+    def list(self, request, *args, **kwargs):
+        response = super().list(request, *args, **kwargs)
+        # Surface the communities that actually have items in this moderator's
+        # queue so the frontend can offer a (stable) community filter.
+        response.data["communities"] = self._queue_communities(request.user)
+        return response
+
+    def _queue_communities(self, user):
+        communities = get_moderatable_communities_or_403(user)
+        rows = (
+            PackageListing.objects.active()
+            .filter(is_review_requested=True, community_id__in=communities)
+            .values("community__identifier", "community__name")
+            .annotate(count=Count("id"))
+            .order_by("community__name")
+        )
+        data = [
+            {
+                "identifier": row["community__identifier"],
+                "name": row["community__name"],
+                "count": row["count"],
+            }
+            for row in rows
+        ]
+        return ReviewCommunitySerializer(data, many=True).data
+
+    @conditional_swagger_auto_schema(
+        operation_id="cyberstorm.moderation.review.packages.bulk_update",
+        request_body=ReviewBulkUpdateSerializer,
+        responses={200: "Success"},
+        tags=["cyberstorm"],
+    )
+    def patch(self, request, *args, **kwargs) -> Response:
+        communities = get_moderatable_communities_or_403(request.user)
+
+        serializer = ReviewBulkUpdateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        # The per-listing services touch listing.community and
+        # listing.package.namespace; fetch them up front to avoid N+1 queries.
+        listings = (
+            PackageListing.objects.active()
+            .filter(
+                pk__in=data["package_listing_ids"],
+                community_id__in=communities,
+            )
+            .select_related(
+                "community",
+                "package",
+                "package__namespace",
+            )
+        )
+
+        updated = 0
+        for listing in listings:
+            self._apply_status(request.user, listing, data)
+            updated += 1
+
+        return Response({"updated": updated}, status=status.HTTP_200_OK)
+
+    def _apply_status(self, user, listing, data) -> None:
+        new_status = data["status"]
+
+        if new_status == PackageListingReviewStatus.approved:
+            approve_package_listing(
+                agent=user,
+                notes=data.get("internal_notes"),
+                listing=listing,
+            )
+        elif new_status == PackageListingReviewStatus.rejected:
+            reject_package_listing(
+                agent=user,
+                reason=data.get("rejection_reason") or "",
+                notes=data.get("internal_notes"),
+                listing=listing,
+            )
+        elif new_status == PackageListingReviewStatus.unreviewed:
+            set_package_listing_unreviewed(
+                agent=user, listing=listing, notes=data.get("internal_notes")
+            )
+
+    def finalize_response(self, request, response, *args, **kwargs):
+        response = super().finalize_response(request, response, *args, **kwargs)
+        response["Cache-Control"] = "no-store, private"
+        return response

--- a/django/thunderstore/api/urls.py
+++ b/django/thunderstore/api/urls.py
@@ -11,6 +11,7 @@ from thunderstore.api.cyberstorm.views import (
     DeprecatePackageAPIView,
     DisbandTeamAPIView,
     DisconnectUserLinkedAccountAPIView,
+    ModerationReviewPackagesAPIView,
     PackageListingAPIView,
     PackageListingByCommunityListAPIView,
     PackageListingByDependencyListAPIView,
@@ -94,6 +95,11 @@ cyberstorm_urls = [
         "listing/<str:community_id>/<str:namespace_id>/<str:package_name>/approve/",
         ApprovePackageListingAPIView.as_view(),
         name="cyberstorm.listing.approve",
+    ),
+    path(
+        "moderation/review/packages/",
+        ModerationReviewPackagesAPIView.as_view(),
+        name="cyberstorm.moderation.review.packages",
     ),
     path(
         "listing/<str:community_id>/<str:namespace_id>/<str:package_name>/report/",

--- a/django/thunderstore/social/api/experimental/views/current_user.py
+++ b/django/thunderstore/social/api/experimental/views/current_user.py
@@ -14,6 +14,7 @@ from thunderstore.account.models.user_flag import UserFlag
 from thunderstore.api.cyberstorm.views.team import TeamPermissionsMixin
 from thunderstore.core.types import UserType
 from thunderstore.repository.models import TeamMember
+from thunderstore.repository.views.package._utils import get_moderatable_communities
 from thunderstore.social.utils import get_connection_avatar_url
 
 
@@ -112,6 +113,7 @@ class UserProfile(TypedDict):
     teams: List[str]
     teams_full: List[UserTeam]
     is_staff: Optional[bool]
+    is_moderator: Optional[bool]
 
 
 class UserProfileSerializer(serializers.Serializer):
@@ -125,6 +127,9 @@ class UserProfileSerializer(serializers.Serializer):
     )  # This is in active use by the Django frontend react components at least
     teams_full = UserTeamSerializer(many=True)
     is_staff = serializers.BooleanField()
+    # True when the user can moderate at least one community (community
+    # owner/moderator, or a global moderator). Gates the moderation UI.
+    is_moderator = serializers.BooleanField()
 
 
 def get_empty_profile() -> UserProfile:
@@ -137,6 +142,7 @@ def get_empty_profile() -> UserProfile:
         "teams": [],
         "teams_full": [],
         "is_staff": False,
+        "is_moderator": False,
     }
 
 
@@ -167,6 +173,7 @@ def get_user_profile(user: UserType) -> UserProfile:
     capabilities = {"package.rate"}
     teams = get_teams(user)
     is_staff = user.is_staff
+    is_moderator = bool(get_moderatable_communities(user))
 
     return UserProfileSerializer(
         {
@@ -178,6 +185,7 @@ def get_user_profile(user: UserType) -> UserProfile:
             "teams": [x.name for x in teams],
             "teams_full": teams,
             "is_staff": is_staff,
+            "is_moderator": is_moderator,
         }
     ).data
 

--- a/django/thunderstore/social/tests/test_current_user.py
+++ b/django/thunderstore/social/tests/test_current_user.py
@@ -9,6 +9,11 @@ from social_django.models import UserSocialAuth  # type: ignore
 
 from thunderstore.account.factories import ServiceAccountFactory
 from thunderstore.account.models.user_flag import UserFlag, UserFlagMembership
+from thunderstore.community.models import (
+    Community,
+    CommunityMemberRole,
+    CommunityMembership,
+)
 from thunderstore.core.types import UserType
 from thunderstore.repository.factories import TeamMemberFactory
 from thunderstore.repository.models.team import TeamMemberRole
@@ -263,6 +268,27 @@ def test_current_user_is_staff_experimental_api(
     _run_current_user_is_staff_test(
         api_client, user, is_authorized, is_staff, expected_status, False
     )
+
+
+@pytest.mark.django_db
+def test_current_user_is_moderator_experimental_api(
+    api_client: APIClient,
+    user: UserType,
+    community: Community,
+):
+    api_client.force_authenticate(user=user)
+
+    # A plain user moderates nothing.
+    response = request_user_info(api_client)
+    assert response.status_code == 200
+    assert response.json()["is_moderator"] is False
+
+    # Becoming a community moderator flips the flag (no staff/superuser needed).
+    CommunityMembership.objects.create(
+        user=user, community=community, role=CommunityMemberRole.moderator
+    )
+    response = request_user_info(api_client)
+    assert response.json()["is_moderator"] is True
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Adds an authenticated Cyberstorm API powering the Nimbus review queue:
- GET /api/cyberstorm/moderation/review-queue/packages/ lists packages with
  is_review_requested across the communities the user can moderate. Unlike the
  public listing endpoints it deliberately surfaces rejected/unreviewed
  listings, so it sets Cache-Control: no-store and 403s non-moderators.
- POST .../bulk-action/ applies a review status (approved/rejected/unreviewed)
  or moves listings into the review queue, in bulk, scoped to the moderator's
  communities (reusing the existing approve/reject services).