### PR TITLE
Improve package listing index performance

### DIFF
--- a/django/thunderstore/repository/models/cache.py
+++ b/django/thunderstore/repository/models/cache.py
@@ -270,10 +270,11 @@ def get_package_listing_chunk(
         .values("count")
     )
 
-    dependencies_prefetch = Prefetch(
-        "dependencies",
-        queryset=PackageVersion.objects.annotate(
-            _full_version_name=Concat(
+    # collect dependency names via a subquery, instead of aggregating them in Python
+    dependency_names = (
+        PackageVersion.objects.filter(dependants=OuterRef("pk"))
+        .annotate(
+            _full_name=Concat(
                 "package__owner__name",
                 Value("-"),
                 "package__name",
@@ -281,15 +282,18 @@ def get_package_listing_chunk(
                 "version_number",
             ),
         )
-        .only("id")
-        .order_by(Lower("package__namespace__name"), Lower("package__name")),
+        .order_by(Lower("package__namespace__name"), Lower("package__name"))
+        # without having a limit, Django will not include the order_by in the subquery. Uses a max of 1000 like ManifestV1Serializer
+        .values("_full_name")[:1000]
     )
 
     versions_prefetch = Prefetch(
         "package__versions",
         queryset=PackageVersion.objects.filter(is_active=True)
         .select_related("package", "package__owner")
-        .prefetch_related(dependencies_prefetch),
+        .annotate(
+            _dependency_names=Subquery(dependency_names, template="ARRAY(%(subquery)s)")
+        ),
     )
 
     listings = (
@@ -342,9 +346,7 @@ def listing_to_json(listing: PackageListing) -> bytes:
                     "description": version.description,
                     "icon": version.icon.url,
                     "version_number": version.version_number,
-                    "dependencies": [
-                        d._full_version_name for d in version.dependencies.all()
-                    ],
+                    "dependencies": version._dependency_names,
                     "download_url": version.full_download_url,
                     "downloads": version.downloads,
                     "date_created": version.date_created.isoformat(),


### PR DESCRIPTION
The `APIV1ChunkedPackageCache.update_for_community` task looks to be bottlenecked by the db query.

In my local test setup with 25k packages (including a Valheim mirror). building the listing index takes ~154s. Of that ~122s (80%) is spend in db queries.

By disabling parts of the query, `dependencies_prefetch` turned out to take most of the time with 82s (53%).

The current implementation uses a prefetch + ORM mapping in python to get the dependency strings list. This PR changes that to a subquery, building the list in the db and directly accessing it in python. The improvement is non-linear and becomes especially noticeable for packages with many versions and dependencies (i.e. usually modpacks).

The results of this PR:

| run | before (total) | after (total) | speedup |
|-----------|-----------|-----------|-----------|
| update with profiling | 154s          |    95s       |   1.6x         |
| update via task       | 122s          |      72s     |   1.7x        |

---

There's obviously a lot more that can be improved by reusing data of immutable objects or doing partial updates. For example writing new uploads through instead of only revalidating the whole index. But that would require more changes, while this looks like a relatively easy improvement to building the index overall.

For reference, this is the profiling output before the change:
```
154.289 update_api_v1_chunked_package_caches  thunderstore/repository/api/v1/tasks.py:38
└─ 154.266 APIV1ChunkedPackageCache.update_for_community  thunderstore/repository/models/cache.py:163
   ├─ 122.501 get_package_listing_chunk  thunderstore/repository/models/cache.py:260
   │  └─ 122.419 PackageListingQueryset.__iter__  django/db/models/query.py:272
   │        [123 frames hidden]  django, weakref, cachalot, <built-in>...
   ├─ 26.327 listing_to_json  thunderstore/repository/models/cache.py:318
   │  ├─ 18.692 <listcomp>  thunderstore/repository/models/cache.py:338
   │  │  ├─ 10.495 cached_property.__get__  django/utils/functional.py:40
   │  │  │  └─ 9.999 PackageVersion.full_download_url  thunderstore/repository/models/package_version.py:270
   │  │  │     └─ 9.886 cached_property.__get__  django/utils/functional.py:40
   │  │  │        └─ 9.823 PackageVersion._download_url  thunderstore/repository/models/package_version.py:259
   │  │  │           └─ 9.255 reverse  django/urls/base.py:28
   │  │  │              └─ 3.313 URLResolver._reverse_with_prefix  django/urls/resolvers.py:613
   │  │  ├─ 2.617 ImageFieldFile.url  django/db/models/fields/files.py:59
   │  │  │  └─ 2.224 S3Boto3Storage.url  storages/backends/s3boto3.py:571
   │  │  └─ 2.253 ManyToManyDescriptor.__get__  django/db/models/fields/related_descriptors.py:523
   │  │     └─ 1.966 ManyRelatedManager.__init__  django/db/models/fields/related_descriptors.py:816
   │  ├─ 2.966 _get_sorted_active_versions  thunderstore/repository/models/cache.py:310
   │  │  └─ 2.232 <lambda>  thunderstore/repository/models/cache.py:314
   │  │     └─ 2.097 StrictVersion.__init__  setuptools/_distutils/version.py:52
   │  │        └─ 1.648 StrictVersion.parse  setuptools/_distutils/version.py:154
   │  ├─ 2.123 dumps  json/__init__.py:183
   │  │     [2 frames hidden]  json
   │  └─ 1.706 PackageListing.get_full_url  thunderstore/community/models/package_listing.py:164
   └─ 5.070 finalize_blob  thunderstore/repository/models/cache.py:179
      └─ 4.676 compress  gzip.py:534
            [2 frames hidden]  gzip, <built-in>
```