### PR TITLE
Resolve dependency names in SQL when building experimental package index (TS-4099)

### DIFF
--- a/django/thunderstore/repository/api/experimental/tests/test_package_index.py
+++ b/django/thunderstore/repository/api/experimental/tests/test_package_index.py
@@ -3,12 +3,12 @@ import json
 import pytest
 import requests
 from django.db import connection
-from django.db.models import F
 from django.test.utils import CaptureQueriesContext
 from rest_framework.test import APIClient
 
 from thunderstore.repository.api.experimental.views.package_index import (
     PackageIndexEntry,
+    get_package_index_queryset,
     update_api_experimental_package_index,
 )
 from thunderstore.repository.factories import PackageVersionFactory
@@ -18,6 +18,8 @@ from thunderstore.repository.models import PackageVersion
 @pytest.mark.django_db
 def test_api_experimental_package_index(api_client: APIClient):
     packages = [PackageVersionFactory() for _ in range(10)]
+    for i, version in enumerate(packages):
+        version.dependencies.set(packages[:i])
     response = api_client.get("/api/experimental/package-index/")
     assert response.status_code == 503
 
@@ -30,18 +32,32 @@ def test_api_experimental_package_index(api_client: APIClient):
 
     results = [json.loads(x) for x in response.content.decode().split("\n") if x]
 
-    queryset = PackageVersion.objects.filter(pk__in=[x.pk for x in packages]).annotate(
-        namespace=F("package__namespace")
-    )
+    queryset = get_package_index_queryset().filter(pk__in=[x.pk for x in packages])
     expected = [PackageIndexEntry(instance=x).data for x in queryset]
     assert len(results) == len(expected)
     for entry in expected:
         assert entry in results
 
+    last = packages[-1]
+    entry = next(
+        x
+        for x in results
+        if x["name"] == last.name and x["version_number"] == last.version_number
+    )
+    assert entry["dependencies"] == [
+        x.full_version_name
+        for x in sorted(
+            packages[:-1],
+            key=lambda v: (v.package.namespace.name.lower(), v.package.name.lower()),
+        )
+    ]
+
 
 @pytest.mark.django_db
 def test_update_api_experimental_package_index_query_count():
-    [PackageVersionFactory() for _ in range(10)]
+    versions = [PackageVersionFactory() for _ in range(10)]
+    for i, version in enumerate(versions):
+        version.dependencies.set(versions[:i])
     assert PackageVersion.objects.count() == 10
     with CaptureQueriesContext(connection) as context:
         update_api_experimental_package_index()

--- a/django/thunderstore/repository/api/experimental/views/package_index.py
+++ b/django/thunderstore/repository/api/experimental/views/package_index.py
@@ -2,7 +2,8 @@ from io import BytesIO
 from typing import List
 
 from django.conf import settings
-from django.db.models import F
+from django.db.models import F, OuterRef, Subquery, Value
+from django.db.models.functions import Concat, Lower
 from django.shortcuts import redirect
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import serializers
@@ -38,15 +39,39 @@ class PackageIndexEntry(serializers.Serializer):
     dependencies = serializers.SerializerMethodField()
 
     def get_dependencies(self, instance: PackageVersion) -> List[str]:
-        return [x.full_version_name for x in instance.dependencies.all()]
+        return instance._dependency_names
+
+
+def get_package_index_queryset() -> PackageVersionQuerySet:
+    dependency_names = (
+        PackageVersion.objects.filter(dependants=OuterRef("pk"))
+        .annotate(
+            _full_name=Concat(
+                "package__namespace__name",
+                Value("-"),
+                "package__name",
+                Value("-"),
+                "version_number",
+            ),
+        )
+        .order_by(
+            Lower("package__namespace__name"),
+            Lower("package__name"),
+            "version_number",
+            "pk",
+        )
+        # Upload validation caps dependencies per version at 1000
+        # (ManifestV1Serializer.dependencies)
+        .values("_full_name")[:1000]
+    )
+    return PackageVersion.objects.active().annotate(
+        namespace=F("package__namespace"),
+        _dependency_names=Subquery(dependency_names, template="ARRAY(%(subquery)s)"),
+    )
 
 
 def serialize_package_index() -> bytes:
-    versions: PackageVersionQuerySet = (
-        PackageVersion.objects.active()
-        .annotate(namespace=F("package__namespace"))
-        .prefetch_related("dependencies", "dependencies__package")
-    )
+    versions: PackageVersionQuerySet = get_package_index_queryset()
     renderer = JSONRenderer()
     result = BytesIO()
 


### PR DESCRIPTION
The serializer resolved each dependency's name via the unprefetched owner FK, issuing one Team query per dependency edge (~11.2M per run) and pushing the hourly rebuild past its 60-minute schedule (TS-4099).

Use the ARRAY(subquery) annotation pattern from #1356 instead, so Postgres builds each version's dependency-name array and query count no longer depends on dependency count. Dependency arrays are now deterministically ordered. Tests now cover versions with dependencies.

Refs. TS-4099