### PR TITLE
Removed double extension from blob causing overflow and truncation

### DIFF
--- a/django/mise.toml
+++ b/django/mise.toml
@@ -1,0 +1,10 @@
+[settings]
+pipx.uvx = true
+
+[tools]
+python = "3.12"
+uv = "latest"
+"pipx:poetry" = "1.4.2"
+
+[tasks.install]
+run = "poetry install --sync"

--- a/django/poetry.lock
+++ b/django/poetry.lock
@@ -3158,4 +3158,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "10617676bc223d5b75a368d11ead0004e5721a6b0b453e01c0f1fad62e8af9af"
+content-hash = "97d96c4a5f02888cd2a96f00b2b7f93272d340eb4ed5d202ecf047acfa448f83"

--- a/django/pyproject.toml
+++ b/django/pyproject.toml
@@ -14,7 +14,8 @@ psycopg2-binary = "^2.9.9"
 easy-thumbnails = "^2.9"  # This has a monkeypatch and might be a difficult upgrade
 gunicorn = { version = "^20.0", extras = ["gevent"] }
 gevent = "^24.2"
-uwsgi = "2.0.30"
+uwsgi = { version = "2.0.30", markers = "sys_platform != 'win32'" }
+# uWSGI is Unix only. Cannot install on Windows.
 social-auth-app-django = "^5.4"
 social-auth-core = "^4.4"
 whitenoise = "^6.2"

--- a/django/thunderstore/storage/models/blob.py
+++ b/django/thunderstore/storage/models/blob.py
@@ -9,7 +9,7 @@ from thunderstore.core.mixins import AdminLinkMixin, SafeDeleteMixin
 
 
 def get_object_file_path(_, filename: str) -> str:
-    return f"blob-storage/sha256/{filename}.sha256.blob"
+    return f"blob-storage/sha256/{filename}"
 
 
 class DataBlob(SafeDeleteMixin, AdminLinkMixin):


### PR DESCRIPTION
Mirror of blob files appear to be getting different naming due to truncation + unique identifiers to prevent conflicts.

This strips the additional extensions to prevent exceeding the cutoff point.