### PR TITLE
Stop async submission polls from waiting on the processing lock (TS-4113)

### DIFF
--- a/django/thunderstore/repository/models/submission.py
+++ b/django/thunderstore/repository/models/submission.py
@@ -52,21 +52,40 @@ class AsyncPackageSubmission(TimestampMixin):
     )
 
     @transaction.atomic
-    def schedule_if_appropriate(self):
+    def schedule_if_appropriate(self) -> bool:
         """
         Schedules processing of this submission if it's in a valid state for
         that to happen. Criteria is:
         - No prior task has been scheduled OR enough time has passed
         - The submission is in the PENDING state
+
+        The processing task locks this row for the whole processing
+        transaction, so a locked row is skipped instead of waited on.
+
+        Returns True if the poll was recorded, False if the row was locked.
         """
         from ..tasks.submission import process_submission_task
 
-        self.datetime_polled = timezone.now()
-        if self.status == PackageSubmissionStatus.PENDING and has_expired(
-            self.datetime_scheduled, timezone.now(), self.TASK_TTL
+        locked = (
+            AsyncPackageSubmission.objects.select_for_update(skip_locked=True)
+            .filter(pk=self.pk)
+            .first()
+        )
+        if locked is None:
+            return False
+
+        now = timezone.now()
+        changes = {"datetime_polled": now, "datetime_updated": now}
+        if locked.status == PackageSubmissionStatus.PENDING and has_expired(
+            locked.datetime_scheduled, now, self.TASK_TTL
         ):
             transaction.on_commit(
                 lambda: process_submission_task.delay(submission_id=self.pk)
             )
-            self.datetime_scheduled = timezone.now()
-        self.save(update_fields=("datetime_scheduled", "datetime_polled"))
+            changes["datetime_scheduled"] = now
+
+        # Write only what changed; the rest of the instance stays as loaded.
+        AsyncPackageSubmission.objects.filter(pk=self.pk).update(**changes)
+        for field, value in changes.items():
+            setattr(self, field, value)
+        return True

--- a/django/thunderstore/repository/tests/test_async_submission.py
+++ b/django/thunderstore/repository/tests/test_async_submission.py
@@ -1,6 +1,12 @@
+from contextlib import contextmanager
+from datetime import timedelta
 from typing import Any, Dict
+from unittest.mock import MagicMock
 
 import pytest
+from django.db import connection, connections, transaction
+from django.utils import timezone
+from freezegun.api import FrozenDateTimeFactory
 
 from thunderstore.community.factories import CommunityFactory, PackageCategoryFactory
 from thunderstore.community.models import Community
@@ -66,3 +72,110 @@ def test_async_package_submission_flow(
     assert (
         submission.created_version.version_number == manifest_v1_data["version_number"]
     )
+
+
+@contextmanager
+def lock_row(instance):
+    """
+    Hold a FOR UPDATE lock on the instance's row from a second database
+    connection, the way the processing task does while it runs.
+    """
+    other = connections.create_connection("default")
+    try:
+        other.set_autocommit(False)
+        with other.cursor() as cursor:
+            cursor.execute(
+                f"SELECT 1 FROM {instance._meta.db_table} WHERE id = %s FOR UPDATE",
+                [instance.pk],
+            )
+        yield
+    finally:
+        other.close()
+
+
+@pytest.fixture()
+def process_submission_delay(mocker) -> MagicMock:
+    return mocker.patch(
+        "thunderstore.repository.tasks.submission.process_submission_task.delay",
+    )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_schedule_if_appropriate_skips_locked_row(
+    async_package_submission: AsyncPackageSubmission,
+    process_submission_delay: MagicMock,
+):
+    submission = async_package_submission
+    polled_before = submission.datetime_polled
+
+    with lock_row(submission), transaction.atomic():
+        # A regression would wait on the lock; fail fast instead of hanging.
+        with connection.cursor() as cursor:
+            cursor.execute("SET LOCAL lock_timeout = '2s'")
+        assert submission.schedule_if_appropriate() is False
+
+    process_submission_delay.assert_not_called()
+    submission.refresh_from_db()
+    assert submission.datetime_polled == polled_before
+    assert submission.datetime_scheduled is None
+
+
+@pytest.mark.django_db(transaction=True)
+def test_schedule_if_appropriate_schedules_pending_submission(
+    async_package_submission: AsyncPackageSubmission,
+    process_submission_delay: MagicMock,
+    freezer: FrozenDateTimeFactory,
+):
+    submission = async_package_submission
+    freezer.tick(timedelta(seconds=1))
+
+    assert submission.schedule_if_appropriate() is True
+
+    process_submission_delay.assert_called_once_with(submission_id=submission.pk)
+    submission.refresh_from_db()
+    assert submission.datetime_scheduled == timezone.now()
+    assert submission.datetime_polled == timezone.now()
+
+
+@pytest.mark.django_db(transaction=True)
+def test_schedule_if_appropriate_reschedules_after_ttl(
+    async_package_submission: AsyncPackageSubmission,
+    process_submission_delay: MagicMock,
+    freezer: FrozenDateTimeFactory,
+):
+    submission = async_package_submission
+    submission.schedule_if_appropriate()
+    scheduled_at = timezone.now()
+    process_submission_delay.reset_mock()
+
+    freezer.tick(timedelta(seconds=AsyncPackageSubmission.TASK_TTL))
+    submission.schedule_if_appropriate()
+    process_submission_delay.assert_not_called()
+    submission.refresh_from_db()
+    assert submission.datetime_scheduled == scheduled_at
+    assert submission.datetime_polled == timezone.now()
+
+    freezer.tick(timedelta(seconds=1))
+    submission.schedule_if_appropriate()
+    process_submission_delay.assert_called_once_with(submission_id=submission.pk)
+    submission.refresh_from_db()
+    assert submission.datetime_scheduled == timezone.now()
+
+
+@pytest.mark.django_db(transaction=True)
+def test_schedule_if_appropriate_ignores_finished_submission(
+    async_package_submission: AsyncPackageSubmission,
+    process_submission_delay: MagicMock,
+    freezer: FrozenDateTimeFactory,
+):
+    submission = async_package_submission
+    submission.status = PackageSubmissionStatus.FINISHED
+    submission.save()
+    freezer.tick(timedelta(seconds=1))
+
+    assert submission.schedule_if_appropriate() is True
+
+    process_submission_delay.assert_not_called()
+    submission.refresh_from_db()
+    assert submission.datetime_scheduled is None
+    assert submission.datetime_polled == timezone.now()


### PR DESCRIPTION
The processing task holds a FOR UPDATE lock on the AsyncPackageSubmission row for the whole processing transaction, and every /poll-async/ request did an UPDATE on that row. Polls blocked until processing finished and hit the 60 s ingress timeout on slow packages, returning a 5xx even though the submission succeeded.

schedule_if_appropriate now reads the row with skip_locked=True and skips the write when the row is locked, since that means processing is already underway.

Refs. TS-4113