### PR TITLE
Expose real team members publicly and seed them in test data.

### DIFF
--- a/django/thunderstore/api/cyberstorm/tests/test_package_listing.py
+++ b/django/thunderstore/api/cyberstorm/tests/test_package_listing.py
@@ -341,7 +341,14 @@ def test_package_listing_view__returns_info(api_client: APIClient) -> None:
     assert actual["rating_count"] == 8
     assert actual["size"] == latest.file_size
     assert actual["team"]["name"] == listing.package.owner.name
-    assert len(actual["team"]["members"]) == 0
+    assert len(actual["team"]["members"]) == 2
+    member_usernames = {member["username"] for member in actual["team"]["members"]}
+    assert owner.user.username in member_usernames
+    assert member.user.username in member_usernames
+    assert {member["role"] for member in actual["team"]["members"]} == {
+        "owner",
+        "member",
+    }
     assert actual["website_url"] == latest.website_url
     assert actual["version_count"] == 1
     assert actual["version_created"] == _date_to_z(latest.date_created)

--- a/django/thunderstore/core/management/commands/content/team.py
+++ b/django/thunderstore/core/management/commands/content/team.py
@@ -1,11 +1,17 @@
 from typing import List, Optional
 
+from django.contrib.auth import get_user_model
+
 from thunderstore.core.management.commands.content.base import (
     ContentPopulator,
     ContentPopulatorContext,
 )
 from thunderstore.repository.models import Namespace, Team
+from thunderstore.repository.models.team import TeamMemberRole
 from thunderstore.utils.iterators import print_progress
+
+MEMBER_USER_PREFIX = "Test_TeamMember_"
+EXTRA_MEMBER_COUNT = 2
 
 
 class TeamPopulator(ContentPopulator):
@@ -26,6 +32,30 @@ class TeamPopulator(ContentPopulator):
             Team.create(name=f"{self.name_prefix}{last + i}")
             for i in print_progress(range(remainder), remainder)
         ]
+
+        print("Populating team members...")
+        for team in print_progress(self.teams, len(self.teams)):
+            self._ensure_team_members(team)
+
+    def _ensure_team_members(self, team: Team) -> None:
+        if team.members.exists():
+            return
+
+        User = get_user_model()
+        owner_username = f"{MEMBER_USER_PREFIX}{team.pk}_owner"
+        owner, _ = User.objects.get_or_create(
+            username=owner_username,
+            defaults={"email": f"{owner_username}@example.com"},
+        )
+        team.add_member(owner, role=TeamMemberRole.owner)
+
+        for index in range(EXTRA_MEMBER_COUNT):
+            member_username = f"{MEMBER_USER_PREFIX}{team.pk}_member_{index}"
+            member, _ = User.objects.get_or_create(
+                username=member_username,
+                defaults={"email": f"{member_username}@example.com"},
+            )
+            team.add_member(member, role=TeamMemberRole.member)
 
     def update_context(self, context) -> None:
         if self.teams is not None:

--- a/django/thunderstore/core/management/commands/content/team.py
+++ b/django/thunderstore/core/management/commands/content/team.py
@@ -38,7 +38,9 @@ class TeamPopulator(ContentPopulator):
             self._ensure_team_members(team)
 
     def _ensure_team_members(self, team: Team) -> None:
-        if team.members.exists():
+        # Ignore service-account-only membership so we still seed an owner
+        # and real users for teams that only have service accounts.
+        if team.members.real_users().exists():
             return
 
         User = get_user_model()

--- a/django/thunderstore/core/tests/test_management_commands.py
+++ b/django/thunderstore/core/tests/test_management_commands.py
@@ -141,6 +141,7 @@ def test_create_test_data_create_data(
         )
         for t in created_teams:
             assert t.owned_packages.all().count() == package_count
+            assert t.members.real_users().count() == 3
         assert (
             Package.objects.annotate(c=Count("latest__dependencies"))
             .filter(c__exact=0)

--- a/django/thunderstore/repository/models/team.py
+++ b/django/thunderstore/repository/models/team.py
@@ -149,8 +149,7 @@ class Team(models.Model):
 
     @property
     def public_members(self) -> "Manager[TeamMember]":
-        # TODO: Filter & return team members that are publicly visible
-        return self.members.none()
+        return self.members.real_users()
 
     @property
     def real_user_count(self):


### PR DESCRIPTION
public_members previously always returned an empty queryset, so package listing APIs never included members. 
Return real users and have the team test-data populator create an owner plus two members so local and API tests exercise the path.