### PR TITLE
Add latest version, install link and dl link to packagelisting-list

### DIFF
--- a/django/thunderstore/api/cyberstorm/serializers/package.py
+++ b/django/thunderstore/api/cyberstorm/serializers/package.py
@@ -59,9 +59,9 @@ class CyberstormPackagePreviewSerializer(serializers.Serializer):
     rating_count = serializers.IntegerField(min_value=0)
     size = serializers.IntegerField(min_value=0)
     datetime_created = serializers.DateTimeField()
-    # Latest version number + its install/download URLs. Additive fields: the
-    # frontend list-card variant treats them as optional (it deploys before the
-    # backend), so an older frontend simply ignores them.
+    # Latest version number + its install/download URLs. Additive: the new
+    # frontend treats them as optional (it deploys first), and older frontends
+    # ignore unknown fields.
     latest_version_number = serializers.CharField(
         max_length=PackageVersion._meta.get_field("version_number").max_length,
     )

--- a/django/thunderstore/api/cyberstorm/serializers/package.py
+++ b/django/thunderstore/api/cyberstorm/serializers/package.py
@@ -59,6 +59,14 @@ class CyberstormPackagePreviewSerializer(serializers.Serializer):
     rating_count = serializers.IntegerField(min_value=0)
     size = serializers.IntegerField(min_value=0)
     datetime_created = serializers.DateTimeField()
+    # Latest version number + its install/download URLs. Additive fields: the
+    # frontend list-card variant treats them as optional (it deploys before the
+    # backend), so an older frontend simply ignores them.
+    latest_version_number = serializers.CharField(
+        max_length=PackageVersion._meta.get_field("version_number").max_length,
+    )
+    install_url = serializers.CharField()
+    download_url = serializers.CharField()
 
 
 class CyberstormPackageDependencySerializer(serializers.Serializer):

--- a/django/thunderstore/api/cyberstorm/tests/test_package_listing_list.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_package_listing_list.py
@@ -58,6 +58,9 @@ def test_base_view__return_data_structure() -> None:
         "rating_count",
         "size",
         "datetime_created",
+        "latest_version_number",
+        "install_url",
+        "download_url",
     ]
 
     assert response.status_code == 200

--- a/django/thunderstore/api/cyberstorm/views/package_listing_list.py
+++ b/django/thunderstore/api/cyberstorm/views/package_listing_list.py
@@ -234,6 +234,11 @@ class BasePackageListAPIView(PublicCacheMixin, ListAPIView):
         for listing in package_page:
             package = listing.package
             latest = package.latest
+            if latest is None:
+                # Stale denormalized data: active() guarantees an active version
+                # EXISTS, but not that the cached latest FK is set. Skip the
+                # listing (it can't be displayed) instead of 500ing the page.
+                continue
             # Link the already-loaded package onto its latest version so the
             # install/download URL properties resolve the owner/name without
             # re-querying (package + package__owner are select_related above).

--- a/django/thunderstore/api/cyberstorm/views/package_listing_list.py
+++ b/django/thunderstore/api/cyberstorm/views/package_listing_list.py
@@ -233,13 +233,18 @@ class BasePackageListAPIView(PublicCacheMixin, ListAPIView):
 
         for listing in package_page:
             package = listing.package
+            latest = package.latest
+            # Link the already-loaded package onto its latest version so the
+            # install/download URL properties resolve the owner/name without
+            # re-querying (package + package__owner are select_related above).
+            latest.package = package
             packages.append(
                 {
                     "categories": listing.categories.all(),
                     "community_identifier": community_id,
-                    "description": package.latest.description,
+                    "description": latest.description,
                     "download_count": listing.download_count,
-                    "icon_url": package.latest.icon.url,
+                    "icon_url": latest.icon.url,
                     "is_deprecated": package.is_deprecated,
                     "is_nsfw": listing.has_nsfw_content,
                     "is_pinned": package.is_pinned,
@@ -247,8 +252,11 @@ class BasePackageListAPIView(PublicCacheMixin, ListAPIView):
                     "namespace": package.namespace.name,
                     "name": package.name,
                     "rating_count": listing.rating_count,
-                    "size": package.latest.file_size,
+                    "size": latest.file_size,
                     "datetime_created": listing.datetime_created,
+                    "latest_version_number": latest.version_number,
+                    "install_url": latest.install_url,
+                    "download_url": latest.full_download_url,
                 },
             )
 


### PR DESCRIPTION
Nimbus will have a mode of PackageSearch that can use these, but doesn't
need them. Make them available in the API endpoints.