### PR TITLE
Add categories and status tags to create_test_data.

### DIFF
--- a/django/thunderstore/core/management/commands/content/base.py
+++ b/django/thunderstore/core/management/commands/content/base.py
@@ -3,14 +3,14 @@ import io
 import os
 from abc import ABC
 from dataclasses import dataclass, field
-from typing import Collection, List, Type
+from typing import Collection, Dict, List, Type
 
 from django.core.files.base import File
 from django.db.models import Model
 from PIL import Image
 
 from django_contracts.models import LegalContract
-from thunderstore.community.models import Community
+from thunderstore.community.models import Community, PackageCategory
 from thunderstore.repository.models import Package, PackageWiki, Team
 
 
@@ -21,6 +21,8 @@ class ContentPopulatorContext:
     communities: Collection[Community] = field(default_factory=list)
     contracts: Collection[LegalContract] = field(default_factory=list)
     package_wikis: Collection[PackageWiki] = field(default_factory=list)
+    # Maps a community's PK to the list of PackageCategories in that community
+    categories: Dict[int, List[PackageCategory]] = field(default_factory=dict)
 
     community_count: int = 0
     dependency_count: int = 0

--- a/django/thunderstore/core/management/commands/content/category.py
+++ b/django/thunderstore/core/management/commands/content/category.py
@@ -1,0 +1,62 @@
+from typing import Dict, List, Optional
+
+from django.utils.text import slugify
+
+from thunderstore.community.models import PackageCategory
+from thunderstore.core.management.commands.content.base import (
+    ContentPopulator,
+    ContentPopulatorContext,
+)
+from thunderstore.core.management.commands.content.community import CommunityPopulator
+from thunderstore.utils.iterators import print_progress
+
+CATEGORY_NAMES = [
+    "Mods",
+    "Tools",
+    "Libraries",
+    "Audio",
+    "Skins",
+    "Tweaks",
+    "Client-side",
+    "Server-side",
+    "Modpacks",
+    "Language",
+    "Misc",
+]
+
+
+class CategoryPopulator(ContentPopulator):
+    categories: Optional[Dict[int, List[PackageCategory]]] = None
+    name_prefix = CommunityPopulator.name_prefix
+
+    def populate(self, context: ContentPopulatorContext) -> None:
+        print("Populating package categories...")
+
+        result: Dict[int, List[PackageCategory]] = {}
+        for community in print_progress(context.communities, len(context.communities)):
+            community_categories = []
+            for name in CATEGORY_NAMES:
+                category, _ = PackageCategory.objects.get_or_create(
+                    community=community,
+                    slug=slugify(name),
+                    defaults={"name": name},
+                )
+                community_categories.append(category)
+            result[community.pk] = community_categories
+
+        self.categories = result
+
+    def update_context(self, context: ContentPopulatorContext) -> None:
+        if self.categories is not None:
+            context.categories = self.categories
+        else:
+            context.categories = {
+                community.pk: list(community.package_categories.all())
+                for community in context.communities
+            }
+
+    def clear(self) -> None:
+        print("Deleting existing package categories...")
+        PackageCategory.objects.filter(
+            community__name__startswith=self.name_prefix
+        ).delete()

--- a/django/thunderstore/core/management/commands/content/package.py
+++ b/django/thunderstore/core/management/commands/content/package.py
@@ -1,3 +1,4 @@
+import random
 from typing import Collection, Optional
 
 from django.db.models import signals
@@ -8,6 +9,13 @@ from thunderstore.core.management.commands.content.base import (
 )
 from thunderstore.repository.models import Package
 from thunderstore.utils.iterators import print_progress
+
+# Probability that a generated package is flagged with the respective "tag" so
+# the pinned/deprecated badges show up in the UI on a portion of the test data.
+# Deprecation is applied by the version populator rather than here, because
+# Package.handle_created_version() resets is_deprecated when versions are added.
+PINNED_PROBABILITY = 0.15
+DEPRECATED_PROBABILITY = 0.15
 
 
 class PackagePopulator(ContentPopulator):
@@ -36,6 +44,7 @@ class PackagePopulator(ContentPopulator):
                     owner=team,
                     name=f"{self.name_prefix}{i + offset}",
                     namespace=team.get_namespace(),
+                    is_pinned=random.random() < PINNED_PROBABILITY,
                 )
                 for i in range(remainder)
             ]

