### PR TITLE
Stop markdown linkifying bare words like README.md

### DIFF
--- a/django/thunderstore/markdown/templatetags/markdownify.py
+++ b/django/thunderstore/markdown/templatetags/markdownify.py
@@ -12,6 +12,11 @@ from thunderstore.markdown.allowed_tags import (
 
 register = template.Library()
 md = MarkdownIt("gfm-like")
+# Disable fuzzy linkification: without this, linkify turns any bare word ending
+# in a valid TLD into a link (e.g. "README.md" -> http://readme.md, "setup.sh"),
+# sending users to unintended/dangerous sites. Explicit URLs (http://, https://)
+# and emails are still autolinked.
+md.linkify.set({"fuzzy_link": False})
 
 
 def render_markdown(value: str):

--- a/django/thunderstore/markdown/tests/test_markdownify.py
+++ b/django/thunderstore/markdown/tests/test_markdownify.py
@@ -32,3 +32,30 @@ def test_markdown_is_rendered_to_markup(markdown: str, expected: str) -> None:
     actual = render_markdown(markdown)
 
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "markdown",
+    (
+        "README.md",
+        "See CHANGELOG.md for details",
+        "Run setup.sh to install",
+        "example.io",
+        "Edit the config.ai file",
+    ),
+)
+def test_bare_word_with_tld_is_not_linkified(markdown: str) -> None:
+    # Bare words ending in a valid TLD (.md, .sh, .io, .ai, ...) must stay plain
+    # text, not become links to e.g. http://readme.md.
+    assert "<a " not in render_markdown(markdown)
+
+
+@pytest.mark.parametrize(
+    "url",
+    (
+        "https://example.com",
+        "http://example.com/path",
+    ),
+)
+def test_explicit_url_is_still_linkified(url: str) -> None:
+    assert f'<a href="{url}">{url}</a>' in render_markdown(url)


### PR DESCRIPTION
The "gfm-like" markdown-it preset enables linkify with fuzzy_link on, so
any bare word ending in a valid TLD got turned into a link: "README.md"
-> http://README.md, "setup.sh" -> http://setup.sh, etc. Those domains
resolve to unrelated, potentially malicious sites (readme.md currently
serves an AI site), confusing users.

Disable fuzzy_link so only explicit http(s):// URLs and emails are
autolinked. render_markdown is the single render path, so this covers
package READMEs/changelogs (new frontend + legacy), wikis, legal
contracts, and the markdown preview endpoints.

Add regression tests for TLD-like bare words and explicit URLs.