### PR TITLE
WIP: TS-3938: Filter package listings by category/section slug, not id/uuid

### DIFF
--- a/django/thunderstore/api/cyberstorm/tests/test_package_listing_list.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_package_listing_list.py
@@ -163,7 +163,7 @@ def test_base_view__when_including_category__filters_out_not_matched(
     PackageListingFactory(community_=community, categories=[])
     included = PackageListingFactory(community_=community, categories=[cat])
 
-    request = APIRequestFactory().get("/", {"included_categories": [str(cat.id)]})
+    request = APIRequestFactory().get("/", {"included_categories": [cat.slug]})
     response = BasePackageListAPIView().dispatch(
         request,
         community_id=community.identifier,
@@ -182,7 +182,7 @@ def test_base_view__when_excluding_category__filters_out_matched(
     included = PackageListingFactory(community_=community, categories=[])
     PackageListingFactory(community_=community, categories=[cat])
 
-    request = APIRequestFactory().get("/", {"excluded_categories": [str(cat.id)]})
+    request = APIRequestFactory().get("/", {"excluded_categories": [cat.slug]})
     response = BasePackageListAPIView().dispatch(
         request,
         community_id=community.identifier,
@@ -212,10 +212,86 @@ def test_base_view__when_requesting_section__filters_based_on_categories(
     PackageListingFactory(community_=community, categories=[excluded])
     PackageListingFactory(community_=community, categories=[irrelevant])
 
-    request = APIRequestFactory().get("/", {"section": section.uuid})
+    request = APIRequestFactory().get("/", {"section": section.slug})
     response = BasePackageListAPIView().dispatch(
         request,
         community_id=community.identifier,
+    )
+
+    assert response.data["count"] == 1
+    assert response.data["results"][0]["name"] == expected.package.name
+
+
+@mock_base_package_list_api_view
+@pytest.mark.django_db
+def test_base_view__filters_by_category_id_for_backwards_compat(
+    community: Community,
+) -> None:
+    # Backwards compatibility: the API still accepts numeric category ids while
+    # clients migrate to slugs.
+    cat = PackageCategory.objects.create(name="c", slug="c", community=community)
+    PackageListingFactory(community_=community, categories=[])
+    included = PackageListingFactory(community_=community, categories=[cat])
+
+    request = APIRequestFactory().get("/", {"included_categories": [str(cat.id)]})
+    response = BasePackageListAPIView().dispatch(
+        request,
+        community_id=community.identifier,
+    )
+
+    assert response.data["count"] == 1
+    assert response.data["results"][0]["name"] == included.package.name
+
+
+@mock_base_package_list_api_view
+@pytest.mark.django_db
+def test_base_view__filters_by_section_uuid_for_backwards_compat(
+    community: Community,
+) -> None:
+    # Backwards compatibility: the API still accepts a section UUID.
+    required = PackageCategory.objects.create(name="r", slug="r", community=community)
+    section = PackageListingSection.objects.create(
+        name="Modpacks", slug="modpacks", community=community
+    )
+    section.require_categories.set([required])
+    expected = PackageListingFactory(community_=community, categories=[required])
+    PackageListingFactory(community_=community, categories=[])
+
+    request = APIRequestFactory().get("/", {"section": str(section.uuid)})
+    response = BasePackageListAPIView().dispatch(
+        request,
+        community_id=community.identifier,
+    )
+
+    assert response.data["count"] == 1
+    assert response.data["results"][0]["name"] == expected.package.name
+
+
+@mock_base_package_list_api_view
+@pytest.mark.django_db
+def test_base_view__section_slug_lookup_is_scoped_to_community() -> None:
+    # Two communities share the same section slug; the filter must use the
+    # section for the requested community only.
+    community_a = CommunityFactory()
+    community_b = CommunityFactory()
+    cat_a = PackageCategory.objects.create(name="a", slug="cat", community=community_a)
+    cat_b = PackageCategory.objects.create(name="b", slug="cat", community=community_b)
+    section_a = PackageListingSection.objects.create(
+        name="Modpacks", slug="modpacks", community=community_a
+    )
+    section_a.require_categories.set([cat_a])
+    section_b = PackageListingSection.objects.create(
+        name="Modpacks", slug="modpacks", community=community_b
+    )
+    section_b.require_categories.set([cat_b])
+
+    expected = PackageListingFactory(community_=community_a, categories=[cat_a])
+    PackageListingFactory(community_=community_a, categories=[])
+
+    request = APIRequestFactory().get("/", {"section": "modpacks"})
+    response = BasePackageListAPIView().dispatch(
+        request,
+        community_id=community_a.identifier,
     )
 
     assert response.data["count"] == 1
@@ -229,7 +305,7 @@ def test_base_view__when_requesting_nonexisting_section__does_nothing() -> None:
 
     request = APIRequestFactory().get(
         "/",
-        {"section": "decade00-0000-4000-a000-000000000000"},
+        {"section": "nonexistent-section-slug"},
     )
     response = BasePackageListAPIView().dispatch(
         request,
@@ -539,7 +615,7 @@ def test_base_view__when_multiple_pages_of_results__page_urls_retain_paramaters(
         "/",
         data={
             "deprecated": True,
-            "included_categories": [str(cat.id)],
+            "included_categories": [cat.slug],
             "ordering": "most-downloaded",
             "page": 2,
             "q": "test",
@@ -551,10 +627,10 @@ def test_base_view__when_multiple_pages_of_results__page_urls_retain_paramaters(
     )
 
     assert response.data["previous"].endswith(
-        f"?deprecated=True&included_categories={cat.id}&nsfw=False&ordering=most-downloaded&page=1&q=test",
+        f"?deprecated=True&included_categories={cat.slug}&nsfw=False&ordering=most-downloaded&page=1&q=test",
     )
     assert response.data["next"].endswith(
-        f"?deprecated=True&included_categories={cat.id}&nsfw=False&ordering=most-downloaded&page=3&q=test",
+        f"?deprecated=True&included_categories={cat.slug}&nsfw=False&ordering=most-downloaded&page=3&q=test",
     )
 
 

--- a/django/thunderstore/api/cyberstorm/views/package_listing_list.py
+++ b/django/thunderstore/api/cyberstorm/views/package_listing_list.py
@@ -3,6 +3,7 @@ from typing import List, Optional, OrderedDict, Tuple
 from urllib.parse import urlencode
 
 from django.conf import settings
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.paginator import Page
 from django.db.models import Count, OuterRef, Q, QuerySet, Subquery, Sum
 from django.urls import reverse
@@ -51,7 +52,10 @@ class PackageListRequestSerializer(serializers.Serializer):
     )
     page = serializers.IntegerField(default=1, min_value=1)
     q = serializers.CharField(required=False, help_text="Free text search")
-    section = serializers.UUIDField(required=False)
+    section = serializers.CharField(
+        required=False,
+        help_text="PackageListingSection slug (a section UUID is also accepted)",
+    )
 
 
 class PackageListResponseSerializer(serializers.Serializer):
@@ -151,7 +155,7 @@ class BasePackageListAPIView(PublicCacheMixin, ListAPIView):
         qs = filter_nsfw(params["nsfw"], qs)
         qs = filter_in_categories(params["included_categories"], qs)
         qs = filter_not_in_categories(params["excluded_categories"], qs)
-        qs = filter_by_section(params.get("section"), qs)
+        qs = filter_by_section(params.get("section"), qs, community)
         qs = filter_by_query(params.get("q"), qs)
 
         return qs.order_by(
@@ -389,60 +393,95 @@ def filter_nsfw(
     return queryset.exclude(has_nsfw_content=True)
 
 
+def _categories_match_q(category_keys: List[str]) -> Q:
+    """
+    Match categories by slug, and — for backwards compatibility during the
+    slug migration — by numeric id too. Remove the id fallback in the follow-up
+    PR once the frontend no longer sends category ids.
+    """
+    numeric_ids = [key for key in category_keys if str(key).isdigit()]
+    query = Q(categories__slug__in=category_keys)
+    if numeric_ids:
+        query |= Q(categories__id__in=numeric_ids)
+    return query
+
+
 def filter_in_categories(
-    category_ids: List[str],
+    category_keys: List[str],
     queryset: QuerySet[PackageListing],
 ) -> QuerySet[PackageListing]:
     """
     Include only packages belonging to specific categories.
 
-    Multiple categories are OR-joined, i.e. if category_ids contain A
+    Multiple categories are OR-joined, i.e. if category_keys contain A
     and B, packages belonging to either will be returned.
     """
-    if not category_ids:
+    if not category_keys:
         return queryset
 
-    return queryset.exclude(~Q(categories__id__in=category_ids))
+    return queryset.exclude(~_categories_match_q(category_keys))
 
 
 def filter_not_in_categories(
-    category_ids: List[str],
+    category_keys: List[str],
     queryset: QuerySet[PackageListing],
 ) -> QuerySet[PackageListing]:
     """
     Exclude packages belonging to specific categories.
 
-    Multiple categories are OR-joined, i.e. if category_ids contain A
+    Multiple categories are OR-joined, i.e. if category_keys contain A
     and B, packages belonging to either will be rejected.
     """
-    if not category_ids:
+    if not category_keys:
         return queryset
 
-    return queryset.exclude(categories__id__in=category_ids)
+    return queryset.exclude(_categories_match_q(category_keys))
+
+
+def _resolve_section(
+    section_key: str, community: Optional[Community]
+) -> Optional[PackageListingSection]:
+    """
+    Resolve a section by slug (scoped to the community, since slugs are only
+    unique per community), falling back to the section UUID for backwards
+    compatibility during the slug migration. Remove the UUID fallback in the
+    follow-up PR once the frontend no longer sends section UUIDs.
+    """
+    section_qs = PackageListingSection.objects.prefetch_related(
+        "require_categories",
+        "exclude_categories",
+    )
+    scoped_qs = section_qs.filter(community=community) if community else section_qs
+    try:
+        return scoped_qs.get(slug=section_key)
+    except PackageListingSection.DoesNotExist:
+        pass
+    try:
+        # uuid is globally unique, so it does not need community scoping.
+        return section_qs.get(uuid=section_key)
+    except (PackageListingSection.DoesNotExist, DjangoValidationError, ValueError):
+        return None
 
 
 def filter_by_section(
-    section_uuid: Optional[str],
+    section_key: Optional[str],
     queryset: QuerySet[PackageListing],
+    community: Optional[Community] = None,
 ) -> QuerySet[PackageListing]:
     """
     PackageListingSections can be used as shortcut for multiple
-    category filters.
+    category filters. Accepts a section slug (preferred) or, for backwards
+    compatibility, a section UUID.
     """
-    if not section_uuid:
+    if not section_key:
         return queryset
 
-    try:
-        section = PackageListingSection.objects.prefetch_related(
-            "require_categories",
-            "exclude_categories",
-        ).get(uuid=section_uuid)
-    except PackageListingSection.DoesNotExist:
-        required = []
-        excluded = []
-    else:
-        required = section.require_categories.values_list("pk", flat=True)
-        excluded = section.exclude_categories.values_list("pk", flat=True)
+    section = _resolve_section(section_key, community)
+    if section is None:
+        return queryset
+
+    required = section.require_categories.values_list("slug", flat=True)
+    excluded = section.exclude_categories.values_list("slug", flat=True)
 
     queryset = filter_in_categories(required, queryset)
     return filter_not_in_categories(excluded, queryset)


### PR DESCRIPTION
The Cyberstorm package listing API identified section and category filters by
database id (section UUID, category pk). Switch the contract to slugs to match
the frontend: accept `section` as a slug (CharField), look it up scoped to the
community (slugs are unique per community, so the lookup must be scoped to
avoid cross-community collisions), and filter categories by `categories__slug__in`.
Tests updated to pass slugs.