--- a/django/thunderstore/core/management/commands/content/package_listing.py
+++ b/django/thunderstore/core/management/commands/content/package_listing.py
@@ -1,3 +1,5 @@
+import random
+
 from django.db.models import signals
 
 from thunderstore.community.models import PackageListing
@@ -6,6 +8,10 @@ from thunderstore.core.management.commands.content.base import (
     ContentPopulatorContext,
 )
 from thunderstore.utils.iterators import print_progress
+
+# Probability that a generated listing is flagged NSFW so the NSFW badge shows
+# up in the UI on a portion of the test data.
+NSFW_PROBABILITY = 0.15
 
 
 class ListingPopulator(ContentPopulator):
@@ -23,11 +29,33 @@ class ListingPopulator(ContentPopulator):
             enumerate(context.packages), len(context.packages)
         ):
             for community in context.communities:
-                package.get_or_create_package_listing(community)
+                listing = package.get_or_create_package_listing(community)
+                self.assign_categories(context, listing, community)
+                self.assign_nsfw(listing)
 
         # Re-enabling previously disabled signals
         signals.post_save.connect(PackageListing.post_save, sender=PackageListing)
         signals.post_delete.connect(PackageListing.post_delete, sender=PackageListing)
+
+    def assign_categories(
+        self,
+        context: ContentPopulatorContext,
+        listing: PackageListing,
+        community,
+    ) -> None:
+        community_categories = context.categories.get(community.pk, [])
+        if not community_categories:
+            return
+        # Allow 0 so some listings end up with no categories (and, combined with
+        # the probabilistic pinned/deprecated/nsfw tags, some with neither).
+        count = random.randint(0, min(3, len(community_categories)))
+        listing.categories.set(random.sample(community_categories, count))
+
+    def assign_nsfw(self, listing: PackageListing) -> None:
+        has_nsfw_content = random.random() < NSFW_PROBABILITY
+        if listing.has_nsfw_content != has_nsfw_content:
+            listing.has_nsfw_content = has_nsfw_content
+            listing.save(update_fields=("has_nsfw_content",))
 
     def clear(self) -> None:
         print("Deleting existing package listings...")

--- a/django/thunderstore/core/management/commands/content/package_version.py
+++ b/django/thunderstore/core/management/commands/content/package_version.py
@@ -1,3 +1,5 @@
+import random
+
 from django.db.models import Q, signals
 
 from thunderstore.core.management.commands.content.base import (
@@ -5,6 +7,7 @@ from thunderstore.core.management.commands.content.base import (
     ContentPopulatorContext,
     dummy_package_icon,
 )
+from thunderstore.core.management.commands.content.package import DEPRECATED_PROBABILITY
 from thunderstore.repository.models import Package, PackageVersion
 from thunderstore.storage.models import DataBlob, DataBlobGroup
 from thunderstore.utils.iterators import print_progress
@@ -170,6 +173,13 @@ class PackageVersionPopulator(ContentPopulator):
             # actually make use of the sender param at all (and can be None)
             package.handle_created_version(None)
             package.handle_updated_version(None)
+
+            # handle_created_version() resets is_deprecated, so apply the
+            # deprecation "tag" here (after versions exist) to make the
+            # deprecated badge show up on a portion of the test data.
+            if random.random() < DEPRECATED_PROBABILITY:
+                package.is_deprecated = True
+                package.save(update_fields=("is_deprecated",))
 
         # Re-enabling previously disabled signals
         signals.post_save.connect(PackageVersion.post_save, sender=PackageVersion)

--- a/django/thunderstore/core/management/commands/create_test_data.py
+++ b/django/thunderstore/core/management/commands/create_test_data.py
@@ -7,6 +7,7 @@ from thunderstore.core.management.commands.content.base import (
     ContentPopulator,
     ContentPopulatorContext,
 )
+from thunderstore.core.management.commands.content.category import CategoryPopulator
 from thunderstore.core.management.commands.content.community import CommunityPopulator
 from thunderstore.core.management.commands.content.community_site import (
     CommunitySitePopulator,
@@ -42,6 +43,7 @@ CONTENT_POPULATORS: Dict[str, Type[ContentPopulator]] = OrderedDict[
     [
         ("community", CommunityPopulator),
         ("community_site", CommunitySitePopulator),
+        ("category", CategoryPopulator),
         ("team", TeamPopulator),
         ("package", PackagePopulator),
         ("version", PackageVersionPopulator),


### PR DESCRIPTION
Generate package categories per community and probabilistically assign categories, pinned, deprecated, and NSFW so local UI work has realistic sidebar data.